### PR TITLE
fix(auth): OAuth Google via expo-web-browser (closes #124)

### DIFF
--- a/app.json
+++ b/app.json
@@ -45,7 +45,8 @@
       "expo-audio",
       "expo-video",
       "expo-localization",
-      "expo-secure-store"
+      "expo-secure-store",
+      "expo-web-browser"
     ],
     "extra": {
       "router": {},

--- a/app/auth/callback.tsx
+++ b/app/auth/callback.tsx
@@ -1,18 +1,19 @@
-// Écran de callback OAuth — destination du deep link doumassi://auth/callback.
-// Capture les tokens (access_token + refresh_token) du fragment de l'URL,
-// établit la session Supabase, puis redirige vers /feed.
+// Écran de callback OAuth — filet de sécurité.
 //
-// 3 stratégies en parallèle (la première qui réussit l'emporte) :
-//   1) Linking.getInitialURL — cas cold start (l'app a été ouverte par le deep link)
-//   2) Linking.addEventListener('url') — cas warm (l'app était déjà ouverte)
-//   3) supabase.auth.onAuthStateChange — fallback si Supabase a quand même capté
-//      la session via un autre mécanisme (rehydratation, refresh token, etc.)
+// En usage normal (depuis #124), ce screen n'est JAMAIS atteint :
+//   useGoogleAuth utilise WebBrowser.openAuthSessionAsync qui intercepte
+//   le redirect Supabase directement dans le browser in-app et retourne
+//   l'URL au code sans passer par la couche deep link système.
 //
-// Timeout de 10s : si rien ne se passe, on retourne sur Welcome avec une erreur.
-// NOTE: en l'état, le retour du deep link doumassi:// depuis Chrome Android peut
-// échouer (limitation OS). Un ticket de fix utilisera expo-web-browser.
+// Mais on garde la route pour gérer les cas edge :
+//   - L'user ouvre l'app pendant que le browser est ouvert → cold start avec
+//     un deep link entrant
+//   - WebBrowser plante / le browser système prend le relais
 //
-// Ticket E2-05 — Sprint 1 Auth & Onboarding.
+// Le screen tente de récupérer les tokens depuis l'URL initiale, sinon
+// redirige vers welcome après un court délai.
+//
+// Ticket E2-05 (création) + #124 (refactor : devient juste un fallback).
 
 import * as Linking from 'expo-linking';
 import { router } from 'expo-router';
@@ -23,10 +24,6 @@ import { t } from '@/i18n';
 import { logger } from '@/lib/logger';
 import { supabase } from '@/lib/supabase';
 
-/**
- * Parse le fragment d'une URL deep link pour en extraire les tokens.
- * Format attendu : doumassi://auth/callback#access_token=XXX&refresh_token=YYY&...
- */
 function extractTokensFromUrl(url: string): {
   accessToken: string;
   refreshToken: string;
@@ -47,23 +44,6 @@ export default function AuthCallbackScreen() {
 
   useEffect(() => {
     let cancelled = false;
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
-
-    const finishWithError = () => {
-      if (cancelled) return;
-      logger.warn('Auth callback failed — redirecting to welcome');
-      setErrorMessage(t.auth.google.callbackError);
-      setTimeout(() => {
-        if (!cancelled) router.replace('/(auth)/welcome');
-      }, 1500);
-    };
-
-    const finishWithSuccess = () => {
-      if (cancelled) return;
-      if (timeoutId) clearTimeout(timeoutId);
-      logger.info('Auth callback success — redirecting to feed');
-      router.replace('/feed');
-    };
 
     const consumeUrl = async (url: string | null) => {
       if (!url || cancelled) return;
@@ -79,42 +59,28 @@ export default function AuthCallbackScreen() {
       if (cancelled) return;
 
       if (error) {
-        logger.warn('setSession failed', { message: error.message });
-        finishWithError();
+        logger.warn('Fallback setSession failed', { message: error.message });
         return;
       }
 
-      finishWithSuccess();
+      router.replace('/feed');
     };
 
-    // Stratégie 1 : URL initiale (cold start)
-    Linking.getInitialURL().then((url) => {
-      void consumeUrl(url);
-    });
+    Linking.getInitialURL().then((url) => void consumeUrl(url));
+    const linkingSub = Linking.addEventListener('url', ({ url }) => void consumeUrl(url));
 
-    // Stratégie 2 : URL entrante (warm)
-    const linkingSub = Linking.addEventListener('url', ({ url }) => {
-      void consumeUrl(url);
-    });
-
-    // Stratégie 3 : auth state change (Supabase peut établir la session autrement)
-    const { data: authSub } = supabase.auth.onAuthStateChange((event, session) => {
-      if (cancelled || !session) return;
-      if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION' || event === 'TOKEN_REFRESHED') {
-        finishWithSuccess();
-      }
-    });
-
-    // Timeout : si rien n'arrive dans 10s, on abandonne
-    timeoutId = setTimeout(() => {
-      finishWithError();
-    }, 10_000);
+    // Filet de sécurité : si rien n'arrive dans 5s, retour Welcome
+    const timeoutId = setTimeout(() => {
+      if (cancelled) return;
+      logger.warn('OAuth callback fallback timeout — redirect welcome');
+      setErrorMessage(t.auth.google.callbackError);
+      setTimeout(() => router.replace('/(auth)/welcome'), 1500);
+    }, 5_000);
 
     return () => {
       cancelled = true;
-      if (timeoutId) clearTimeout(timeoutId);
+      clearTimeout(timeoutId);
       linkingSub.remove();
-      authSub.subscription.unsubscribe();
     };
   }, []);
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "expo-status-bar": "~55.0.5",
     "expo-updates": "~55.0.21",
     "expo-video": "~55.0.15",
+    "expo-web-browser": "~55.0.14",
     "lucide-react-native": "1.11.0",
     "posthog-react-native": "4.43.5",
     "posthog-react-native-session-replay": "1.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       expo-video:
         specifier: ~55.0.15
         version: 55.0.15(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      expo-web-browser:
+        specifier: ~55.0.14
+        version: 55.0.14(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))
       lucide-react-native:
         specifier: 1.11.0
         version: 1.11.0(react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -4112,6 +4115,12 @@ packages:
     peerDependencies:
       expo: '*'
       react: '*'
+      react-native: '*'
+
+  expo-web-browser@55.0.14:
+    resolution: {integrity: sha512-bTDkBSQBnrlnYcM7Aak72AOvJuvdgA3M8p//Lazrm0Nfa77T9cRXzQ6KhLrB08V39n1+00d1dvuTWznJslkmdg==}
+    peerDependencies:
+      expo: '*'
       react-native: '*'
 
   expo@55.0.17:
@@ -12326,6 +12335,11 @@ snapshots:
     dependencies:
       expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
+
+  expo-web-browser@55.0.14(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)):
+    dependencies:
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
 
   expo@55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3):

--- a/src/features/auth/hooks/useGoogleAuth.ts
+++ b/src/features/auth/hooks/useGoogleAuth.ts
@@ -1,11 +1,18 @@
 // Hook pour le flow OAuth Google.
-// Délègue à Supabase la génération de l'URL de consentement Google,
-// ouvre cette URL dans le navigateur du téléphone, puis le retour est géré
-// par le deep link doumassi://auth/callback (cf. app/auth/callback.tsx).
+// Utilise expo-web-browser (Chrome Custom Tabs sur Android, ASWebAuthenticationSession sur iOS)
+// qui gère le round-trip OAuth de manière fiable, contrairement à Linking.openURL
+// qui dépendait de Chrome Android pour suivre le redirect vers le custom scheme.
 //
-// Ticket E2-05 — Sprint 1 Auth & Onboarding.
+// Flow :
+//   1. supabase.auth.signInWithOAuth({ skipBrowserRedirect: true }) → URL Google
+//   2. WebBrowser.openAuthSessionAsync(url, redirectTo) → ouvre le browser in-app
+//   3. WebBrowser détecte le redirect vers redirectTo, ferme le browser, retourne l'URL
+//   4. On parse les tokens du fragment, on appelle setSession, on redirect /feed
+//
+// Ticket E2-05 (création) + #124 (fix Android Chrome deep link).
 
-import * as Linking from 'expo-linking';
+import { router } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
 import { useState } from 'react';
 
 import { mapAuthError } from '@/features/auth/lib/mapAuthError';
@@ -16,6 +23,25 @@ import { supabase } from '@/lib/supabase';
 // Doit matcher `scheme` dans app.json + l'allowlist Redirect URLs Supabase
 // (Authentication → URL Configuration).
 const OAUTH_REDIRECT_URL = 'doumassi://auth/callback';
+
+/**
+ * Parse le fragment d'une URL deep link pour en extraire les tokens.
+ * Format attendu : doumassi://auth/callback#access_token=XXX&refresh_token=YYY&...
+ */
+function extractTokensFromUrl(url: string): {
+  accessToken: string;
+  refreshToken: string;
+} | null {
+  const hashIndex = url.indexOf('#');
+  if (hashIndex === -1) return null;
+
+  const params = new URLSearchParams(url.slice(hashIndex + 1));
+  const accessToken = params.get('access_token');
+  const refreshToken = params.get('refresh_token');
+
+  if (!accessToken || !refreshToken) return null;
+  return { accessToken, refreshToken };
+}
 
 export function useGoogleAuth() {
   const [isLoading, setIsLoading] = useState(false);
@@ -28,18 +54,18 @@ export function useGoogleAuth() {
     try {
       logger.debug('Tentative OAuth Google');
 
+      // 1. Récupérer l'URL Google de consentement depuis Supabase
       const { data, error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
           redirectTo: OAUTH_REDIRECT_URL,
-          // skipBrowserRedirect: on gère manuellement l'ouverture du navigateur
-          // car on est sur React Native (pas de redirection auto possible).
+          // skipBrowserRedirect: on gère manuellement l'ouverture via WebBrowser
           skipBrowserRedirect: true,
         },
       });
 
       if (error) {
-        logger.warn('Erreur signInWithOAuth Google', { message: error.message });
+        logger.warn('signInWithOAuth Google failed', { message: error.message });
         setErrorMessage(mapAuthError(error.message));
         return;
       }
@@ -50,16 +76,47 @@ export function useGoogleAuth() {
         return;
       }
 
-      // Ouvre la page de consentement Google dans le navigateur du tél.
-      // Après auth réussie, Google → Supabase callback → deep link doumassi://auth/callback
-      const supported = await Linking.canOpenURL(data.url);
-      if (!supported) {
-        logger.warn('URL OAuth non supportée par le device');
-        setErrorMessage(t.auth.errors.unknown);
+      // 2. Ouvrir l'URL dans Chrome Custom Tabs (Android) / ASWebAuthenticationSession (iOS)
+      // openAuthSessionAsync surveille le redirectTo et ferme automatiquement le browser
+      // dès que la cible est atteinte (contrairement à Linking.openURL qui ne le détecte pas).
+      const result = await WebBrowser.openAuthSessionAsync(data.url, OAUTH_REDIRECT_URL);
+
+      logger.debug('WebBrowser auth session result', { type: result.type });
+
+      // L'user a fermé le browser sans terminer (cancel/dismiss)
+      if (result.type !== 'success') {
+        if (result.type === 'cancel' || result.type === 'dismiss') {
+          // Pas d'erreur affichée — l'user a juste annulé volontairement
+          logger.info('OAuth Google annulé par l’utilisateur');
+          return;
+        }
+        logger.warn('WebBrowser auth session non-success', { type: result.type });
+        setErrorMessage(t.auth.google.callbackError);
         return;
       }
 
-      await Linking.openURL(data.url);
+      // 3. Parser les tokens depuis l'URL retournée
+      const tokens = extractTokensFromUrl(result.url);
+      if (!tokens) {
+        logger.warn('URL OAuth retour sans tokens', { url: result.url });
+        setErrorMessage(t.auth.google.callbackError);
+        return;
+      }
+
+      // 4. Établir la session Supabase
+      const { error: sessionError } = await supabase.auth.setSession({
+        access_token: tokens.accessToken,
+        refresh_token: tokens.refreshToken,
+      });
+
+      if (sessionError) {
+        logger.warn('setSession failed après OAuth', { message: sessionError.message });
+        setErrorMessage(t.auth.google.callbackError);
+        return;
+      }
+
+      logger.info('OAuth Google success — redirect /feed');
+      router.replace('/feed');
     } catch (err: unknown) {
       logger.error('Erreur inattendue OAuth Google', err);
       setErrorMessage(t.auth.errors.unknown);


### PR DESCRIPTION
## Summary

Fixe le bug où le flow Google OAuth restait coincé sur "Signing you in…" sur Android — Chrome refusait de suivre le redirect 302 de Supabase vers le custom scheme `doumassi://`, donc le deep link n'arrivait jamais dans l'app.

Switch vers **`expo-web-browser.openAuthSessionAsync`** qui ouvre Chrome Custom Tabs (Android) / ASWebAuthenticationSession (iOS) **in-app** et intercepte le redirect directement, sans dépendre de la couche deep link système.

## Changements

- ➕ `pnpm add expo-web-browser` (module natif)
- ✏️ `app.json` : plugin `expo-web-browser` ajouté automatiquement
- ✏️ [src/features/auth/hooks/useGoogleAuth.ts](src/features/auth/hooks/useGoogleAuth.ts) : refactor complet
  - `WebBrowser.openAuthSessionAsync(authUrl, redirectTo)` au lieu de `Linking.openURL`
  - Le hook gère désormais tout le round-trip (open browser → wait redirect → parse tokens → setSession → redirect /feed)
  - Plus besoin de Linking listeners ni de timeout fragile
- ✏️ [app/auth/callback.tsx](app/auth/callback.tsx) : devient un **filet de sécurité minimal**
  - En usage normal cette route n'est plus jamais atteinte (WebBrowser intercepte tout)
  - Garde une logique simple pour les cas edge (cold start avec deep link, plantage WebBrowser)

## ⚠️ Action requise pour toute l'équipe après merge

`expo-web-browser` est un module natif → **rebuild du Dev Build obligatoire** :

\`\`\`bash
pnpm build:dev:android
\`\`\`

Puis désinstaller l'ancien APK et installer le nouveau.

À mettre dans Slack `#dev` au moment du merge.

## Test plan

- [ ] Cold start → Welcome → "Continue with Google"
- [ ] Browser in-app s'ouvre (pas le navigateur système)
- [ ] Compte Google sélectionné, consentement → l'app reprend la main automatiquement
- [ ] Atterrit sur Feed (ou Onboarding pour un user Google avec username temporaire — voir #127)
- [ ] Fermer le browser sans valider → retour silencieux sur Welcome (pas d'erreur)
- [ ] Lint + typecheck verts ✅

## Closes

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)