### PR TITLE
chore(auth): hardening validation username (reserved names + temp pattern)

### DIFF
--- a/src/features/auth/schemas/completeAccountSchema.ts
+++ b/src/features/auth/schemas/completeAccountSchema.ts
@@ -6,12 +6,10 @@
 
 import { z } from 'zod';
 
+import { usernameSchema } from './usernameRules';
+
 export const completeAccountSchema = z.object({
-  username: z
-    .string()
-    .min(3, 'Username must be at least 3 characters')
-    .max(30, 'Username cannot exceed 30 characters')
-    .regex(/^[a-zA-Z0-9_]+$/, 'Username can only contain letters, numbers and underscores'),
+  username: usernameSchema,
 
   birthday: z
     .string()

--- a/src/features/auth/schemas/signupSchema.ts
+++ b/src/features/auth/schemas/signupSchema.ts
@@ -10,15 +10,13 @@
 
 import { z } from 'zod';
 
+import { usernameSchema } from './usernameRules';
+
 export const signupSchema = z
   .object({
     fullName: z.string().min(2, 'Full name must be at least 2 characters'),
 
-    username: z
-      .string()
-      .min(3, 'Username must be at least 3 characters')
-      .max(30, 'Username cannot exceed 30 characters')
-      .regex(/^[a-zA-Z0-9_]+$/, 'Username can only contain letters, numbers and underscores'),
+    username: usernameSchema,
 
     email: z.string().min(1, 'Email is required').email('Invalid email address'),
 

--- a/src/features/auth/schemas/usernameRules.ts
+++ b/src/features/auth/schemas/usernameRules.ts
@@ -1,0 +1,104 @@
+// Validation Zod partagée pour le champ `username`.
+// Utilisée par signupSchema et completeAccountSchema pour garder une seule
+// source de vérité sur les règles d'unicité, format et noms réservés.
+//
+// Règles :
+//   1. Longueur : 3 à 30 caractères
+//   2. Format : ^[a-zA-Z][a-zA-Z0-9_]*$ — commence par une lettre, puis lettres/chiffres/underscores
+//   3. Ne se termine pas par un underscore (cosmétique, plus propre)
+//   4. Ne matche pas le pattern temporaire `user_[0-9a-f]{8}` réservé par
+//      le trigger Supabase pour les users Google OAuth fresh (sinon le guard
+//      les renverrait en boucle vers /complete-account)
+//   5. N'est pas dans la liste des noms réservés (admin, support, etc.)
+//
+// La vérification d'unicité en BDD est faite séparément via la RPC
+// `is_username_available` (hook useUsernameAvailability).
+//
+// Pour defense-in-depth, la même blacklist devrait être appliquée côté
+// Supabase dans la RPC ou via un trigger. Voir prompt dans la PR.
+
+import { z } from 'zod';
+
+/** Pattern temporaire généré par le trigger Supabase pour les users Google. */
+export const TEMP_USERNAME_PATTERN = /^user_[0-9a-f]{8}$/;
+
+/**
+ * Noms réservés interdits (case-insensitive). Couvre :
+ * - Comptes système / admin
+ * - Termes susceptibles de phishing (`support_official` etc.)
+ * - Termes brand DOUMASSI
+ * - Valeurs techniques courantes (null, undefined, etc.)
+ *
+ * À étendre si besoin futur. Cette liste vit ici pour rester accessible
+ * côté client. La RPC Supabase doit avoir la même liste pour defense-in-depth.
+ */
+export const RESERVED_USERNAMES: ReadonlySet<string> = new Set([
+  // Système / admin
+  'admin',
+  'administrator',
+  'root',
+  'sudo',
+  'system',
+  'staff',
+  'moderator',
+  'mod',
+  // Support / help
+  'support',
+  'helpdesk',
+  'help',
+  'contact',
+  'feedback',
+  'abuse',
+  'report',
+  // API / technique
+  'api',
+  'app',
+  'www',
+  'mail',
+  'email',
+  'null',
+  'undefined',
+  'true',
+  'false',
+  'anonymous',
+  'deleted',
+  // Brand
+  'doumassi',
+  'doumassiapp',
+  'doumassi_app',
+  'doumassi_official',
+  'doumassi_team',
+  'official',
+  'team',
+  // Personnages publics / rôles
+  'ceo',
+  'founder',
+  'owner',
+  'me',
+  'you',
+  'user',
+  'users',
+  'guest',
+]);
+
+/**
+ * Schéma Zod partagé pour valider un username.
+ * Réutilisé par signupSchema et completeAccountSchema.
+ */
+export const usernameSchema = z
+  .string()
+  .min(3, 'Username must be at least 3 characters')
+  .max(30, 'Username cannot exceed 30 characters')
+  .regex(
+    /^[a-zA-Z][a-zA-Z0-9_]*$/,
+    'Username must start with a letter and contain only letters, numbers and underscores'
+  )
+  .refine((val) => !val.endsWith('_'), {
+    message: 'Username cannot end with an underscore',
+  })
+  .refine((val) => !TEMP_USERNAME_PATTERN.test(val), {
+    message: 'This username format is reserved',
+  })
+  .refine((val) => !RESERVED_USERNAMES.has(val.toLowerCase()), {
+    message: 'This username is reserved',
+  });


### PR DESCRIPTION
## Summary

Renforce la validation du champ `username` côté client (Zod) avec des règles communes au signup et au complete-account (Google OAuth).

## Pourquoi

Le projet acceptait n'importe quel `^[a-zA-Z0-9_]+$` de 3-30 chars. Plusieurs problèmes :

1. **Bug critique** : un user pouvait choisir `user_a3f9b2c1` (8 hex chars) → notre `useAuthGuard` détectait ça comme un username temporaire généré par le trigger Google OAuth → renvoyait l'user en boucle infinie sur `/complete-account`.
2. **Anti-phishing** : `support_official`, `admin`, `doumassi_team` étaient libres. Un user mal intentionné pouvait s'usurper.
3. **UX** : `123` ou `_abdou_` techniquement valides mais moches.

## Changements

### Nouveau module partagé
- ➕ [src/features/auth/schemas/usernameRules.ts](src/features/auth/schemas/usernameRules.ts)
  - `usernameSchema` Zod réutilisable
  - `RESERVED_USERNAMES` set (~30 noms : admin, support, doumassi, root, api, null...)
  - `TEMP_USERNAME_PATTERN` regex `^user_[0-9a-f]{8}$`

### Schemas mis à jour
- ✏️ [signupSchema.ts](src/features/auth/schemas/signupSchema.ts) → utilise `usernameSchema`
- ✏️ [completeAccountSchema.ts](src/features/auth/schemas/completeAccountSchema.ts) → utilise `usernameSchema`

### Règles appliquées
- 3-30 caractères (inchangé)
- ✅ Doit **commencer par une lettre** (avant : pouvait commencer par chiffre ou underscore)
- ✅ Lettres/chiffres/underscores uniquement (inchangé)
- ✅ Ne peut pas se terminer par underscore
- ✅ Pas le pattern `user_XXXXXXXX` (fix critique)
- ✅ Pas dans la liste des noms réservés (case-insensitive)

## Pré-requis Supabase recommandé (defense-in-depth)

Pour bloquer aussi au niveau BDD (et pas juste côté client), à coller dans l'IA Supabase :

```
Update the RPC `is_username_available(p_username text)` to also return FALSE
for these cases (in addition to the existing unicity check):

1. Username matches the temporary pattern reserved by the OAuth trigger:
   - Regex: `^user_[0-9a-f]{8}$`

2. Username is in the reserved names list (case-insensitive):
   admin, administrator, root, sudo, system, staff, moderator, mod,
   support, helpdesk, help, contact, feedback, abuse, report,
   api, app, www, mail, email, null, undefined, true, false,
   anonymous, deleted,
   doumassi, doumassiapp, doumassi_app, doumassi_official, doumassi_team,
   official, team, ceo, founder, owner, me, you, user, users, guest

3. Username does not match the format regex `^[a-zA-Z][a-zA-Z0-9_]*$`
   (must start with a letter)

4. Username ends with an underscore.

Keep the existing case-insensitive unicity check on top of these rules.
Apply as a new migration that REPLACES the existing function.
```

Ça évite qu'un attaquant qui contourne le client (curl direct sur l'API Supabase) puisse créer un compte avec un username interdit.

## Test plan

- [ ] Signup : try `admin` → erreur "This username is reserved"
- [ ] Signup : try `user_a3f9b2c1` → erreur "This username format is reserved"
- [ ] Signup : try `_abdou` → erreur "Username must start with a letter..."
- [ ] Signup : try `abdou_` → erreur "Username cannot end with an underscore"
- [ ] Signup : try `abdou123` → ✓ Available (si dispo)
- [ ] Complete-account (Google OAuth) : mêmes règles appliquées
- [ ] Lint + typecheck verts ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)