### PR TITLE
feat(auth): supprimer mon compte depuis les paramètres (E3-12)

### DIFF
--- a/app/(feed)/settings.tsx
+++ b/app/(feed)/settings.tsx
@@ -430,7 +430,7 @@ export default function SettingsScreen() {
               icon={Trash2}
               label="Supprimer mon compte"
               destructive
-              onPress={soonAlert}
+              onPress={() => router.push('/(feed)/settings/delete-account')}
               isLast
             />
           </Section>

--- a/app/(feed)/settings/delete-account.tsx
+++ b/app/(feed)/settings/delete-account.tsx
@@ -1,0 +1,412 @@
+// Écran "Supprimer mon compte" — E3-12.
+// Conformité RGPD : pas de hard delete immédiat, on enregistre une
+// demande dans `deletion_requests` avec un délai de 30 jours pour
+// annulation. Le hard delete sera traité par un job background
+// (ticket post-MVP).
+
+import { router } from 'expo-router';
+import { AlertTriangle, ArrowLeft, ShieldOff } from 'lucide-react-native';
+import { useCallback, useState } from 'react';
+import { Alert, KeyboardAvoidingView, Platform, StyleSheet, TouchableOpacity } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import {
+  Button,
+  Input,
+  ScrollView,
+  Sheet,
+  Spinner,
+  Text,
+  TextArea,
+  View,
+  XStack,
+  YStack,
+} from 'tamagui';
+
+import {
+  type DeletionRequestRow,
+  useCancelDeletion,
+  useDeletionRequest,
+  useRequestDeletion,
+} from '@/features/auth/hooks/useDeletionRequest';
+import { useLogout } from '@/features/auth/hooks/useLogout';
+import { logger } from '@/lib/logger';
+
+const CONFIRM_KEYWORD = 'SUPPRIMER';
+
+function formatDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString('fr-FR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+// ─── Écran "demande déjà en cours" ────────────────────────────────────────
+function PendingDeletionView({ request }: { request: DeletionRequestRow }) {
+  const cancelDeletion = useCancelDeletion();
+  const scheduledDate = formatDate(request.scheduled_delete_at);
+
+  const handleCancel = useCallback(async () => {
+    try {
+      await cancelDeletion.mutateAsync();
+      Alert.alert(
+        'Demande annulée',
+        'Votre demande de suppression a été annulée. Votre compte reste actif.'
+      );
+    } catch (err) {
+      logger.warn('Cancel deletion failed', { message: (err as Error).message });
+      Alert.alert(
+        'Erreur',
+        "L'annulation a échoué. Réessayez dans un instant ou contactez le support."
+      );
+    }
+  }, [cancelDeletion]);
+
+  return (
+    <YStack gap="$4" paddingTop="$3">
+      <YStack
+        backgroundColor="$surface"
+        borderRadius="$lg"
+        padding="$4"
+        gap="$3"
+        borderWidth={1}
+        borderColor="$danger"
+      >
+        <XStack gap="$3" alignItems="center">
+          <AlertTriangle size={24} color="#FF3B30" />
+          <Text color="$danger" fontSize={16} fontWeight="700">
+            Suppression programmée
+          </Text>
+        </XStack>
+        <Text color="$color" fontSize={15} lineHeight={22}>
+          Votre compte sera définitivement supprimé le <Text fontWeight="700">{scheduledDate}</Text>
+          .
+        </Text>
+        <Text color="$textSecondary" fontSize={13} lineHeight={20}>
+          Vous pouvez annuler cette demande à tout moment avant cette date en revenant ici. Une fois
+          la date passée, la suppression est définitive et irréversible.
+        </Text>
+      </YStack>
+
+      {request.reason ? (
+        <YStack backgroundColor="$surface" borderRadius="$lg" padding="$4" gap="$2">
+          <Text color="$textSecondary" fontSize={12} fontWeight="700" textTransform="uppercase">
+            Raison transmise
+          </Text>
+          <Text color="$color" fontSize={14} lineHeight={20}>
+            {request.reason}
+          </Text>
+        </YStack>
+      ) : null}
+
+      <Button
+        onPress={() => void handleCancel()}
+        disabled={cancelDeletion.isPending}
+        backgroundColor="$accentNeon"
+        color="#000000"
+        borderRadius="$lg"
+        height={50}
+        fontWeight="800"
+        fontSize={15}
+        pressStyle={{ opacity: 0.85, scale: 0.98 }}
+      >
+        {cancelDeletion.isPending ? (
+          <Spinner color="#000000" />
+        ) : (
+          'Annuler la demande de suppression'
+        )}
+      </Button>
+    </YStack>
+  );
+}
+
+// ─── Écran "demander la suppression" ──────────────────────────────────────
+function RequestDeletionView() {
+  const requestDeletion = useRequestDeletion();
+  const { logout } = useLogout();
+  const [reason, setReason] = useState('');
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmInput, setConfirmInput] = useState('');
+
+  const canConfirm = confirmInput.trim().toUpperCase() === CONFIRM_KEYWORD;
+
+  const handleConfirm = useCallback(async () => {
+    try {
+      await requestDeletion.mutateAsync(reason.trim() || null);
+      setConfirmOpen(false);
+      // Logout + redirect — le guard renvoie vers /welcome.
+      await logout();
+      // Le message info à l'user (date de suppression effective).
+      Alert.alert(
+        'Demande enregistrée',
+        'Votre compte sera supprimé dans 30 jours. Reconnectez-vous avant cette date pour annuler.'
+      );
+    } catch (err) {
+      logger.warn('Request deletion failed', { message: (err as Error).message });
+      Alert.alert('Erreur', "La demande n'a pas pu être enregistrée. Réessayez dans un instant.");
+    }
+  }, [requestDeletion, reason, logout]);
+
+  return (
+    <YStack gap="$4" paddingTop="$3">
+      {/* Warning banner */}
+      <YStack
+        backgroundColor="$surface"
+        borderRadius="$lg"
+        padding="$4"
+        gap="$2"
+        borderWidth={1}
+        borderColor="$danger"
+      >
+        <XStack gap="$3" alignItems="center">
+          <AlertTriangle size={22} color="#FF3B30" />
+          <Text color="$danger" fontSize={15} fontWeight="700">
+            Action irréversible
+          </Text>
+        </XStack>
+        <Text color="$color" fontSize={14} lineHeight={20}>
+          Toutes vos données seront supprimées 30 jours après votre demande. Vous pouvez annuler à
+          tout moment avant cette échéance.
+        </Text>
+      </YStack>
+
+      {/* Liste de ce qui sera supprimé */}
+      <YStack backgroundColor="$surface" borderRadius="$lg" padding="$4" gap="$3">
+        <Text color="$textSecondary" fontSize={12} fontWeight="700" textTransform="uppercase">
+          Ce qui sera supprimé
+        </Text>
+        <YStack gap="$2">
+          {[
+            'Votre profil (photo, bio, username)',
+            'Vos publications et commentaires',
+            'Vos messages privés',
+            'Vos abonnés et abonnements',
+            'Votre historique de connexion',
+          ].map((item) => (
+            <XStack key={item} gap="$2" alignItems="flex-start">
+              <Text color="$textSecondary" fontSize={14}>
+                •
+              </Text>
+              <Text color="$color" fontSize={14} flex={1} lineHeight={20}>
+                {item}
+              </Text>
+            </XStack>
+          ))}
+        </YStack>
+      </YStack>
+
+      {/* Raison (optionnelle) */}
+      <YStack gap="$2">
+        <Text color="$textSecondary" fontSize={13} fontWeight="700">
+          Pourquoi nous quittez-vous ? (optionnel)
+        </Text>
+        <TextArea
+          value={reason}
+          onChangeText={(text) => setReason(text.slice(0, 500))}
+          placeholder="Votre retour nous aide à améliorer DOUMASSI…"
+          placeholderTextColor="$placeholderColor"
+          minHeight={90}
+          maxLength={500}
+          backgroundColor="$surface"
+          borderColor="$borderColor"
+          borderWidth={1}
+          borderRadius="$lg"
+          color="$color"
+          fontSize={14}
+          padding="$3"
+        />
+        <Text color="$placeholderColor" fontSize={11} textAlign="right">
+          {reason.length}/500
+        </Text>
+      </YStack>
+
+      <Button
+        onPress={() => setConfirmOpen(true)}
+        backgroundColor="$danger"
+        color="#FFFFFF"
+        borderRadius="$lg"
+        height={50}
+        fontWeight="800"
+        fontSize={15}
+        pressStyle={{ opacity: 0.85, scale: 0.98 }}
+      >
+        Demander la suppression de mon compte
+      </Button>
+
+      {/* Modal de confirmation à 2 étapes */}
+      <Sheet
+        modal
+        open={confirmOpen}
+        onOpenChange={(open: boolean) => {
+          setConfirmOpen(open);
+          if (!open) setConfirmInput('');
+        }}
+        snapPoints={[50]}
+        dismissOnSnapToBottom
+      >
+        <Sheet.Overlay backgroundColor="rgba(0,0,0,0.72)" />
+        <Sheet.Frame
+          backgroundColor="$surface"
+          borderTopLeftRadius="$lg"
+          borderTopRightRadius="$lg"
+          padding="$5"
+          gap="$4"
+        >
+          <Sheet.Handle backgroundColor="$borderColor" />
+
+          <YStack alignItems="center" gap="$2">
+            <ShieldOff size={36} color="#FF3B30" />
+            <Text color="$color" fontSize={18} fontWeight="800" textAlign="center">
+              Êtes-vous sûr ?
+            </Text>
+          </YStack>
+
+          <Text color="$textSecondary" fontSize={14} textAlign="center" lineHeight={20}>
+            Tapez{' '}
+            <Text color="$danger" fontWeight="700">
+              {CONFIRM_KEYWORD}
+            </Text>{' '}
+            pour confirmer la suppression de votre compte.
+          </Text>
+
+          <Input
+            value={confirmInput}
+            onChangeText={setConfirmInput}
+            placeholder={CONFIRM_KEYWORD}
+            placeholderTextColor="$placeholderColor"
+            autoCapitalize="characters"
+            autoCorrect={false}
+            backgroundColor="$background"
+            borderColor={canConfirm ? '$danger' : '$borderColor'}
+            borderWidth={1}
+            borderRadius="$lg"
+            color="$color"
+            fontSize={16}
+            fontWeight="700"
+            textAlign="center"
+            height={48}
+          />
+
+          <XStack gap="$3">
+            <Button
+              flex={1}
+              onPress={() => {
+                setConfirmOpen(false);
+                setConfirmInput('');
+              }}
+              backgroundColor="transparent"
+              borderColor="$borderColor"
+              borderWidth={1}
+              color="$color"
+              borderRadius="$lg"
+              height={48}
+              fontWeight="600"
+              fontSize={14}
+              pressStyle={{ opacity: 0.7 }}
+            >
+              Annuler
+            </Button>
+            <Button
+              flex={1}
+              onPress={() => void handleConfirm()}
+              disabled={!canConfirm || requestDeletion.isPending}
+              backgroundColor="$danger"
+              color="#FFFFFF"
+              borderRadius="$lg"
+              height={48}
+              fontWeight="800"
+              fontSize={14}
+              opacity={!canConfirm || requestDeletion.isPending ? 0.45 : 1}
+              pressStyle={{ opacity: 0.85, scale: 0.98 }}
+            >
+              {requestDeletion.isPending ? <Spinner color="#FFFFFF" /> : 'Confirmer la suppression'}
+            </Button>
+          </XStack>
+        </Sheet.Frame>
+      </Sheet>
+    </YStack>
+  );
+}
+
+// ─── Écran principal ───────────────────────────────────────────────────────
+export default function DeleteAccountScreen() {
+  const insets = useSafeAreaInsets();
+  const deletionRequestQuery = useDeletionRequest();
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace('/settings');
+    }
+  }, []);
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.screen}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+    >
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+        {/* Header */}
+        <XStack
+          height={56}
+          paddingHorizontal="$4"
+          alignItems="center"
+          borderBottomWidth={StyleSheet.hairlineWidth}
+          borderBottomColor="$borderColor"
+        >
+          <TouchableOpacity
+            onPress={handleBack}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          >
+            <ArrowLeft size={24} color="#FFFFFF" />
+          </TouchableOpacity>
+          <Text
+            flex={1}
+            marginLeft="$3"
+            color="$danger"
+            fontSize={18}
+            fontWeight="700"
+            fontFamily="$heading"
+          >
+            Supprimer mon compte
+          </Text>
+          <View width={24} />
+        </XStack>
+
+        <ScrollView
+          flex={1}
+          backgroundColor="$background"
+          contentContainerStyle={styles.content}
+          keyboardShouldPersistTaps="handled"
+        >
+          <YStack width="100%" maxWidth={430} alignSelf="center">
+            {deletionRequestQuery.isLoading ? (
+              <YStack paddingVertical={80} alignItems="center">
+                <Spinner size="large" color="$color" />
+              </YStack>
+            ) : deletionRequestQuery.data ? (
+              <PendingDeletionView request={deletionRequestQuery.data} />
+            ) : (
+              <RequestDeletionView />
+            )}
+          </YStack>
+        </ScrollView>
+      </YStack>
+    </KeyboardAvoidingView>
+  );
+}
+
+const styles = StyleSheet.create({
+  screen: {
+    flex: 1,
+    backgroundColor: '#000000',
+  },
+  content: {
+    flexGrow: 1,
+    paddingHorizontal: 20,
+    paddingBottom: 48,
+  },
+});

--- a/src/features/auth/hooks/useDeletionRequest.ts
+++ b/src/features/auth/hooks/useDeletionRequest.ts
@@ -1,0 +1,111 @@
+// Hook gestion de la demande de suppression de compte — E3-12.
+// - useDeletionRequest() : lit la demande en cours (si elle existe)
+// - requestDeletion(reason) : INSERT dans deletion_requests
+// - cancelDeletion() : UPDATE cancelled_at = now()
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export const deletionRequestQueryKey = ['account', 'deletion-request'] as const;
+
+export interface DeletionRequestRow {
+  user_id: string;
+  requested_at: string;
+  reason: string | null;
+  scheduled_delete_at: string;
+  cancelled_at: string | null;
+}
+
+async function getCurrentUserId(): Promise<string | null> {
+  const { data, error } = await supabase.auth.getSession();
+  if (error) throw error;
+  return data.session?.user?.id ?? null;
+}
+
+/**
+ * Récupère la demande de suppression active (cancelled_at IS NULL) pour
+ * l'user courant, si elle existe.
+ */
+export function useDeletionRequest() {
+  return useQuery({
+    queryKey: deletionRequestQueryKey,
+    queryFn: async (): Promise<DeletionRequestRow | null> => {
+      const userId = await getCurrentUserId();
+      if (!userId) return null;
+
+      const { data, error } = await supabase
+        .from('deletion_requests')
+        .select('user_id, requested_at, reason, scheduled_delete_at, cancelled_at')
+        .eq('user_id', userId)
+        .is('cancelled_at', null)
+        .maybeSingle();
+
+      if (error) {
+        logger.warn('Deletion request query failed', { message: error.message });
+        throw error;
+      }
+
+      return (data as DeletionRequestRow | null) ?? null;
+    },
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * Mutation : crée une demande de suppression du compte courant.
+ * `reason` est optionnel (commentaire libre de l'user pour analyse interne).
+ */
+export function useRequestDeletion() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (reason: string | null) => {
+      const userId = await getCurrentUserId();
+      if (!userId) throw new Error('No authenticated user');
+
+      const { error } = await supabase
+        .from('deletion_requests')
+        .insert({ user_id: userId, reason });
+
+      if (error) throw error;
+
+      logger.info('Account deletion requested', {
+        userId,
+        hasReason: Boolean(reason && reason.trim()),
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: deletionRequestQueryKey });
+    },
+  });
+}
+
+/**
+ * Mutation : annule la demande de suppression active de l'user courant
+ * (UPDATE cancelled_at = now()).
+ */
+export function useCancelDeletion() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const userId = await getCurrentUserId();
+      if (!userId) throw new Error('No authenticated user');
+
+      const { error } = await supabase
+        .from('deletion_requests')
+        .update({ cancelled_at: new Date().toISOString() })
+        .eq('user_id', userId)
+        .is('cancelled_at', null);
+
+      if (error) throw error;
+
+      logger.info('Account deletion cancelled', { userId });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: deletionRequestQueryKey });
+    },
+  });
+}

--- a/supabase/migrations/20260516120000_create_deletion_requests.sql
+++ b/supabase/migrations/20260516120000_create_deletion_requests.sql
@@ -1,0 +1,36 @@
+-- Migration E3-12 — Demandes de suppression de compte (RGPD)
+--
+-- Pattern recommandé par la CNIL : ne pas hard-delete immédiatement.
+-- L'user demande la suppression → row dans deletion_requests avec
+-- scheduled_delete_at = now() + 30 jours. Pendant ces 30 jours, l'user
+-- peut annuler en se reconnectant. Passé ce délai, un job background
+-- purgera les comptes effectivement (ticket dédié post-MVP).
+
+create table if not exists public.deletion_requests (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  requested_at timestamptz not null default now(),
+  reason text,
+  scheduled_delete_at timestamptz not null default (now() + interval '30 days'),
+  cancelled_at timestamptz
+);
+
+-- Index pour le job background (sélection des demandes à exécuter).
+create index if not exists deletion_requests_scheduled_idx
+  on public.deletion_requests (scheduled_delete_at)
+  where cancelled_at is null;
+
+alter table public.deletion_requests enable row level security;
+
+-- L'user peut lire/créer/annuler sa propre demande, jamais celle des autres.
+create policy "users can see their own deletion request"
+  on public.deletion_requests for select
+  using (auth.uid() = user_id);
+
+create policy "users can request their own deletion"
+  on public.deletion_requests for insert
+  with check (auth.uid() = user_id);
+
+create policy "users can cancel their own deletion"
+  on public.deletion_requests for update
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary

Conformité RGPD obligatoire pour la bêta sur stores. Permet à l'user de demander la suppression de son compte depuis Settings → Compte → Supprimer mon compte. **Pas de hard delete immédiat** : on enregistre la demande dans une table dédiée avec un délai de 30 jours pour annulation (pattern CNIL).

## Contenu

- **Migration** : table `deletion_requests` (user_id PK, scheduled_delete_at, cancelled_at) + RLS deny-by-default
- **Hook** `useDeletionRequest` + `useRequestDeletion` + `useCancelDeletion`
- **Écran** `app/(feed)/settings/delete-account.tsx` :
  - État 1 (demander) : warning, liste de ce qui sera supprimé, textarea raison (optionnelle, 500 chars max), confirmation 2 étapes via Sheet (taper SUPPRIMER). Après succès → logout + redirect.
  - État 2 (demande en cours) : affiche la date prévue, raison transmise si fournie, bouton "Annuler la demande"
- **Settings.tsx** : placeholder remplacé par `router.push('/(feed)/settings/delete-account')`

## ⚠️ Migration à appliquer en BDD avant merge

MCP Supabase refuse l'accès direct depuis cette session. Le SQL à coller dans AI Supabase :

```sql
create table if not exists public.deletion_requests (
  user_id uuid primary key references auth.users(id) on delete cascade,
  requested_at timestamptz not null default now(),
  reason text,
  scheduled_delete_at timestamptz not null default (now() + interval '30 days'),
  cancelled_at timestamptz
);

create index if not exists deletion_requests_scheduled_idx
  on public.deletion_requests (scheduled_delete_at)
  where cancelled_at is null;

alter table public.deletion_requests enable row level security;

create policy "users can see their own deletion request"
  on public.deletion_requests for select
  using (auth.uid() = user_id);

create policy "users can request their own deletion"
  on public.deletion_requests for insert
  with check (auth.uid() = user_id);

create policy "users can cancel their own deletion"
  on public.deletion_requests for update
  using (auth.uid() = user_id)
  with check (auth.uid() = user_id);
```

Étapes :
1. Apply sur **dev** (`kbysmkhalnolbsojzahf`)
2. Apply sur **staging** (`sdapojfdwduhuyduymxk`)
3. Run `get_advisors` (security) — pas de nouveau warning attendu

## Hors scope

- **Hard delete effectif** (job background qui purge les `deletion_requests` avec `scheduled_delete_at < now()`) → ticket dédié post-MVP
- **Email de confirmation** à l'user → quand on aura le système d'emails transactionnels

## Test plan

- [ ] Migration appliquée dev + staging + advisors clean
- [ ] Tap "Supprimer mon compte" depuis Settings → ouvre l'écran
- [ ] Sans raison → confirmation modal → tape "supprimer" en minuscules → bouton actif (case-insensitive via `.toUpperCase()`)
- [ ] Tape "DELETE" ou autre → bouton reste disabled
- [ ] Confirme → row INSERT + logout + alert info date
- [ ] Se reconnecter → revenir sur la page → affiche "Suppression programmée le [date]" + raison
- [ ] Tap "Annuler la demande" → UPDATE cancelled_at → revient à l'état 1
- [ ] RLS : un user ne peut pas lire la demande d'un autre (test avec 2 sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)