### PR TITLE
chore(db): committer les migrations Sprint 3 appliquées en dev + staging

### DIFF
--- a/supabase/migrations/20260517100001_extend_posts_for_feed.sql
+++ b/supabase/migrations/20260517100001_extend_posts_for_feed.sql
@@ -1,0 +1,10 @@
+-- Sprint 3 : colonnes feed sur la table posts
+alter table public.posts
+  add column if not exists media_urls text[] not null default '{}',
+  add column if not exists media_type text not null default 'text'
+    check (media_type in ('text', 'image', 'video')),
+  add column if not exists like_count int not null default 0,
+  add column if not exists comment_count int not null default 0,
+  add column if not exists share_count int not null default 0,
+  add column if not exists bookmark_count int not null default 0,
+  add column if not exists view_count int not null default 0;

--- a/supabase/migrations/20260517100002_posts_counters_triggers.sql
+++ b/supabase/migrations/20260517100002_posts_counters_triggers.sql
@@ -1,0 +1,83 @@
+-- Sprint 3 : triggers qui maintiennent les compteurs dénormalisés sur posts
+
+-- like_count
+create or replace function public.fn_posts_like_count()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if TG_OP = 'INSERT' then
+    update public.posts set like_count = like_count + 1 where id = NEW.post_id;
+    return NEW;
+  elsif TG_OP = 'DELETE' then
+    update public.posts set like_count = greatest(0, like_count - 1) where id = OLD.post_id;
+    return OLD;
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists trg_posts_like_count on public.likes;
+create trigger trg_posts_like_count
+  after insert or delete on public.likes
+  for each row execute function public.fn_posts_like_count();
+
+-- bookmark_count
+create or replace function public.fn_posts_bookmark_count()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if TG_OP = 'INSERT' then
+    update public.posts set bookmark_count = bookmark_count + 1 where id = NEW.post_id;
+    return NEW;
+  elsif TG_OP = 'DELETE' then
+    update public.posts set bookmark_count = greatest(0, bookmark_count - 1) where id = OLD.post_id;
+    return OLD;
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists trg_posts_bookmark_count on public.bookmarks;
+create trigger trg_posts_bookmark_count
+  after insert or delete on public.bookmarks
+  for each row execute function public.fn_posts_bookmark_count();
+
+-- comment_count (gère soft delete)
+create or replace function public.fn_posts_comment_count()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if TG_OP = 'INSERT' then
+    if NEW.deleted_at is null then
+      update public.posts set comment_count = comment_count + 1 where id = NEW.post_id;
+    end if;
+    return NEW;
+  elsif TG_OP = 'UPDATE' then
+    if OLD.deleted_at is null and NEW.deleted_at is not null then
+      update public.posts set comment_count = greatest(0, comment_count - 1) where id = NEW.post_id;
+    elsif OLD.deleted_at is not null and NEW.deleted_at is null then
+      update public.posts set comment_count = comment_count + 1 where id = NEW.post_id;
+    end if;
+    return NEW;
+  elsif TG_OP = 'DELETE' then
+    if OLD.deleted_at is null then
+      update public.posts set comment_count = greatest(0, comment_count - 1) where id = OLD.post_id;
+    end if;
+    return OLD;
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists trg_posts_comment_count on public.comments;
+create trigger trg_posts_comment_count
+  after insert or update or delete on public.comments
+  for each row execute function public.fn_posts_comment_count();
+
+-- Backfill initial des compteurs
+update public.posts p set
+  like_count = (select count(*) from public.likes where post_id = p.id),
+  bookmark_count = (select count(*) from public.bookmarks where post_id = p.id),
+  comment_count = (select count(*) from public.comments where post_id = p.id and deleted_at is null);
+
+-- Hygiène : trigger functions pas appelables directement via REST
+revoke execute on function public.fn_posts_like_count() from anon, authenticated;
+revoke execute on function public.fn_posts_bookmark_count() from anon, authenticated;
+revoke execute on function public.fn_posts_comment_count() from anon, authenticated;

--- a/supabase/migrations/20260517100003_feed_rpcs.sql
+++ b/supabase/migrations/20260517100003_feed_rpcs.sql
@@ -1,0 +1,102 @@
+-- Sprint 3 : RPCs principales du feed
+
+create or replace function public.get_feed(
+  p_cursor timestamptz default null,
+  p_limit int default 20
+)
+returns table (
+  id uuid, author_id uuid, author_username text, author_full_name text,
+  author_avatar_url text, author_is_verified boolean,
+  content text, media_urls text[], media_type text, location text, created_at timestamptz,
+  like_count int, comment_count int, share_count int, bookmark_count int, view_count int,
+  liked_by_me boolean, bookmarked_by_me boolean
+)
+language sql security definer set search_path = public stable as $$
+  select
+    p.id, p.author_id,
+    pr.username, pr.full_name, pr.avatar_url,
+    coalesce(pr.is_verified, false),
+    p.content, p.media_urls, p.media_type, p.location, p.created_at,
+    p.like_count, p.comment_count, p.share_count, p.bookmark_count, p.view_count,
+    exists (select 1 from public.likes l where l.post_id = p.id and l.user_id = auth.uid()),
+    exists (select 1 from public.bookmarks b where b.post_id = p.id and b.user_id = auth.uid())
+  from public.posts p
+  join public.profiles pr on pr.id = p.author_id
+  where p.deleted_at is null
+    and public.can_view_post(p.author_id)
+    and (p_cursor is null or p.created_at < p_cursor)
+  order by p.created_at desc
+  limit p_limit;
+$$;
+
+grant execute on function public.get_feed(timestamptz, int) to authenticated;
+
+create or replace function public.get_post_with_counts(p_post_id uuid)
+returns table (
+  id uuid, author_id uuid, author_username text, author_full_name text,
+  author_avatar_url text, author_is_verified boolean,
+  content text, media_urls text[], media_type text, location text, created_at timestamptz,
+  like_count int, comment_count int, share_count int, bookmark_count int, view_count int,
+  liked_by_me boolean, bookmarked_by_me boolean
+)
+language sql security definer set search_path = public stable as $$
+  select
+    p.id, p.author_id,
+    pr.username, pr.full_name, pr.avatar_url, coalesce(pr.is_verified, false),
+    p.content, p.media_urls, p.media_type, p.location, p.created_at,
+    p.like_count, p.comment_count, p.share_count, p.bookmark_count, p.view_count,
+    exists (select 1 from public.likes l where l.post_id = p.id and l.user_id = auth.uid()),
+    exists (select 1 from public.bookmarks b where b.post_id = p.id and b.user_id = auth.uid())
+  from public.posts p
+  join public.profiles pr on pr.id = p.author_id
+  where p.id = p_post_id and p.deleted_at is null and public.can_view_post(p.author_id);
+$$;
+
+grant execute on function public.get_post_with_counts(uuid) to authenticated;
+
+create or replace function public.toggle_like(p_post_id uuid)
+returns boolean language plpgsql security definer set search_path = public as $$
+declare
+  v_user uuid := auth.uid();
+begin
+  if v_user is null then raise exception 'Not authenticated'; end if;
+  if exists (select 1 from public.likes where post_id = p_post_id and user_id = v_user) then
+    delete from public.likes where post_id = p_post_id and user_id = v_user;
+    return false;
+  else
+    insert into public.likes (post_id, user_id) values (p_post_id, v_user);
+    return true;
+  end if;
+end;
+$$;
+
+grant execute on function public.toggle_like(uuid) to authenticated;
+
+create or replace function public.toggle_bookmark(p_post_id uuid)
+returns boolean language plpgsql security definer set search_path = public as $$
+declare
+  v_user uuid := auth.uid();
+begin
+  if v_user is null then raise exception 'Not authenticated'; end if;
+  if exists (select 1 from public.bookmarks where post_id = p_post_id and user_id = v_user) then
+    delete from public.bookmarks where post_id = p_post_id and user_id = v_user;
+    return false;
+  else
+    insert into public.bookmarks (post_id, user_id) values (p_post_id, v_user);
+    return true;
+  end if;
+end;
+$$;
+
+grant execute on function public.toggle_bookmark(uuid) to authenticated;
+
+create or replace function public.increment_share_count(p_post_id uuid)
+returns int language sql security definer set search_path = public as $$
+  update public.posts
+  set share_count = share_count + 1
+  where id = p_post_id and deleted_at is null
+    and public.can_view_post(author_id)
+  returning share_count;
+$$;
+
+grant execute on function public.increment_share_count(uuid) to authenticated;

--- a/supabase/migrations/20260517100004_adapt_notifications_for_sprint3.sql
+++ b/supabase/migrations/20260517100004_adapt_notifications_for_sprint3.sql
@@ -1,0 +1,45 @@
+-- Sprint 3 : adaptation de la table notifications existante (Sprint 0)
+-- La table existe déjà avec : is_read, metadata (jsonb), type (enum), entity_type (enum)
+-- On ajoute : is_seen, payload (alias de metadata), valeur 'payment' dans l'enum
+
+alter table public.notifications
+  add column if not exists is_seen boolean not null default false,
+  add column if not exists payload jsonb;
+
+-- Synchroniser payload depuis metadata pour les éventuelles données existantes
+update public.notifications set payload = metadata where payload is null and metadata is not null;
+
+-- Ajouter la valeur 'payment' à l'enum notification_type
+alter type public.notification_type add value if not exists 'payment';
+
+-- Indexes manquants
+create index if not exists notifications_recipient_created_idx
+  on public.notifications (recipient_id, created_at desc);
+
+create index if not exists notifications_unseen_idx
+  on public.notifications (recipient_id)
+  where is_seen = false;
+
+-- Policies avec (select auth.uid()) pour la perf
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where tablename = 'notifications' and policyname = 'users see their own notifications'
+  ) then
+    execute 'create policy "users see their own notifications"
+      on public.notifications for select
+      using (( select auth.uid()) = recipient_id)';
+  end if;
+
+  if not exists (
+    select 1 from pg_policies
+    where tablename = 'notifications' and policyname = 'users update their own notifications'
+  ) then
+    execute 'create policy "users update their own notifications"
+      on public.notifications for update
+      using (( select auth.uid()) = recipient_id)
+      with check (( select auth.uid()) = recipient_id)';
+  end if;
+end;
+$$;

--- a/supabase/migrations/20260517100005_notifications_triggers.sql
+++ b/supabase/migrations/20260517100005_notifications_triggers.sql
@@ -1,0 +1,76 @@
+-- Sprint 3 : triggers de notifications (follow, like, comment)
+
+create or replace function public.fn_notify_follow()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if NEW.follower_id = NEW.followed_id then return NEW; end if;
+
+  if TG_OP = 'INSERT' then
+    if NEW.status = 'pending' then
+      insert into public.notifications (recipient_id, actor_id, type)
+      values (NEW.followed_id, NEW.follower_id, 'follow_request');
+    elsif NEW.status = 'accepted' then
+      insert into public.notifications (recipient_id, actor_id, type)
+      values (NEW.followed_id, NEW.follower_id, 'follow');
+    end if;
+  elsif TG_OP = 'UPDATE' then
+    if OLD.status = 'pending' and NEW.status = 'accepted' then
+      delete from public.notifications
+        where recipient_id = NEW.followed_id
+          and actor_id = NEW.follower_id
+          and type = 'follow_request';
+      insert into public.notifications (recipient_id, actor_id, type)
+      values (NEW.follower_id, NEW.followed_id, 'follow');
+    end if;
+  end if;
+  return NEW;
+end;
+$$;
+
+drop trigger if exists trg_notify_follow on public.follows;
+create trigger trg_notify_follow
+  after insert or update on public.follows
+  for each row execute function public.fn_notify_follow();
+
+create or replace function public.fn_notify_like()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  v_post_author uuid;
+begin
+  select author_id into v_post_author from public.posts where id = NEW.post_id;
+  if v_post_author is null or v_post_author = NEW.user_id then return NEW; end if;
+  insert into public.notifications (recipient_id, actor_id, type, entity_type, entity_id)
+  values (v_post_author, NEW.user_id, 'like', 'post', NEW.post_id);
+  return NEW;
+end;
+$$;
+
+drop trigger if exists trg_notify_like on public.likes;
+create trigger trg_notify_like
+  after insert on public.likes
+  for each row execute function public.fn_notify_like();
+
+create or replace function public.fn_notify_comment()
+returns trigger language plpgsql security definer set search_path = public as $$
+declare
+  v_post_author uuid;
+begin
+  if NEW.deleted_at is not null then return NEW; end if;
+  select author_id into v_post_author from public.posts where id = NEW.post_id;
+  if v_post_author is null or v_post_author = NEW.author_id then return NEW; end if;
+  insert into public.notifications (recipient_id, actor_id, type, entity_type, entity_id, payload)
+  values (v_post_author, NEW.author_id, 'comment', 'post', NEW.post_id,
+          jsonb_build_object('preview', left(NEW.content, 100)));
+  return NEW;
+end;
+$$;
+
+drop trigger if exists trg_notify_comment on public.comments;
+create trigger trg_notify_comment
+  after insert on public.comments
+  for each row execute function public.fn_notify_comment();
+
+-- Hygiène : trigger functions pas appelables directement via REST
+revoke execute on function public.fn_notify_follow() from anon, authenticated;
+revoke execute on function public.fn_notify_like() from anon, authenticated;
+revoke execute on function public.fn_notify_comment() from anon, authenticated;

--- a/supabase/migrations/20260517100006_notifications_rpcs.sql
+++ b/supabase/migrations/20260517100006_notifications_rpcs.sql
@@ -1,0 +1,58 @@
+-- Sprint 3 : RPCs notifications
+
+create or replace function public.get_notifications(
+  p_filter text default 'all',
+  p_limit int default 30
+)
+returns table (
+  id uuid, recipient_id uuid, actor_id uuid,
+  actor_username text, actor_full_name text, actor_avatar_url text, actor_is_verified boolean,
+  type text, entity_type text, entity_id uuid, payload jsonb,
+  is_seen boolean, is_read boolean, created_at timestamptz
+)
+language sql security definer set search_path = public stable as $$
+  select
+    n.id, n.recipient_id, n.actor_id,
+    pr.username, pr.full_name, pr.avatar_url, coalesce(pr.is_verified, false),
+    n.type::text, n.entity_type::text, n.entity_id,
+    coalesce(n.payload, n.metadata),
+    n.is_seen, n.is_read, n.created_at
+  from public.notifications n
+  left join public.profiles pr on pr.id = n.actor_id
+  where n.recipient_id = auth.uid()
+    and case
+      when p_filter = 'unread'   then n.is_read = false
+      when p_filter = 'social'   then n.type in ('follow', 'follow_request', 'like', 'comment', 'mention')
+      when p_filter = 'payment'  then n.type::text = 'payment'
+      when p_filter = 'ai'       then n.type::text = 'system'
+      else true
+    end
+  order by n.created_at desc
+  limit p_limit;
+$$;
+
+grant execute on function public.get_notifications(text, int) to authenticated;
+
+create or replace function public.mark_all_notifications_seen()
+returns void language sql security definer set search_path = public as $$
+  update public.notifications set is_seen = true
+  where recipient_id = auth.uid() and is_seen = false;
+$$;
+
+grant execute on function public.mark_all_notifications_seen() to authenticated;
+
+create or replace function public.mark_notification_read(p_notification_id uuid)
+returns void language sql security definer set search_path = public as $$
+  update public.notifications set is_read = true, is_seen = true
+  where id = p_notification_id and recipient_id = auth.uid();
+$$;
+
+grant execute on function public.mark_notification_read(uuid) to authenticated;
+
+create or replace function public.count_unread_notifications()
+returns int language sql security definer set search_path = public stable as $$
+  select count(*)::int from public.notifications
+  where recipient_id = auth.uid() and is_seen = false;
+$$;
+
+grant execute on function public.count_unread_notifications() to authenticated;

--- a/supabase/migrations/20260517100007_revoke_anon_trigger_functions_sprint3.sql
+++ b/supabase/migrations/20260517100007_revoke_anon_trigger_functions_sprint3.sql
@@ -1,0 +1,11 @@
+-- Sprint 3 hygiène : révoquer l'accès REST direct aux fonctions trigger
+-- Ces fonctions sont des triggers internes, pas des RPCs publiques.
+-- Elles n'ont pas besoin d'être appelables via /rest/v1/rpc/
+-- Migration idempotente (revoke déjà partiellement effectué dans 100002 et 100005)
+
+revoke execute on function public.fn_posts_like_count() from anon, authenticated;
+revoke execute on function public.fn_posts_bookmark_count() from anon, authenticated;
+revoke execute on function public.fn_posts_comment_count() from anon, authenticated;
+revoke execute on function public.fn_notify_follow() from anon, authenticated;
+revoke execute on function public.fn_notify_like() from anon, authenticated;
+revoke execute on function public.fn_notify_comment() from anon, authenticated;


### PR DESCRIPTION
## Summary

Cohérence repo ↔ BDD : ces 7 fichiers reflètent les migrations exécutées via **AI Supabase** sur les projets `dev` (`kbysmkhalnolbsojzahf`) et `staging` (`sdapojfdwduhuyduymxk`) le 17 mai 2026.

- 8/8 tests d'intégration passent côté AI Supabase
- Advisors clean, aucun nouveau warning
- Pattern projet : SQL d'abord en BDD via Claude Web (MCP local refuse l'accès direct), puis fichiers committés au repo

## Contenu

| # | Migration | Rôle |
|---|---|---|
| 1 | `extend_posts_for_feed` | Colonnes `media_urls`, `media_type` + 5 compteurs sur `posts` |
| 2 | `posts_counters_triggers` | Triggers `like_count`, `bookmark_count`, `comment_count` (gère soft delete) + backfill |
| 3 | `feed_rpcs` | `get_feed` (curseur), `get_post_with_counts`, `toggle_like`, `toggle_bookmark`, `increment_share_count` |
| 4 | `adapt_notifications_for_sprint3` | **Adaptation** (la table existait depuis Sprint 0) : ajout `is_seen` + `payload`, valeur `'payment'` dans l'enum |
| 5 | `notifications_triggers` | `fn_notify_follow` (pending→accepted), `fn_notify_like`, `fn_notify_comment` (skip self-actions) |
| 6 | `notifications_rpcs` | `get_notifications` (filtres all/unread/social/payment/ai), `mark_all_seen`, `mark_read`, `count_unread` |
| 7 | `revoke_anon_trigger_functions_sprint3` | Hygiène : révoque l'accès REST direct aux trigger functions (idempotent avec 2 et 5) |

## Détails techniques

- Toutes les fonctions sont `SECURITY DEFINER` avec `set search_path = public` (best practice Supabase)
- `get_feed` retourne déjà `liked_by_me` et `bookmarked_by_me` côté serveur (économise un round-trip)
- `fn_notify_comment` gère `deleted_at` (pas de notif sur commentaire soft-deleted)
- `fn_notify_follow` supprime la notif `follow_request` quand le statut passe à `accepted` et notifie le demandeur initial

## Test plan

- [x] Migrations appliquées en dev (AI Supabase)
- [x] Migrations appliquées en staging (AI Supabase)
- [x] 8/8 tests d'intégration passent côté AI Supabase
- [x] Advisors clean (pas de nouveau warning sécurité)
- [ ] À tester côté client une fois les tickets Sprint 3 implémentés (E4-01, E4-02, E4-03…)

🤖 Generated with [Claude Code](https://claude.com/claude-code)