### PR TITLE
fix(profile): bouton Save désactivé sur édition profil (E3-02)

### DIFF
--- a/app/(feed)/profile/edit.tsx
+++ b/app/(feed)/profile/edit.tsx
@@ -129,6 +129,11 @@ export default function EditProfileScreen() {
       bio: profile.bio ?? '',
       isProfessional: Boolean(profile.is_professional),
     });
+    // Force la validation immédiate du form pour que `formState.isValid` soit
+    // correct dès le mount (avec mode 'onChange' RHF ne valide qu'au premier
+    // touch d'un champ, ce qui désactive le bouton Save même si l'user modifie
+    // un autre champ qu'username).
+    void form.trigger();
   }, [form, profile]);
 
   const values = form.watch();


### PR DESCRIPTION
## Bug rapporté

> Dans les paramètres, quand on appuie sur "Modifier son profil", les changements dans les champs ne sont pas pris en compte. Le bouton Save ne devient cliquable que lorsque je modifie le username, ce qui n'est pas le comportement attendu. Toute modification du profil devrait activer le bouton Save.

## Diagnostic

Le bouton Save dépend de `form.formState.isValid` (cf. ligne 160 de [app/(feed)/profile/edit.tsx](app/(feed)/profile/edit.tsx)). Avec `mode: 'onChange'` de React Hook Form, `isValid` n'est calculé qu'**au premier touch d'un champ**. Au mount, il reste à `false` même si toutes les valeurs du profil chargé sont valides — d'où le bouton désactivé.

Quand l'user modifie le username (qui passe par un Controller RHF), ça déclenche la validation et `isValid` bascule à true. Idem pour fullName/bio/isProfessional en théorie — sauf que si l'user a profile.full_name = null en BDD, le champ est rempli avec `''` qui viole le `min(2)` du schema → la validation échoue silencieusement.

## Fix

Forcer `form.trigger()` juste après `form.reset()` dans le `useEffect` qui synchronise le form avec le profil chargé. La validation complète tourne immédiatement, `isValid` est correct dès le départ, et toute modification d'un champ valide active Save.

Si l'user a un profil avec `full_name = null` en BDD, l'erreur "Full name must be at least 2 characters" s'affichera immédiatement sous le champ — c'est conforme à la spec (le full_name est requis).

## Test plan

- [ ] Ouvrir un profil complet (full_name, bio, etc.) → modifier la bio → Save s'active
- [ ] Modifier le toggle isProfessional → Save s'active
- [ ] Changer l'avatar → Save s'active
- [ ] Changer la cover → Save s'active
- [ ] Ouvrir un profil avec full_name vide en BDD → erreur visible sous le champ + Save désactivé jusqu'à correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)