### PR TITLE
feat(auth): guards de navigation + écran welcome (E2-01 + E2-07)

### DIFF
--- a/app/(auth)/welcome.tsx
+++ b/app/(auth)/welcome.tsx
@@ -19,14 +19,13 @@ export default function WelcomeScreen() {
       backgroundColor="$background"
       contentContainerStyle={{
         flexGrow: 1,
-        justifyContent: 'space-between',
         paddingHorizontal: 24,
         paddingTop: 80,
         paddingBottom: 48,
       }}
     >
-      {/* Logo + tagline centrés en haut */}
-      <YStack alignItems="center" gap="$4" marginTop="$8">
+      <YStack alignItems="center" gap="$5" width="100%" maxWidth={400} alignSelf="center">
+        {/* Logo + tagline */}
         <Image
           source={logoSource}
           style={{ width: 120, height: 120 }}
@@ -44,46 +43,47 @@ export default function WelcomeScreen() {
           textAlign="center"
           lineHeight={22}
           paddingHorizontal="$4"
+          marginBottom="$4"
         >
           {copy.tagline}
         </Text>
-      </YStack>
 
-      {/* Boutons en bas */}
-      <YStack gap="$3" width="100%" maxWidth={400} alignSelf="center">
-        <Button
-          id="welcome-signin-button"
-          onPress={() => router.push('/(auth)/login')}
-          backgroundColor="$color"
-          color="$background"
-          borderRadius="$4"
-          height={52}
-          fontWeight="700"
-          fontSize={16}
-          pressStyle={{ opacity: 0.85, scale: 0.98 }}
-        >
-          {copy.signIn}
-        </Button>
+        {/* Boutons juste sous la tagline */}
+        <YStack gap="$3" width="100%">
+          <Button
+            id="welcome-signin-button"
+            onPress={() => router.push('/(auth)/login')}
+            backgroundColor="$color"
+            color="$background"
+            borderRadius="$4"
+            height={52}
+            fontWeight="700"
+            fontSize={16}
+            pressStyle={{ opacity: 0.85, scale: 0.98 }}
+          >
+            {copy.signIn}
+          </Button>
 
-        <Button
-          id="welcome-signup-button"
-          onPress={() => router.push('/(auth)/signup')}
-          backgroundColor="transparent"
-          borderWidth={1}
-          borderColor="$borderColor"
-          color="$color"
-          borderRadius="$4"
-          height={52}
-          fontWeight="700"
-          fontSize={16}
-          pressStyle={{
-            opacity: 0.85,
-            scale: 0.98,
-            borderColor: '$borderColorHover',
-          }}
-        >
-          {copy.createAccount}
-        </Button>
+          <Button
+            id="welcome-signup-button"
+            onPress={() => router.push('/(auth)/signup')}
+            backgroundColor="transparent"
+            borderWidth={1}
+            borderColor="$borderColor"
+            color="$color"
+            borderRadius="$4"
+            height={52}
+            fontWeight="700"
+            fontSize={16}
+            pressStyle={{
+              opacity: 0.85,
+              scale: 0.98,
+              borderColor: '$borderColorHover',
+            }}
+          >
+            {copy.createAccount}
+          </Button>
+        </YStack>
       </YStack>
     </ScrollView>
   );

--- a/app/(auth)/welcome.tsx
+++ b/app/(auth)/welcome.tsx
@@ -1,0 +1,90 @@
+// Écran Welcome — premier écran pour user non authentifié.
+// Logo + tagline + 2 boutons : "Sign in" et "Create an account".
+// Ticket E2-01 — Sprint 1 Auth & Onboarding (livré dans le scope E2-07).
+
+import { Image } from 'expo-image';
+import { router } from 'expo-router';
+import { Button, ScrollView, Text, YStack } from 'tamagui';
+
+import { t } from '@/i18n';
+
+const logoSource = require('../../assets/Logo-Doumassi.png') as number;
+
+export default function WelcomeScreen() {
+  const copy = t.auth.welcome;
+
+  return (
+    <ScrollView
+      flex={1}
+      backgroundColor="$background"
+      contentContainerStyle={{
+        flexGrow: 1,
+        justifyContent: 'space-between',
+        paddingHorizontal: 24,
+        paddingTop: 80,
+        paddingBottom: 48,
+      }}
+    >
+      {/* Logo + tagline centrés en haut */}
+      <YStack alignItems="center" gap="$4" marginTop="$8">
+        <Image
+          source={logoSource}
+          style={{ width: 120, height: 120 }}
+          contentFit="contain"
+          accessibilityLabel="Logo DOUMASSI"
+        />
+
+        <Text fontSize={40} fontWeight="700" color="$color" letterSpacing={2} fontFamily="$heading">
+          {t.splash.tagline}
+        </Text>
+
+        <Text
+          fontSize={15}
+          color="$placeholderColor"
+          textAlign="center"
+          lineHeight={22}
+          paddingHorizontal="$4"
+        >
+          {copy.tagline}
+        </Text>
+      </YStack>
+
+      {/* Boutons en bas */}
+      <YStack gap="$3" width="100%" maxWidth={400} alignSelf="center">
+        <Button
+          id="welcome-signin-button"
+          onPress={() => router.push('/(auth)/login')}
+          backgroundColor="$color"
+          color="$background"
+          borderRadius="$4"
+          height={52}
+          fontWeight="700"
+          fontSize={16}
+          pressStyle={{ opacity: 0.85, scale: 0.98 }}
+        >
+          {copy.signIn}
+        </Button>
+
+        <Button
+          id="welcome-signup-button"
+          onPress={() => router.push('/(auth)/signup')}
+          backgroundColor="transparent"
+          borderWidth={1}
+          borderColor="$borderColor"
+          color="$color"
+          borderRadius="$4"
+          height={52}
+          fontWeight="700"
+          fontSize={16}
+          pressStyle={{
+            opacity: 0.85,
+            scale: 0.98,
+            borderColor: '$borderColorHover',
+          }}
+        >
+          {copy.createAccount}
+        </Button>
+      </YStack>
+    </ScrollView>
+  );
+}

--- a/app/(onboarding)/_layout.tsx
+++ b/app/(onboarding)/_layout.tsx
@@ -1,19 +1,19 @@
-// Layout du groupe (feed) — écrans authentifiés (post-login).
+// Layout du groupe (onboarding) — étapes de complétion de profil.
 // Bloque l'accès si :
 //   - pas de session → redirect /welcome
-//   - profil incomplet → redirect /onboarding
+//   - profil déjà complet → redirect /feed (évite de re-onboarder un user déjà setup)
 //
-// Ticket E2-03 (création) + E2-07 (guard de session).
+// Sera rempli par les tickets E2-08 (pseudo), E2-09 (avatar), E2-10 (cover), E2-11 (intérêts).
+// Ticket E2-07 — Sprint 1 Auth & Onboarding (squelette + guard).
 
 import { Redirect, Stack } from 'expo-router';
 
 import GuardLoader from '@/components/GuardLoader';
 import { useAuthGuard } from '@/features/auth/hooks/useAuthGuard';
 
-export default function FeedLayout() {
+export default function OnboardingLayout() {
   const status = useAuthGuard();
 
-  // Pendant le check (cold start), on affiche un loader pour éviter le flash.
   if (status === 'loading') {
     return <GuardLoader />;
   }
@@ -22,8 +22,8 @@ export default function FeedLayout() {
     return <Redirect href="/(auth)/welcome" />;
   }
 
-  if (status === 'incomplete') {
-    return <Redirect href="/(onboarding)" />;
+  if (status === 'complete') {
+    return <Redirect href="/feed" />;
   }
 
   return (

--- a/app/(onboarding)/index.tsx
+++ b/app/(onboarding)/index.tsx
@@ -4,12 +4,31 @@
 // Ticket E2-07 — Sprint 1 Auth & Onboarding.
 
 import { router } from 'expo-router';
-import { Button, Text, YStack } from 'tamagui';
+import { useState } from 'react';
+import { Button, Spinner, Text, YStack } from 'tamagui';
 
 import { t } from '@/i18n';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
 
 export default function OnboardingPlaceholder() {
   const copy = t.auth.onboarding;
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const handleSignOut = async () => {
+    setIsSigningOut(true);
+    try {
+      const { error } = await supabase.auth.signOut();
+      if (error) {
+        logger.warn('Sign out failed', { message: error.message });
+      }
+      router.replace('/(auth)/welcome');
+    } catch (err: unknown) {
+      logger.error('Unexpected sign out error', err);
+    } finally {
+      setIsSigningOut(false);
+    }
+  };
 
   return (
     <YStack
@@ -41,6 +60,20 @@ export default function OnboardingPlaceholder() {
         pressStyle={{ opacity: 0.85, scale: 0.98 }}
       >
         {copy.continueToFeed}
+      </Button>
+
+      {/* Échappatoire pour sortir tant que les vrais steps onboarding n'existent pas */}
+      <Button
+        onPress={handleSignOut}
+        disabled={isSigningOut}
+        backgroundColor="transparent"
+        color="$placeholderColor"
+        fontWeight="600"
+        fontSize={14}
+        marginTop="$2"
+        pressStyle={{ opacity: 0.7 }}
+      >
+        {isSigningOut ? <Spinner size="small" color="$placeholderColor" /> : 'Sign out'}
       </Button>
     </YStack>
   );

--- a/app/(onboarding)/index.tsx
+++ b/app/(onboarding)/index.tsx
@@ -1,0 +1,47 @@
+// Écran d'onboarding — placeholder.
+// Ce squelette sera remplacé par les vrais steps (pseudo, avatar, cover, intérêts)
+// dans les tickets E2-08 à E2-11.
+// Ticket E2-07 — Sprint 1 Auth & Onboarding.
+
+import { router } from 'expo-router';
+import { Button, Text, YStack } from 'tamagui';
+
+import { t } from '@/i18n';
+
+export default function OnboardingPlaceholder() {
+  const copy = t.auth.onboarding;
+
+  return (
+    <YStack
+      flex={1}
+      backgroundColor="$background"
+      alignItems="center"
+      justifyContent="center"
+      paddingHorizontal="$5"
+      gap="$5"
+    >
+      <Text fontSize={32} fontWeight="700" color="$color" textAlign="center" fontFamily="$heading">
+        {copy.placeholderTitle}
+      </Text>
+
+      <Text fontSize={15} color="$placeholderColor" textAlign="center" lineHeight={22}>
+        {copy.placeholderSubtitle}
+      </Text>
+
+      <Button
+        onPress={() => router.replace('/feed')}
+        backgroundColor="$color"
+        color="$background"
+        borderRadius="$4"
+        height={48}
+        fontWeight="700"
+        fontSize={16}
+        width="100%"
+        maxWidth={320}
+        pressStyle={{ opacity: 0.85, scale: 0.98 }}
+      >
+        {copy.continueToFeed}
+      </Button>
+    </YStack>
+  );
+}

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -9,6 +9,8 @@
 //      la session via un autre mécanisme (rehydratation, refresh token, etc.)
 //
 // Timeout de 10s : si rien ne se passe, on retourne sur Welcome avec une erreur.
+// NOTE: en l'état, le retour du deep link doumassi:// depuis Chrome Android peut
+// échouer (limitation OS). Un ticket de fix utilisera expo-web-browser.
 //
 // Ticket E2-05 — Sprint 1 Auth & Onboarding.
 
@@ -42,7 +44,6 @@ function extractTokensFromUrl(url: string): {
 
 export default function AuthCallbackScreen() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [debugUrl, setDebugUrl] = useState<string>('(waiting...)');
 
   useEffect(() => {
     let cancelled = false;
@@ -64,19 +65,12 @@ export default function AuthCallbackScreen() {
       router.replace('/feed');
     };
 
-    const consumeUrl = async (url: string | null, source: string) => {
-      // En warn pour que Sentry capture en breadcrumb
-      logger.warn(`[CALLBACK] consume URL from ${source}`, { url });
+    const consumeUrl = async (url: string | null) => {
       if (!url || cancelled) return;
-      setDebugUrl(`[${source}] ${url.slice(0, 200)}`);
 
       const tokens = extractTokensFromUrl(url);
-      if (!tokens) {
-        logger.warn(`[CALLBACK] URL has no tokens fragment`, { url, source });
-        return;
-      }
+      if (!tokens) return;
 
-      logger.warn(`[CALLBACK] Tokens extracted, calling setSession`, { source });
       const { error } = await supabase.auth.setSession({
         access_token: tokens.accessToken,
         refresh_token: tokens.refreshToken,
@@ -85,7 +79,7 @@ export default function AuthCallbackScreen() {
       if (cancelled) return;
 
       if (error) {
-        logger.warn('[CALLBACK] setSession failed', { message: error.message });
+        logger.warn('setSession failed', { message: error.message });
         finishWithError();
         return;
       }
@@ -95,18 +89,16 @@ export default function AuthCallbackScreen() {
 
     // Stratégie 1 : URL initiale (cold start)
     Linking.getInitialURL().then((url) => {
-      logger.warn(`[CALLBACK] getInitialURL resolved`, { url });
-      void consumeUrl(url, 'getInitialURL');
+      void consumeUrl(url);
     });
 
     // Stratégie 2 : URL entrante (warm)
     const linkingSub = Linking.addEventListener('url', ({ url }) => {
-      void consumeUrl(url, 'addEventListener');
+      void consumeUrl(url);
     });
 
     // Stratégie 3 : auth state change (Supabase peut établir la session autrement)
     const { data: authSub } = supabase.auth.onAuthStateChange((event, session) => {
-      logger.warn(`[CALLBACK] Auth state change`, { event, hasSession: !!session });
       if (cancelled || !session) return;
       if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION' || event === 'TOKEN_REFRESHED') {
         finishWithSuccess();
@@ -147,17 +139,6 @@ export default function AuthCallbackScreen() {
           </Text>
         </>
       )}
-
-      {/* Debug : URL captée. À retirer après diagnostic. */}
-      <Text
-        fontSize={10}
-        color="$placeholderColor"
-        textAlign="center"
-        marginTop="$4"
-        paddingHorizontal="$2"
-      >
-        {debugUrl}
-      </Text>
     </YStack>
   );
 }

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -46,7 +46,7 @@ export default function AuthCallbackScreen() {
         logger.warn('Deep link auth/callback sans tokens valides', { url });
         if (!cancelled) {
           setErrorMessage(t.auth.google.callbackError);
-          setTimeout(() => router.replace('/(auth)/login'), 1500);
+          setTimeout(() => router.replace('/(auth)/welcome'), 1500);
         }
         return;
       }
@@ -60,14 +60,14 @@ export default function AuthCallbackScreen() {
         logger.warn('setSession a échoué après callback OAuth', { message: error.message });
         if (!cancelled) {
           setErrorMessage(t.auth.google.callbackError);
-          setTimeout(() => router.replace('/(auth)/login'), 1500);
+          setTimeout(() => router.replace('/(auth)/welcome'), 1500);
         }
         return;
       }
 
       logger.info('Session établie après OAuth Google');
       if (!cancelled) {
-        router.replace('/');
+        router.replace('/feed');
       }
     };
 

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -42,6 +42,7 @@ function extractTokensFromUrl(url: string): {
 
 export default function AuthCallbackScreen() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [debugUrl, setDebugUrl] = useState<string>('(waiting...)');
 
   useEffect(() => {
     let cancelled = false;
@@ -64,15 +65,18 @@ export default function AuthCallbackScreen() {
     };
 
     const consumeUrl = async (url: string | null, source: string) => {
-      logger.debug('Auth callback consume URL', { source, hasUrl: !!url });
+      // En warn pour que Sentry capture en breadcrumb
+      logger.warn(`[CALLBACK] consume URL from ${source}`, { url });
       if (!url || cancelled) return;
+      setDebugUrl(`[${source}] ${url.slice(0, 200)}`);
 
       const tokens = extractTokensFromUrl(url);
       if (!tokens) {
-        logger.debug('URL has no tokens (probably initial launch URL)', { url });
+        logger.warn(`[CALLBACK] URL has no tokens fragment`, { url, source });
         return;
       }
 
+      logger.warn(`[CALLBACK] Tokens extracted, calling setSession`, { source });
       const { error } = await supabase.auth.setSession({
         access_token: tokens.accessToken,
         refresh_token: tokens.refreshToken,
@@ -81,7 +85,7 @@ export default function AuthCallbackScreen() {
       if (cancelled) return;
 
       if (error) {
-        logger.warn('setSession failed', { message: error.message });
+        logger.warn('[CALLBACK] setSession failed', { message: error.message });
         finishWithError();
         return;
       }
@@ -91,6 +95,7 @@ export default function AuthCallbackScreen() {
 
     // Stratégie 1 : URL initiale (cold start)
     Linking.getInitialURL().then((url) => {
+      logger.warn(`[CALLBACK] getInitialURL resolved`, { url });
       void consumeUrl(url, 'getInitialURL');
     });
 
@@ -101,7 +106,7 @@ export default function AuthCallbackScreen() {
 
     // Stratégie 3 : auth state change (Supabase peut établir la session autrement)
     const { data: authSub } = supabase.auth.onAuthStateChange((event, session) => {
-      logger.debug('Auth state change in callback', { event, hasSession: !!session });
+      logger.warn(`[CALLBACK] Auth state change`, { event, hasSession: !!session });
       if (cancelled || !session) return;
       if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION' || event === 'TOKEN_REFRESHED') {
         finishWithSuccess();
@@ -142,6 +147,17 @@ export default function AuthCallbackScreen() {
           </Text>
         </>
       )}
+
+      {/* Debug : URL captée. À retirer après diagnostic. */}
+      <Text
+        fontSize={10}
+        color="$placeholderColor"
+        textAlign="center"
+        marginTop="$4"
+        paddingHorizontal="$2"
+      >
+        {debugUrl}
+      </Text>
     </YStack>
   );
 }

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -1,6 +1,14 @@
 // Écran de callback OAuth — destination du deep link doumassi://auth/callback.
-// Capte les tokens (access_token + refresh_token) du fragment de l'URL,
-// établit la session Supabase, puis redirige vers l'accueil.
+// Capture les tokens (access_token + refresh_token) du fragment de l'URL,
+// établit la session Supabase, puis redirige vers /feed.
+//
+// 3 stratégies en parallèle (la première qui réussit l'emporte) :
+//   1) Linking.getInitialURL — cas cold start (l'app a été ouverte par le deep link)
+//   2) Linking.addEventListener('url') — cas warm (l'app était déjà ouverte)
+//   3) supabase.auth.onAuthStateChange — fallback si Supabase a quand même capté
+//      la session via un autre mécanisme (rehydratation, refresh token, etc.)
+//
+// Timeout de 10s : si rien ne se passe, on retourne sur Welcome avec une erreur.
 //
 // Ticket E2-05 — Sprint 1 Auth & Onboarding.
 
@@ -37,17 +45,31 @@ export default function AuthCallbackScreen() {
 
   useEffect(() => {
     let cancelled = false;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
-    const consumeUrl = async (url: string | null) => {
+    const finishWithError = () => {
+      if (cancelled) return;
+      logger.warn('Auth callback failed — redirecting to welcome');
+      setErrorMessage(t.auth.google.callbackError);
+      setTimeout(() => {
+        if (!cancelled) router.replace('/(auth)/welcome');
+      }, 1500);
+    };
+
+    const finishWithSuccess = () => {
+      if (cancelled) return;
+      if (timeoutId) clearTimeout(timeoutId);
+      logger.info('Auth callback success — redirecting to feed');
+      router.replace('/feed');
+    };
+
+    const consumeUrl = async (url: string | null, source: string) => {
+      logger.debug('Auth callback consume URL', { source, hasUrl: !!url });
       if (!url || cancelled) return;
 
       const tokens = extractTokensFromUrl(url);
       if (!tokens) {
-        logger.warn('Deep link auth/callback sans tokens valides', { url });
-        if (!cancelled) {
-          setErrorMessage(t.auth.google.callbackError);
-          setTimeout(() => router.replace('/(auth)/welcome'), 1500);
-        }
+        logger.debug('URL has no tokens (probably initial launch URL)', { url });
         return;
       }
 
@@ -56,30 +78,46 @@ export default function AuthCallbackScreen() {
         refresh_token: tokens.refreshToken,
       });
 
+      if (cancelled) return;
+
       if (error) {
-        logger.warn('setSession a échoué après callback OAuth', { message: error.message });
-        if (!cancelled) {
-          setErrorMessage(t.auth.google.callbackError);
-          setTimeout(() => router.replace('/(auth)/welcome'), 1500);
-        }
+        logger.warn('setSession failed', { message: error.message });
+        finishWithError();
         return;
       }
 
-      logger.info('Session établie après OAuth Google');
-      if (!cancelled) {
-        router.replace('/feed');
-      }
+      finishWithSuccess();
     };
 
-    // Cas 1 : l'app a été ouverte directement par le deep link (cold start)
-    Linking.getInitialURL().then(consumeUrl);
+    // Stratégie 1 : URL initiale (cold start)
+    Linking.getInitialURL().then((url) => {
+      void consumeUrl(url, 'getInitialURL');
+    });
 
-    // Cas 2 : l'app était déjà en arrière-plan, le deep link arrive en cours
-    const subscription = Linking.addEventListener('url', ({ url }) => consumeUrl(url));
+    // Stratégie 2 : URL entrante (warm)
+    const linkingSub = Linking.addEventListener('url', ({ url }) => {
+      void consumeUrl(url, 'addEventListener');
+    });
+
+    // Stratégie 3 : auth state change (Supabase peut établir la session autrement)
+    const { data: authSub } = supabase.auth.onAuthStateChange((event, session) => {
+      logger.debug('Auth state change in callback', { event, hasSession: !!session });
+      if (cancelled || !session) return;
+      if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION' || event === 'TOKEN_REFRESHED') {
+        finishWithSuccess();
+      }
+    });
+
+    // Timeout : si rien n'arrive dans 10s, on abandonne
+    timeoutId = setTimeout(() => {
+      finishWithError();
+    }, 10_000);
 
     return () => {
       cancelled = true;
-      subscription.remove();
+      if (timeoutId) clearTimeout(timeoutId);
+      linkingSub.remove();
+      authSub.subscription.unsubscribe();
     };
   }, []);
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,41 +1,65 @@
 // Écran Splash applicatif (premier écran après le boot natif).
-// Ticket E1-17 + E2-03 — affiche "DOUMASSI" 1s, fade-out 1s,
-// puis redirige vers /feed si session active, /login sinon.
+// Affiche "DOUMASSI" 1s, fade-out 1s, puis redirige selon useAuthGuard :
+//   - unauthenticated → /welcome
+//   - incomplete      → /onboarding
+//   - complete        → /feed
+// Garde le splash visible tant que l'auth est en cours pour éviter les flashs.
+//
+// Ticket E1-17 (splash) + E2-07 (guard logic).
 
 import { router } from 'expo-router';
 import { useEffect, useRef } from 'react';
 import { Animated } from 'react-native';
 import { Text, YStack } from 'tamagui';
 
+import { useAuthGuard } from '@/features/auth/hooks/useAuthGuard';
 import { t } from '@/i18n';
-import { supabase } from '@/lib/supabase';
 
 export default function Splash() {
   const opacity = useRef(new Animated.Value(1)).current;
+  const status = useAuthGuard();
+  const minDisplayElapsed = useRef(false);
 
   useEffect(() => {
-    let isMounted = true;
-
+    // Affiche le splash au moins 1s pour ne pas qu'il "flashe".
     const timer = setTimeout(() => {
-      Animated.timing(opacity, {
-        toValue: 0,
-        duration: 1000,
-        useNativeDriver: true,
-      }).start(async () => {
-        const { data } = await supabase.auth.getSession();
-
-        if (!isMounted) return;
-
-        router.replace(data.session ? '/feed' : '/login');
-      });
+      minDisplayElapsed.current = true;
+      maybeRedirect();
     }, 1000);
 
-    return () => {
-      isMounted = false;
-      clearTimeout(timer);
-      opacity.stopAnimation();
-    };
-  }, [opacity]);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // À chaque changement de status, tente de rediriger
+  // (uniquement après le délai minimum + une fois le check terminé).
+  useEffect(() => {
+    maybeRedirect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status]);
+
+  const maybeRedirect = () => {
+    if (!minDisplayElapsed.current) return;
+    if (status === 'loading') return;
+
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: 600,
+      useNativeDriver: true,
+    }).start(() => {
+      switch (status) {
+        case 'unauthenticated':
+          router.replace('/(auth)/welcome');
+          break;
+        case 'incomplete':
+          router.replace('/(onboarding)');
+          break;
+        case 'complete':
+          router.replace('/feed');
+          break;
+      }
+    });
+  };
 
   return (
     <Animated.View style={{ flex: 1, opacity }}>

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,14 +1,15 @@
 // Écran Splash applicatif (premier écran après le boot natif).
-// Affiche "DOUMASSI" 1s, fade-out 1s, puis redirige selon useAuthGuard :
+// Affiche "DOUMASSI" 1s, fade-out 600ms, puis redirige selon useAuthGuard :
 //   - unauthenticated → /welcome
 //   - incomplete      → /onboarding
 //   - complete        → /feed
-// Garde le splash visible tant que l'auth est en cours pour éviter les flashs.
+// Garde le splash visible tant que (1) le délai min n'est pas écoulé ET
+// (2) l'auth est en cours de check, pour éviter les flashs.
 //
 // Ticket E1-17 (splash) + E2-07 (guard logic).
 
 import { router } from 'expo-router';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Animated } from 'react-native';
 import { Text, YStack } from 'tamagui';
 
@@ -18,29 +19,20 @@ import { t } from '@/i18n';
 export default function Splash() {
   const opacity = useRef(new Animated.Value(1)).current;
   const status = useAuthGuard();
-  const minDisplayElapsed = useRef(false);
+  const [minElapsed, setMinElapsed] = useState(false);
+  const hasRedirected = useRef(false);
 
+  // Délai minimum d'affichage (état pour déclencher le useEffect de redirect)
   useEffect(() => {
-    // Affiche le splash au moins 1s pour ne pas qu'il "flashe".
-    const timer = setTimeout(() => {
-      minDisplayElapsed.current = true;
-      maybeRedirect();
-    }, 1000);
-
+    const timer = setTimeout(() => setMinElapsed(true), 1000);
     return () => clearTimeout(timer);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // À chaque changement de status, tente de rediriger
-  // (uniquement après le délai minimum + une fois le check terminé).
+  // Redirect dès que les 2 conditions sont remplies (1) délai écoulé (2) status connu
   useEffect(() => {
-    maybeRedirect();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status]);
-
-  const maybeRedirect = () => {
-    if (!minDisplayElapsed.current) return;
-    if (status === 'loading') return;
+    if (!minElapsed || status === 'loading') return;
+    if (hasRedirected.current) return;
+    hasRedirected.current = true;
 
     Animated.timing(opacity, {
       toValue: 0,
@@ -59,7 +51,7 @@ export default function Splash() {
           break;
       }
     });
-  };
+  }, [minElapsed, status, opacity]);
 
   return (
     <Animated.View style={{ flex: 1, opacity }}>

--- a/src/components/GuardLoader.tsx
+++ b/src/components/GuardLoader.tsx
@@ -1,0 +1,11 @@
+// Loader minimaliste affiché pendant que useAuthGuard vérifie la session.
+// Volontairement simple (pas d'animation, pas de spinner) : matche le fond noir
+// du splash pour qu'il y ait zéro flash visible quand on transite splash → guard → écran.
+//
+// Ticket E2-07 — Sprint 1 Auth & Onboarding.
+
+import { YStack } from 'tamagui';
+
+export default function GuardLoader() {
+  return <YStack flex={1} backgroundColor="$background" />;
+}

--- a/src/features/auth/hooks/useAuthGuard.ts
+++ b/src/features/auth/hooks/useAuthGuard.ts
@@ -1,0 +1,79 @@
+// Hook qui détermine l'état d'authentification + de complétion du profil.
+// Source de vérité unique pour les guards de navigation (E2-07).
+//
+// États possibles :
+//   - 'loading'        : check en cours, on affiche le splash
+//   - 'unauthenticated': pas de session → /welcome
+//   - 'incomplete'     : session OK mais profil pas fini (pas de username) → /onboarding
+//   - 'complete'       : session OK + profil complet → /feed
+//
+// Le hook écoute supabase.auth.onAuthStateChange pour réagir aux login/logout
+// en temps réel (pas besoin de re-mount le composant).
+//
+// Ticket E2-07 — Sprint 1 Auth & Onboarding.
+
+import { useEffect, useState } from 'react';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type AuthStatus = 'loading' | 'unauthenticated' | 'incomplete' | 'complete';
+
+/**
+ * Vérifie auprès de Supabase si le profil de l'utilisateur courant est complet.
+ * Pour le MVP, on considère un profil complet si `username` est non-null.
+ * Les autres champs (avatar, cover, intérêts) viendront avec E2-09 à E2-11.
+ */
+async function isProfileComplete(userId: string): Promise<boolean> {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('username')
+    .eq('id', userId)
+    .maybeSingle();
+
+  if (error) {
+    logger.warn('Échec lecture profile', { message: error.message });
+    // En cas d'erreur réseau, on considère le profil incomplet plutôt que de bloquer l'user
+    // sur le feed avec un compte cassé.
+    return false;
+  }
+
+  return Boolean(data?.username);
+}
+
+export function useAuthGuard() {
+  const [status, setStatus] = useState<AuthStatus>('loading');
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const resolveStatus = async (userId: string | undefined) => {
+      if (!userId) {
+        if (!cancelled) setStatus('unauthenticated');
+        return;
+      }
+
+      const complete = await isProfileComplete(userId);
+      if (cancelled) return;
+      setStatus(complete ? 'complete' : 'incomplete');
+    };
+
+    // Initial check (cold start)
+    supabase.auth.getSession().then(({ data }) => {
+      void resolveStatus(data.session?.user?.id);
+    });
+
+    // Listener pour login/logout en cours de route
+    const { data: subscription } = supabase.auth.onAuthStateChange((event, session) => {
+      logger.debug('Auth state changed', { event });
+      void resolveStatus(session?.user?.id);
+    });
+
+    return () => {
+      cancelled = true;
+      subscription.subscription.unsubscribe();
+    };
+  }, []);
+
+  return status;
+}

--- a/src/features/auth/hooks/useResetPassword.ts
+++ b/src/features/auth/hooks/useResetPassword.ts
@@ -125,7 +125,7 @@ export function useResetPassword() {
       // Redirection vers login après une courte pause (laisse le succès s'afficher).
       setTimeout(() => {
         supabase.auth.signOut().finally(() => {
-          router.replace('/(auth)/login');
+          router.replace('/(auth)/welcome');
         });
       }, 1500);
     } catch (err: unknown) {

--- a/src/features/feed/screens/FeedScreen.tsx
+++ b/src/features/feed/screens/FeedScreen.tsx
@@ -19,7 +19,7 @@ export function FeedScreen() {
       if (error) {
         logger.warn('Échec signOut', { message: error.message });
       }
-      router.replace('/login');
+      router.replace('/(auth)/welcome');
     } catch (err: unknown) {
       logger.error('Erreur inattendue lors du signOut', err);
     } finally {

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -7,6 +7,17 @@ export const fr = {
     tagline: 'DOUMASSI',
   },
   auth: {
+    welcome: {
+      tagline: 'The French super-app.',
+      signIn: 'Sign in',
+      createAccount: 'Create an account',
+    },
+    onboarding: {
+      placeholderTitle: 'Almost there!',
+      placeholderSubtitle:
+        'Complete your profile to start using DOUMASSI.\nThe full onboarding flow is coming soon.',
+      continueToFeed: 'Skip for now',
+    },
     google: {
       continueWithGoogle: 'Continue with Google',
       callbackInProgress: 'Signing you in…',


### PR DESCRIPTION
## Summary

Cette PR boucle deux tickets en un :
- **E2-07 (Guards de navigation)** : routes publiques vs protégées avec redirect intelligent selon l'état d'auth + complétion du profil
- **E2-01 (Écran Welcome)** : ce ticket était CLOSED sur GitHub mais le fichier `welcome.tsx` n'avait jamais été livré (PR #117 a livré le login screen à la place). Rattrapé ici.

## Critères d'acceptation E2-07
- ✅ Layout racine avec check session (`useAuthGuard` dans le splash + layouts protégés)
- ✅ Redirection `/welcome` si pas de session
- ✅ Redirection `/onboarding` si session mais `profile.username` null
- ✅ Redirection `/feed` si profil complet
- ✅ Pas de flash visible (`GuardLoader` fond noir matchant le splash)

## Critères d'acceptation E2-01
- ✅ Route `app/(auth)/welcome.tsx`
- ✅ Logo + tagline affichés
- ✅ Bouton "Sign in" → `/login`
- ✅ Bouton "Create an account" → `/signup`

## Architecture

- Hook `useAuthGuard` : source de vérité unique (états `loading`/`unauthenticated`/`incomplete`/`complete`)
  - Écoute `supabase.auth.onAuthStateChange` pour réagir aux login/logout en temps réel
  - Query `profiles.username` pour déterminer si onboarding est requis
- Splash garde un délai minimum de 1s pour éviter le flash perçu
- Layouts `(feed)` et `(onboarding)` utilisent `<Redirect>` d'expo-router quand l'état ne matche pas
- Squelette `app/(onboarding)/` créé pour accueillir les futurs steps E2-08 à E2-11

## Test plan

- [ ] Cold start sans session → atterrit sur `/welcome`
- [ ] Cold start avec session + profil complet → atterrit sur `/feed`
- [ ] Cold start avec session + `profile.username` null → atterrit sur `/onboarding`
- [ ] Login email/phone → redirige vers `/feed` (le guard route ensuite si profil incomplet)
- [ ] Signup → redirige vers `/feed` (route vers `/onboarding` si username pas encore set)
- [ ] OAuth Google → callback → `/feed` (idem)
- [ ] Sign out depuis Feed → atterrit sur `/welcome`
- [ ] Deep link direct vers `/feed` sans session → bloqué par le guard, renvoyé vers `/welcome`
- [ ] Pas de flash visible entre splash et écran final
- [ ] Lint + typecheck verts ✅

Closes #24
Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)