### PR TITLE
fix(profile): activer Save dès qu'une modif est détectée (E3-02, finalize)

### DIFF
--- a/app/(feed)/profile/edit.tsx
+++ b/app/(feed)/profile/edit.tsx
@@ -129,11 +129,6 @@ export default function EditProfileScreen() {
       bio: profile.bio ?? '',
       isProfessional: Boolean(profile.is_professional),
     });
-    // Force la validation immédiate du form pour que `formState.isValid` soit
-    // correct dès le mount (avec mode 'onChange' RHF ne valide qu'au premier
-    // touch d'un champ, ce qui désactive le bouton Save même si l'user modifie
-    // un autre champ qu'username).
-    void form.trigger();
   }, [form, profile]);
 
   const values = form.watch();
@@ -159,10 +154,13 @@ export default function EditProfileScreen() {
       values.isProfessional !== Boolean(profile.is_professional))
   );
 
+  // Save activé dès qu'il y a un changement détecté (`hasChanges`).
+  // La validation Zod est appliquée au moment du submit via `form.handleSubmit`
+  // (errors inline restent visibles sous les champs si invalide).
+  // On bloque uniquement les états transitoires (upload, cooldown, taken…).
   const submitDisabled =
     !profile ||
     !hasChanges ||
-    !form.formState.isValid ||
     isUsernameBlocked ||
     isUsernameTaken ||
     isUsernameChecking ||


### PR DESCRIPTION
## Pourquoi cette PR

Suite de la PR #162. Le merge n'a squashé que le 1er commit (race de timing pendant le merge) → seul `form.trigger()` est dans `dev`, le retrait de `!form.formState.isValid` est manquant.

Le bug initial reste donc présent : si le profil chargé contient un champ déjà invalide (ex: `full_name = null` en BDD), `isValid` reste à `false` en permanence, et Save reste désactivé même quand l'user modifie la bio.

## Fix

- Retirer `!form.formState.isValid` du `submitDisabled` → Save s'active dès qu'`hasChanges` est true.
- Retirer le `form.trigger()` devenu inutile.
- La validation Zod tourne au submit (via `form.handleSubmit`). Si invalide, `onSubmit` n'est pas appelé et les erreurs inline (déjà câblées sous chaque champ) guident l'user.

## Test plan

- [ ] Modifier la bio → Save s'active
- [ ] Toggle "Professional account" → Save s'active
- [ ] Changer l'avatar → Save s'active
- [ ] Changer la cover → Save s'active
- [ ] Modifier le username → Save s'active
- [ ] Cliquer Save avec un fullName vide (< 2 chars) → erreur inline visible, formulaire non soumis

🤖 Generated with [Claude Code](https://claude.com/claude-code)