### PR TITLE
feat(profile): onglet Boutique sur l'écran profil (E3-VENDOR)

### DIFF
--- a/app/(feed)/profile/[id]/index.tsx
+++ b/app/(feed)/profile/[id]/index.tsx
@@ -20,14 +20,17 @@ import { Button, Sheet, Text, XStack, YStack } from 'tamagui';
 
 import { BlockConfirmModal } from '@/features/profile/components/BlockConfirmModal';
 import { FollowButton } from '@/features/profile/components/FollowButton';
+import { ListingCard } from '@/features/profile/components/ListingCard';
 import { ProfileEmptyState } from '@/features/profile/components/ProfileEmptyState';
 import { ProfileGridItem } from '@/features/profile/components/ProfileGridItem';
 import { ProfileHeader } from '@/features/profile/components/ProfileHeader';
 import { ProfileSkeleton } from '@/features/profile/components/ProfileSkeleton';
 import { ProfileStats } from '@/features/profile/components/ProfileStats';
 import { ProfileTabs, type ProfileTab } from '@/features/profile/components/ProfileTabs';
+import { ShopEmptyState } from '@/features/profile/components/ShopEmptyState';
 import { UnfollowConfirmModal } from '@/features/profile/components/UnfollowConfirmModal';
 import { useFollow } from '@/features/profile/hooks/useFollow';
+import { useListings, type ListingItem } from '@/features/profile/hooks/useListings';
 import { useUserProfile, type PostGridItem } from '@/features/profile/hooks/useProfile';
 import { logger } from '@/lib/logger';
 import { supabase } from '@/lib/supabase';
@@ -42,6 +45,7 @@ export default function OtherUserProfileScreen() {
 
   const { profile, counters, posts, isLoading, isError } = useUserProfile(targetUserId);
   const { status: followStatus, isPending, follow, unfollow } = useFollow(targetUserId);
+  const { data: listings } = useListings(targetUserId);
 
   const { width: screenWidth } = useWindowDimensions();
   const itemSize = (screenWidth - GRID_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS;
@@ -214,7 +218,19 @@ export default function OtherUserProfileScreen() {
     [itemSize]
   );
 
-  const keyExtractor = useCallback((item: PostGridItem) => item.id, []);
+  const renderListingItem = useCallback(
+    ({ item, index }: { item: ListingItem; index: number }) => (
+      <ListingCard
+        item={item}
+        size={itemSize}
+        gap={GRID_GAP}
+        isLastColumn={(index + 1) % NUM_COLUMNS === 0}
+      />
+    ),
+    [itemSize]
+  );
+
+  const keyExtractor = useCallback((item: { id: string }) => item.id, []);
 
   // --- Attente du check de blocage ---
   // --- Self-visit : redirige vers son propre profil ---
@@ -267,6 +283,7 @@ export default function OtherUserProfileScreen() {
   // --- Profil privé + non suivi (self already redirected above) ---
   const isPrivateAndNotFollowing = profile.is_private === true && followStatus !== 'following';
 
+  const isShopTab = activeTab === 'shop';
   const gridData = activeTab === 'grid' ? posts : [];
 
   const ListHeader = (
@@ -349,6 +366,17 @@ export default function OtherUserProfileScreen() {
           keyExtractor={keyExtractor}
           numColumns={NUM_COLUMNS}
           ListHeaderComponent={ListHeader}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.listContent}
+        />
+      ) : isShopTab ? (
+        <FlashList<ListingItem>
+          data={listings ?? []}
+          renderItem={renderListingItem}
+          keyExtractor={keyExtractor}
+          numColumns={NUM_COLUMNS}
+          ListHeaderComponent={ListHeader}
+          ListEmptyComponent={ShopEmptyState}
           showsVerticalScrollIndicator={false}
           contentContainerStyle={styles.listContent}
         />

--- a/src/features/profile/components/ListingCard.tsx
+++ b/src/features/profile/components/ListingCard.tsx
@@ -1,0 +1,104 @@
+// Carte produit (Listing) pour l'onglet Boutique — E3-VENDOR.
+// Affiche l'image principale en ratio 1:1 avec les overlays prix et action.
+
+import { Image } from 'expo-image';
+import { Store } from 'lucide-react-native';
+import { Alert, StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, YStack } from 'tamagui';
+
+import type { ListingItem } from '@/features/profile/hooks/useListings';
+
+interface ListingCardProps {
+  item: ListingItem;
+  size: number;
+  gap: number;
+  isLastColumn: boolean;
+}
+
+export function ListingCard({ item, size, gap, isLastColumn }: ListingCardProps) {
+  // Placeholder MVP : la page produit n'existe pas encore (vertical Marketplace
+  // au Sprint 5). On affiche un message d'attente plutôt que de naviguer.
+  const handleViewProduct = () => {
+    Alert.alert('Bientôt disponible', 'La page produit arrive prochainement.');
+  };
+
+  // Conversion cents -> unité principale
+  const price = item.price_cents / 100;
+  const formattedPrice = new Intl.NumberFormat('fr-FR', {
+    style: 'currency',
+    currency: item.currency || 'EUR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(price);
+
+  const mainImage = item.images && item.images.length > 0 ? item.images[0] : null;
+
+  return (
+    <YStack
+      width={size}
+      height={size}
+      marginRight={isLastColumn ? 0 : gap}
+      marginBottom={gap}
+      position="relative"
+    >
+      {/* Image 1:1 */}
+      {mainImage ? (
+        <Image
+          source={{ uri: mainImage }}
+          style={styles.image}
+          contentFit="cover"
+          transition={200}
+        />
+      ) : (
+        <YStack
+          flex={1}
+          backgroundColor="$surface"
+          alignItems="center"
+          justifyContent="center"
+          borderRadius={8}
+        >
+          <Store size={32} color="#A0A0A0" />
+        </YStack>
+      )}
+
+      {/* Overlay Prix — bas à droite */}
+      <YStack
+        position="absolute"
+        bottom={8}
+        right={8}
+        backgroundColor="rgba(0, 0, 0, 0.7)"
+        paddingHorizontal={8}
+        paddingVertical={4}
+        borderRadius={6}
+      >
+        <Text fontSize={13} fontWeight="700" color="#FFFFFF">
+          {formattedPrice}
+        </Text>
+      </YStack>
+
+      {/* Overlay Bouton — bas à gauche */}
+      <TouchableOpacity onPress={handleViewProduct} activeOpacity={0.8} style={styles.viewButton}>
+        <Text fontSize={11} fontWeight="600" color="#000000">
+          Voir le produit
+        </Text>
+      </TouchableOpacity>
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  image: {
+    width: '100%',
+    height: '100%',
+    borderRadius: 8,
+  },
+  viewButton: {
+    position: 'absolute',
+    bottom: 8,
+    left: 8,
+    backgroundColor: '#FFFFFF',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 6,
+  },
+});

--- a/src/features/profile/components/ProfileTabs.tsx
+++ b/src/features/profile/components/ProfileTabs.tsx
@@ -1,11 +1,12 @@
-// Segmented control des onglets profil : Grid / Reels / Tagged.
+// Segmented control des onglets profil : Grid / Reels / Tagged / Shop.
 // Identique entre Mon profil et Profil autre.
+// E3-VENDOR : ajout du 4e onglet "Boutique" (additif, non-breaking).
 
-import { Grid3x3, Play, UserSquare2 } from 'lucide-react-native';
+import { Grid3x3, Play, Store, UserSquare2 } from 'lucide-react-native';
 import { StyleSheet, TouchableOpacity } from 'react-native';
 import { XStack } from 'tamagui';
 
-export type ProfileTab = 'grid' | 'reels' | 'tagged';
+export type ProfileTab = 'grid' | 'reels' | 'tagged' | 'shop';
 
 interface ProfileTabsProps {
   active: ProfileTab;
@@ -49,6 +50,11 @@ export function ProfileTabs({ active, onChange }: ProfileTabsProps) {
         icon={<UserSquare2 size={22} color={active === 'tagged' ? '#FFFFFF' : '#A0A0A0'} />}
         isActive={active === 'tagged'}
         onPress={() => onChange('tagged')}
+      />
+      <TabButton
+        icon={<Store size={22} color={active === 'shop' ? '#FFFFFF' : '#A0A0A0'} />}
+        isActive={active === 'shop'}
+        onPress={() => onChange('shop')}
       />
     </XStack>
   );

--- a/src/features/profile/components/ShopEmptyState.tsx
+++ b/src/features/profile/components/ShopEmptyState.tsx
@@ -1,0 +1,26 @@
+// Empty state de l'onglet Boutique — E3-VENDOR.
+// Partagé entre Mon profil et Profil d'un autre utilisateur.
+
+import { Store } from 'lucide-react-native';
+import { Text, YStack } from 'tamagui';
+
+export function ShopEmptyState() {
+  return (
+    <YStack alignItems="center" justifyContent="center" paddingVertical={80} gap="$3">
+      <YStack
+        width={72}
+        height={72}
+        borderRadius={36}
+        borderWidth={2}
+        borderColor="$borderColorHover"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Store size={32} color="#A0A0A0" />
+      </YStack>
+      <Text fontSize={15} color="$textSecondary" textAlign="center" fontWeight="500">
+        Aucun produit en vente
+      </Text>
+    </YStack>
+  );
+}

--- a/src/features/profile/hooks/useListings.ts
+++ b/src/features/profile/hooks/useListings.ts
@@ -1,0 +1,46 @@
+// Hook de données des annonces (listings) — E3-VENDOR.
+// Récupère les articles en vente d'un utilisateur depuis la table `listings`.
+
+import { useQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export interface ListingItem {
+  id: string;
+  seller_id: string;
+  title: string;
+  description: string | null;
+  price_cents: number;
+  currency: string;
+  images: string[];
+  is_active: boolean;
+  badge: string | null;
+  discount_percent: number | null;
+}
+
+async function fetchListingsByUserId(userId: string): Promise<ListingItem[]> {
+  const { data, error } = await supabase
+    .from('listings')
+    .select(
+      'id, seller_id, title, description, price_cents, currency, images, is_active, badge, discount_percent'
+    )
+    .eq('seller_id', userId)
+    .eq('is_active', true)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    logger.warn('Erreur fetch listings', { userId, message: error.message });
+    throw error;
+  }
+
+  return (data ?? []) as ListingItem[];
+}
+
+export function useListings(userId: string | null) {
+  return useQuery({
+    queryKey: ['profile', 'listings', userId],
+    queryFn: () => fetchListingsByUserId(userId as string),
+    enabled: userId !== null,
+  });
+}

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -1,7 +1,8 @@
-// Écran "Mon profil" — E3-01 (v2).
+// Écran "Mon profil" — E3-01 (v2) + E3-VENDOR.
 // Composition de composants partagés (ProfileHeader, ProfileStats, ProfileTabs,
 // ProfileGridItem) + boutons d'action "Modifier" / "Partager" + kebab menu
-// avec Settings / Share. Fidèle à la maquette Canva, dark mode exclusif.
+// avec Settings / Share. 4 onglets : Grille / Reels / Identifié / Boutique.
+// Fidèle à la maquette Canva, dark mode exclusif.
 
 import { FlashList } from '@shopify/flash-list';
 import { router } from 'expo-router';
@@ -10,12 +11,15 @@ import { useCallback, useState } from 'react';
 import { Share, StyleSheet, useWindowDimensions } from 'react-native';
 import { Button, Sheet, Text, XStack, YStack } from 'tamagui';
 
+import { ListingCard } from '@/features/profile/components/ListingCard';
 import { ProfileEmptyState } from '@/features/profile/components/ProfileEmptyState';
 import { ProfileGridItem } from '@/features/profile/components/ProfileGridItem';
 import { ProfileHeader } from '@/features/profile/components/ProfileHeader';
 import { ProfileSkeleton } from '@/features/profile/components/ProfileSkeleton';
 import { ProfileStats } from '@/features/profile/components/ProfileStats';
 import { ProfileTabs, type ProfileTab } from '@/features/profile/components/ProfileTabs';
+import { ShopEmptyState } from '@/features/profile/components/ShopEmptyState';
+import { useListings, type ListingItem } from '@/features/profile/hooks/useListings';
 import { useProfile, type PostGridItem } from '@/features/profile/hooks/useProfile';
 import { t } from '@/i18n';
 
@@ -24,6 +28,7 @@ const NUM_COLUMNS = 3;
 
 export function ProfileScreen() {
   const { profile, userId, counters, posts, isLoading, refetch } = useProfile();
+  const { data: listings } = useListings(userId);
   const { width: screenWidth } = useWindowDimensions();
   const copy = t.profile;
 
@@ -76,13 +81,26 @@ export function ProfileScreen() {
     [itemSize]
   );
 
-  const keyExtractor = useCallback((item: PostGridItem) => item.id, []);
+  const renderListingItem = useCallback(
+    ({ item, index }: { item: ListingItem; index: number }) => (
+      <ListingCard
+        item={item}
+        size={itemSize}
+        gap={GRID_GAP}
+        isLastColumn={(index + 1) % NUM_COLUMNS === 0}
+      />
+    ),
+    [itemSize]
+  );
+
+  const keyExtractor = useCallback((item: { id: string }) => item.id, []);
 
   if (isLoading) {
     return <ProfileSkeleton />;
   }
 
-  // Seul l'onglet "grid" affiche du contenu pour l'instant.
+  const isShopTab = activeTab === 'shop';
+  // Seuls les onglets "grid" et "shop" affichent du contenu pour l'instant.
   const gridData = activeTab === 'grid' ? posts : [];
 
   const ListHeader = (
@@ -136,18 +154,33 @@ export function ProfileScreen() {
 
   return (
     <>
-      <FlashList<PostGridItem>
-        data={gridData}
-        renderItem={renderGridItem}
-        keyExtractor={keyExtractor}
-        numColumns={NUM_COLUMNS}
-        ListHeaderComponent={ListHeader}
-        ListEmptyComponent={ProfileEmptyState}
-        showsVerticalScrollIndicator={false}
-        onRefresh={refetch}
-        refreshing={false}
-        contentContainerStyle={styles.listContent}
-      />
+      {isShopTab ? (
+        <FlashList<ListingItem>
+          data={listings ?? []}
+          renderItem={renderListingItem}
+          keyExtractor={keyExtractor}
+          numColumns={NUM_COLUMNS}
+          ListHeaderComponent={ListHeader}
+          ListEmptyComponent={ShopEmptyState}
+          showsVerticalScrollIndicator={false}
+          onRefresh={refetch}
+          refreshing={false}
+          contentContainerStyle={styles.listContent}
+        />
+      ) : (
+        <FlashList<PostGridItem>
+          data={gridData}
+          renderItem={renderGridItem}
+          keyExtractor={keyExtractor}
+          numColumns={NUM_COLUMNS}
+          ListHeaderComponent={ListHeader}
+          ListEmptyComponent={ProfileEmptyState}
+          showsVerticalScrollIndicator={false}
+          onRefresh={refetch}
+          refreshing={false}
+          contentContainerStyle={styles.listContent}
+        />
+      )}
 
       <Sheet
         modal


### PR DESCRIPTION
## Summary

Ajout du **4e onglet "Boutique"** sur l'écran profil — **additif**, sans toucher aux 3 onglets existants (Grille / Reels / Identifié).

Réécriture propre du ticket #143. La 1ère tentative (PR #144) faisait un breaking change en **remplaçant** l'onglet "Identifié" — or le CEO voulait juste un 4e onglet **à côté** des autres. Cette PR remplace #144.

## Changements

- **ProfileTabs** : `ProfileTab` étendu à `'shop'`, 4e `TabButton` (icône `Store`). Aucune modif des 3 onglets existants.
- **ProfileScreen** + **profile/[id]/index.tsx** : grille de produits affichée quand `activeTab === 'shop'`, via une `FlashList` dédiée.
- **useListings** + **ListingCard** : récupérés de la PR #144 (le vrai travail réutilisable d'Ilias).
- **ListingCard** : `console.warn` → `Alert.alert('Bientôt disponible')` (CLAUDE.md règle 6).
- **ShopEmptyState** : composant partagé extrait.

## Hors scope (assumé)

- Le bouton "Voir le produit" est un **placeholder** — pas de page produit en MVP (vertical Marketplace prévu Sprint 5).
- Pas de gestion vendeur, panier, paiement.

## Test plan

- [ ] Profil perso : 4 onglets visibles, "Identifié" toujours là
- [ ] Tap onglet Boutique → grille de produits OU empty state "Aucun produit en vente"
- [ ] Profil d'un autre user : même comportement
- [ ] Profil privé non suivi : l'onglet Boutique reste masqué (cohérent avec les autres onglets)
- [ ] Tap "Voir le produit" → Alert "Bientôt disponible"
- [ ] Prix formaté correctement (cents → EUR)

## ⚠️ Pré-requis BDD

Le hook `useListings` query la table `listings` (déployée Sprint 0). Colonnes attendues : `id, seller_id, title, description, price_cents, currency, images, is_active, badge, discount_percent`. **À valider au runtime** — je n'ai pas pu vérifier le schéma exact (MCP Supabase sans accès).

Closes #143. Remplace #144 (à fermer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)