### PR TITLE
feat(auth): OAuth Google sign-in (E2-05)

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -10,7 +10,9 @@ import { useState } from 'react';
 import { Controller } from 'react-hook-form';
 import { Button, Input, ScrollView, Spinner, Text, XStack, YStack } from 'tamagui';
 
+import { useGoogleAuth } from '@/features/auth/hooks/useGoogleAuth';
 import { useLogin } from '@/features/auth/hooks/useLogin';
+import { t } from '@/i18n';
 
 const logoSource = require('../../assets/Logo-Doumassi.png') as number;
 
@@ -33,6 +35,11 @@ function DoumassLogo() {
 
 export default function LoginScreen() {
   const { form, isLoading, loginError, onSubmit } = useLogin();
+  const {
+    signIn: signInWithGoogle,
+    isLoading: isGoogleLoading,
+    errorMessage: googleError,
+  } = useGoogleAuth();
   const [showPassword, setShowPassword] = useState(false);
 
   return (
@@ -230,6 +237,47 @@ export default function LoginScreen() {
           >
             Create an account
           </Button>
+
+          {/* Séparateur "or" */}
+          <XStack alignItems="center" gap="$3" marginTop="$2">
+            <YStack flex={1} height={1} backgroundColor="$borderColor" />
+            <Text fontSize={12} color="$placeholderColor" fontWeight="600">
+              or
+            </Text>
+            <YStack flex={1} height={1} backgroundColor="$borderColor" />
+          </XStack>
+
+          {/* Bouton "Continue with Google" */}
+          <Button
+            id="login-google-button"
+            onPress={signInWithGoogle}
+            disabled={isGoogleLoading}
+            backgroundColor="white"
+            color="black"
+            borderRadius="$4"
+            height={48}
+            fontWeight="700"
+            fontSize={15}
+            pressStyle={{ opacity: 0.85, scale: 0.98 }}
+            icon={
+              <Text fontSize={18} fontWeight="700" color="#4285F4">
+                G
+              </Text>
+            }
+          >
+            {isGoogleLoading ? (
+              <Spinner size="small" color="black" />
+            ) : (
+              t.auth.google.continueWithGoogle
+            )}
+          </Button>
+
+          {/* Erreur OAuth Google */}
+          {googleError ? (
+            <Text fontSize={13} color="$danger" textAlign="center">
+              {googleError}
+            </Text>
+          ) : null}
         </YStack>
       </YStack>
     </ScrollView>

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -1,0 +1,109 @@
+// Écran de callback OAuth — destination du deep link doumassi://auth/callback.
+// Capte les tokens (access_token + refresh_token) du fragment de l'URL,
+// établit la session Supabase, puis redirige vers l'accueil.
+//
+// Ticket E2-05 — Sprint 1 Auth & Onboarding.
+
+import * as Linking from 'expo-linking';
+import { router } from 'expo-router';
+import { useEffect, useState } from 'react';
+import { Spinner, Text, YStack } from 'tamagui';
+
+import { t } from '@/i18n';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+/**
+ * Parse le fragment d'une URL deep link pour en extraire les tokens.
+ * Format attendu : doumassi://auth/callback#access_token=XXX&refresh_token=YYY&...
+ */
+function extractTokensFromUrl(url: string): {
+  accessToken: string;
+  refreshToken: string;
+} | null {
+  const hashIndex = url.indexOf('#');
+  if (hashIndex === -1) return null;
+
+  const params = new URLSearchParams(url.slice(hashIndex + 1));
+  const accessToken = params.get('access_token');
+  const refreshToken = params.get('refresh_token');
+
+  if (!accessToken || !refreshToken) return null;
+  return { accessToken, refreshToken };
+}
+
+export default function AuthCallbackScreen() {
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const consumeUrl = async (url: string | null) => {
+      if (!url || cancelled) return;
+
+      const tokens = extractTokensFromUrl(url);
+      if (!tokens) {
+        logger.warn('Deep link auth/callback sans tokens valides', { url });
+        if (!cancelled) {
+          setErrorMessage(t.auth.google.callbackError);
+          setTimeout(() => router.replace('/(auth)/login'), 1500);
+        }
+        return;
+      }
+
+      const { error } = await supabase.auth.setSession({
+        access_token: tokens.accessToken,
+        refresh_token: tokens.refreshToken,
+      });
+
+      if (error) {
+        logger.warn('setSession a échoué après callback OAuth', { message: error.message });
+        if (!cancelled) {
+          setErrorMessage(t.auth.google.callbackError);
+          setTimeout(() => router.replace('/(auth)/login'), 1500);
+        }
+        return;
+      }
+
+      logger.info('Session établie après OAuth Google');
+      if (!cancelled) {
+        router.replace('/');
+      }
+    };
+
+    // Cas 1 : l'app a été ouverte directement par le deep link (cold start)
+    Linking.getInitialURL().then(consumeUrl);
+
+    // Cas 2 : l'app était déjà en arrière-plan, le deep link arrive en cours
+    const subscription = Linking.addEventListener('url', ({ url }) => consumeUrl(url));
+
+    return () => {
+      cancelled = true;
+      subscription.remove();
+    };
+  }, []);
+
+  return (
+    <YStack
+      flex={1}
+      backgroundColor="$background"
+      alignItems="center"
+      justifyContent="center"
+      gap="$4"
+      paddingHorizontal="$5"
+    >
+      {errorMessage ? (
+        <Text fontSize={14} color="$danger" textAlign="center">
+          {errorMessage}
+        </Text>
+      ) : (
+        <>
+          <Spinner size="large" color="$accentNeon" />
+          <Text fontSize={14} color="$placeholderColor">
+            {t.auth.google.callbackInProgress}
+          </Text>
+        </>
+      )}
+    </YStack>
+  );
+}

--- a/src/features/auth/hooks/useGoogleAuth.ts
+++ b/src/features/auth/hooks/useGoogleAuth.ts
@@ -1,0 +1,72 @@
+// Hook pour le flow OAuth Google.
+// Délègue à Supabase la génération de l'URL de consentement Google,
+// ouvre cette URL dans le navigateur du téléphone, puis le retour est géré
+// par le deep link doumassi://auth/callback (cf. app/auth/callback.tsx).
+//
+// Ticket E2-05 — Sprint 1 Auth & Onboarding.
+
+import * as Linking from 'expo-linking';
+import { useState } from 'react';
+
+import { mapAuthError } from '@/features/auth/lib/mapAuthError';
+import { t } from '@/i18n';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+// Doit matcher `scheme` dans app.json + l'allowlist Redirect URLs Supabase
+// (Authentication → URL Configuration).
+const OAUTH_REDIRECT_URL = 'doumassi://auth/callback';
+
+export function useGoogleAuth() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const signIn = async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      logger.debug('Tentative OAuth Google');
+
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: 'google',
+        options: {
+          redirectTo: OAUTH_REDIRECT_URL,
+          // skipBrowserRedirect: on gère manuellement l'ouverture du navigateur
+          // car on est sur React Native (pas de redirection auto possible).
+          skipBrowserRedirect: true,
+        },
+      });
+
+      if (error) {
+        logger.warn('Erreur signInWithOAuth Google', { message: error.message });
+        setErrorMessage(mapAuthError(error.message));
+        return;
+      }
+
+      if (!data?.url) {
+        logger.warn('Pas d’URL OAuth retournée par Supabase');
+        setErrorMessage(t.auth.errors.unknown);
+        return;
+      }
+
+      // Ouvre la page de consentement Google dans le navigateur du tél.
+      // Après auth réussie, Google → Supabase callback → deep link doumassi://auth/callback
+      const supported = await Linking.canOpenURL(data.url);
+      if (!supported) {
+        logger.warn('URL OAuth non supportée par le device');
+        setErrorMessage(t.auth.errors.unknown);
+        return;
+      }
+
+      await Linking.openURL(data.url);
+    } catch (err: unknown) {
+      logger.error('Erreur inattendue OAuth Google', err);
+      setErrorMessage(t.auth.errors.unknown);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { signIn, isLoading, errorMessage };
+}

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -7,6 +7,11 @@ export const fr = {
     tagline: 'DOUMASSI',
   },
   auth: {
+    google: {
+      continueWithGoogle: 'Continue with Google',
+      callbackInProgress: 'Signing you in…',
+      callbackError: 'Google sign-in failed. Please try again.',
+    },
     forgotPassword: {
       title: 'Forgot your\npassword?',
       subtitle:


### PR DESCRIPTION
- Hook useGoogleAuth qui delegue a Supabase signInWithOAuth puis ouvre l'URL de consentement Google via Linking.openURL
- Ecran app/auth/callback.tsx qui receptionne le deep link doumassi://auth/callback, capte les tokens du fragment, fait setSession, redirige vers home
- Bouton "Continue with Google" sur login + separateur "or"
- Strings i18n auth.google (continueWithGoogle, callbackInProgress, callbackError)
- Pas de nouvelle dep native: utilise expo-linking deja installe (pas de rebuild Dev Build necessaire)

Configs externes faites en parallele :
- Google Cloud OAuth client (Web application) cree avec redirect URI Supabase
- Provider Google active sur Supabase + Client ID/Secret
- doumassi://auth/callback ajoute dans Redirect URLs allowlist

A faire avant prod (hors ticket) :
- Logo Google officiel multicolore au lieu du G bleu simple
- Logo + App name DOUMASSI sur OAuth consent screen Google Cloud
- Custom auth domain Supabase pour masquer *.supabase.co

## Ticket lié

Closes #XXX

## Checklist

- [ ] Le code compile et passe le lint local
- [ ] Les tests unitaires passent
- [ ] La couverture de tests respecte les seuils de ma zone (voir cadrage §9.4)
- [ ] J'ai testé manuellement le happy path + 2 cas d'erreur
- [ ] Les critères d'acceptation du ticket sont tous cochés
- [ ] Si nouveau composant : story / exemple ajouté
- [ ] Si changement de schéma DB : migration commitée + testée sur dev
- [ ] Si secret/env : documenté dans Notion
- [ ] Si nouveau coût API : monitoring PostHog mis à jour
- [ ] Aucun console.log oublié, aucun TODO sans issue liée
- [ ] Si j'ai ajouté du code dans `lib/`, `hooks/`, `services/` ou `stores/`, j'ai ajouté les tests correspondants. Sinon j'ai ouvert un ticket `type: tech` pour le faire dans le sprint.

## Captures

(Obligatoire pour tout changement UI — avant / après)

## Comment tester

1. git checkout cette branche
2. ...

## Points d'attention pour le reviewer

(Si une décision est discutable, pointe-la ici.)
