### PR TITLE
chore(db): committer le rattrapage profiles.is_verified (staging sync)

### DIFF
--- a/supabase/migrations/20260515142500_profiles_add_is_verified.sql
+++ b/supabase/migrations/20260515142500_profiles_add_is_verified.sql
@@ -1,0 +1,19 @@
+-- Rattrapage : aligner staging sur dev — colonne profiles.is_verified
+--
+-- Contexte : dev avait depuis longtemps la colonne `is_verified` sur
+-- profiles (utilisée par l'écran profil pour le badge bleu). Staging
+-- avait divergé — la colonne y était absente.
+--
+-- Détecté lors de l'application de la migration get_my_blocked_users
+-- (E3-10), dont la fonction sélectionne `is_verified` et plantait sur
+-- staging.
+--
+-- Cette migration applique (idempotente via `if not exists`) la colonne
+-- manquante. Sur dev elle est no-op puisque déjà présente.
+--
+-- Note : à terme, la source de vérité doit redevenir le repo via
+-- `supabase db push` plutôt que les applications hors-bande. Ce
+-- rattrapage est une dette acceptée.
+
+alter table public.profiles
+  add column if not exists is_verified boolean not null default false;


### PR DESCRIPTION
## Contexte

Lors de l'application de la migration `get_my_blocked_users` pour E3-10, AI Supabase a constaté que **staging avait divergé de dev** : la colonne `profiles.is_verified` y était absente.

Dev l'avait depuis longtemps (utilisée par l'écran profil pour le badge bleu) mais elle n'avait jamais été appliquée à staging par une migration "officielle". La nouvelle RPC `get_my_blocked_users` qui sélectionne `is_verified` plantait donc sur staging.

AI Supabase a appliqué le rattrapage sur staging dans la même session. Cette PR commit le fichier correspondant pour la cohérence repo ↔ BDD (pas de migration fantôme).

## Contenu

- 1 fichier : `supabase/migrations/20260515142500_profiles_add_is_verified.sql`
- Migration **idempotente** (`add column if not exists`)
- No-op sur dev (colonne déjà présente)

## À noter (dette technique)

Cet incident révèle qu'on a accumulé des migrations appliquées hors-bande qui ne sont pas dans le repo. À terme, on devrait retomber sur un workflow `supabase db push` strict pour que le repo soit la source de vérité. Pas urgent mais à tracker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)