### PR TITLE
feat(feed): hook useCreatePost + invalidation cache (E4-05)

### DIFF
--- a/src/features/feed/hooks/useCreatePost.ts
+++ b/src/features/feed/hooks/useCreatePost.ts
@@ -1,0 +1,85 @@
+// Hook useCreatePost — E4-05.
+// Encapsule l'INSERT dans `posts` + invalidation des caches feed et profile.
+// N'envoie jamais author_id côté client (RLS default via auth.uid()).
+
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Payload attendu par le caller (E4-03 CreatePostScreen). */
+export interface CreatePostInput {
+  content: string;
+  media_urls: string[];
+  media_type: 'text' | 'image' | 'video';
+}
+
+/** Row retournée par le SELECT après INSERT. */
+interface PostRow {
+  id: string;
+  author_id: string;
+  content: string;
+  media_urls: string[];
+  media_type: 'text' | 'image' | 'video';
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useCreatePost() {
+  const queryClient = useQueryClient();
+
+  return useMutation<PostRow, Error, CreatePostInput>({
+    mutationFn: async (input) => {
+      const { data, error } = await supabase
+        .from('posts')
+        .insert({
+          content: input.content,
+          media_urls: input.media_urls,
+          media_type: input.media_type,
+          // author_id : géré par default auth.uid() côté BDD
+        })
+        .select()
+        .single();
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return data as PostRow;
+    },
+
+    onSuccess: (data) => {
+      // Invalide le feed global pour refetch
+      void queryClient.invalidateQueries({
+        queryKey: ['feed'],
+      });
+
+      // Invalide le grid de posts du profil de l'auteur
+      void queryClient.invalidateQueries({
+        queryKey: ['profile', 'user', data.author_id, 'posts'],
+      });
+
+      // Invalide aussi le grid "mes posts" (profil personnel)
+      void queryClient.invalidateQueries({
+        queryKey: ['profile', 'me', 'posts'],
+      });
+
+      logger.info('post_created', { post_id: data.id });
+    },
+
+    onError: (error) => {
+      // On passe l'objet Error tel quel : `logger.error` le route vers
+      // Sentry.captureException (cf. src/lib/logger.ts), ce qui conserve la
+      // stack trace. Le réduire à { message } le ferait tomber dans la
+      // branche captureMessage — stack perdue.
+      logger.error('create_post_failed', error);
+    },
+  });
+}


### PR DESCRIPTION
## Ticket lié

Closes #45

## Checklist

- [x] Le code compile et passe le lint local
- [x] Les tests unitaires passent
- [x] La couverture de tests respecte les seuils de ma zone (voir cadrage §9.4)
- [x] J'ai testé manuellement le happy path + 2 cas d'erreur
- [x] Les critères d'acceptation du ticket sont tous cochés
- [x] Si nouveau composant : story / exemple ajouté
- [x] Si changement de schéma DB : migration commitée + testée sur dev
- [x] Si secret/env : documenté dans Notion
- [x] Si nouveau coût API : monitoring PostHog mis à jour
- [x] Aucun console.log oublié, aucun TODO sans issue liée
- [x] Si j'ai ajouté du code dans `lib/`, `hooks/`, `services/` ou `stores/`, j'ai ajouté les tests correspondants. Sinon j'ai ouvert un ticket `type: tech` pour le faire dans le sprint.

## Comment tester

1. `git checkout feature/e4-05-mutation-createpost`
2. `pnpm install`
3. Importer `useCreatePost` dans n'importe quel composant et appeler `.mutate({ content: 'test', media_urls: [], media_type: 'text' })` — vérifier l'insertion en BDD et l'invalidation cache feed / profile.

## Points d'attention pour le reviewer

- QueryKeys alignées avec celles déjà utilisées dans `useBlock.ts` et `useProfile.ts`
- `author_id` jamais envoyé côté client (RLS default via `auth.uid()`)
- Logger via `logger.error(err)` pour conserver la stack trace dans Sentry