### PR TITLE
chore(db): bucket storage posts + policies (préreq E4-04)

### DIFF
--- a/supabase/migrations/20260518150000_posts_storage_bucket.sql
+++ b/supabase/migrations/20260518150000_posts_storage_bucket.sql
@@ -1,0 +1,84 @@
+-- Sprint 3 : bucket Storage `posts` + policies
+-- Préreq pour E4-04 (Upload image vers Supabase Storage)
+-- Migration idempotente : ok si le bucket / les policies existent déjà depuis Sprint 0
+
+-- 1. Bucket `posts`
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'posts',
+  'posts',
+  true,
+  10485760, -- 10 Mo max par fichier
+  array['image/jpeg', 'image/png', 'image/webp']
+)
+on conflict (id) do update
+  set public = excluded.public,
+      file_size_limit = excluded.file_size_limit,
+      allowed_mime_types = excluded.allowed_mime_types;
+
+-- 2. Policies (idempotent via DO block + pg_policies check)
+do $$
+begin
+  -- Upload : l'user authentifié peut écrire uniquement dans son propre dossier {user_id}/
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'posts users upload own folder'
+  ) then
+    create policy "posts users upload own folder"
+      on storage.objects for insert
+      to authenticated
+      with check (
+        bucket_id = 'posts'
+        and (storage.foldername(name))[1] = auth.uid()::text
+      );
+  end if;
+
+  -- Update (rare en pratique mais utile si replace)
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'posts users update own folder'
+  ) then
+    create policy "posts users update own folder"
+      on storage.objects for update
+      to authenticated
+      using (
+        bucket_id = 'posts'
+        and (storage.foldername(name))[1] = auth.uid()::text
+      );
+  end if;
+
+  -- Delete : l'user peut supprimer ses propres fichiers (cleanup après suppression de post)
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'posts users delete own folder'
+  ) then
+    create policy "posts users delete own folder"
+      on storage.objects for delete
+      to authenticated
+      using (
+        bucket_id = 'posts'
+        and (storage.foldername(name))[1] = auth.uid()::text
+      );
+  end if;
+
+  -- Lecture publique (les médias de posts sont semi-publics ; la RLS sur public.posts
+  -- contrôle déjà qui voit quel post, et personne ne devine une URL avec un UUID)
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname = 'posts public read'
+  ) then
+    create policy "posts public read"
+      on storage.objects for select
+      to anon, authenticated
+      using (bucket_id = 'posts');
+  end if;
+end;
+$$;


### PR DESCRIPTION
## Summary

Cohérence repo ↔ BDD : reflète la migration `posts_storage_bucket` appliquée en **dev** + **staging** le 18 mai 2026 via AI Supabase.

Préreq pour le ticket **#44 (E4-04 Upload Storage)** — une fois cette PR mergée, n'importe quel dev peut prendre #44 sans toucher à la Console Supabase.

## Contenu

- **Bucket `posts`** : upsert (public, 10 Mo max, MIME jpeg/png/webp)
- **4 policies** `storage.objects` (idempotentes via DO block) :
  - `posts users upload own folder` (INSERT auth, dossier `{user_id}/`)
  - `posts users update own folder` (UPDATE auth, idem)
  - `posts users delete own folder` (DELETE auth, idem)
  - `posts public read` (SELECT anon + authenticated)

## Notes état BDD

- Le bucket existait depuis Sprint 0 avec MIME `jpeg/png/webp/gif` → la migration retire le support gif (cohérent avec scope E4-04). Les gifs déjà uploadés restent accessibles (la whitelist ne s'applique qu'aux nouveaux uploads).
- 4 anciennes policies Sprint 0 (`posts_insert_own`, etc.) coexistent avec les nouvelles. Fonctionnellement identiques. À nettoyer post-MVP dans une migration hygiène dédiée.

## Test plan

- [x] Migration appliquée en dev (AI Supabase confirmé)
- [x] Migration appliquée en staging (AI Supabase confirmé)
- [ ] À tester côté client une fois #44 implémenté (upload depuis l'app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)