### PR TITLE
feat(feed): écran Feed 5 onglets (E4-01)

### DIFF
--- a/src/features/feed/components/FeedStories.tsx
+++ b/src/features/feed/components/FeedStories.tsx
@@ -29,7 +29,7 @@ export function FeedStories({ stories, onStoryPress }: FeedStoriesProps) {
           pressStyle={{ scale: 0.97, opacity: 0.85 }}
           accessibilityRole="button"
           accessibilityLabel={
-            story.isMe ? 'Ajouter a votre story' : `Ouvrir la story de @${story.username}`
+            story.isMe ? 'Ajouter à votre story' : `Ouvrir la story de @${story.username}`
           }
         >
           <YStack

--- a/src/features/feed/components/FeedStories.tsx
+++ b/src/features/feed/components/FeedStories.tsx
@@ -1,0 +1,105 @@
+import { Image } from 'expo-image';
+import { Plus } from 'lucide-react-native';
+import { ScrollView, StyleSheet } from 'react-native';
+import { Text, XStack, YStack } from 'tamagui';
+
+import type { FeedStory } from '@/features/feed/hooks/useFeedStories';
+
+type FeedStoriesProps = {
+  stories: FeedStory[];
+  onStoryPress: (story: FeedStory) => void;
+};
+
+export function FeedStories({ stories, onStoryPress }: FeedStoriesProps) {
+  if (stories.length === 0) return null;
+
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.content}
+    >
+      {stories.map((story) => (
+        <YStack
+          key={story.id}
+          width={72}
+          alignItems="center"
+          gap={6}
+          onPress={() => onStoryPress(story)}
+          pressStyle={{ scale: 0.97, opacity: 0.85 }}
+          accessibilityRole="button"
+          accessibilityLabel={
+            story.isMe ? 'Ajouter a votre story' : `Ouvrir la story de @${story.username}`
+          }
+        >
+          <YStack
+            width={72}
+            height={72}
+            borderRadius={9999}
+            padding={story.hasUnseenStory ? 2 : 0}
+            backgroundColor={story.hasUnseenStory ? '#10D970' : 'transparent'}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <YStack
+              width={story.hasUnseenStory ? 68 : 72}
+              height={story.hasUnseenStory ? 68 : 72}
+              borderRadius={9999}
+              backgroundColor="$surface"
+              alignItems="center"
+              justifyContent="center"
+              overflow="hidden"
+            >
+              {story.avatar_url ? (
+                <Image
+                  source={{ uri: story.avatar_url }}
+                  style={styles.avatar}
+                  contentFit="cover"
+                  transition={200}
+                />
+              ) : (
+                <Text color="$color" fontSize={22} fontWeight="700">
+                  {story.username.charAt(0).toUpperCase()}
+                </Text>
+              )}
+            </YStack>
+
+            {story.isMe ? (
+              <XStack
+                position="absolute"
+                right={0}
+                bottom={0}
+                width={22}
+                height={22}
+                borderRadius={9999}
+                backgroundColor="$accentNeon"
+                borderWidth={2}
+                borderColor="$background"
+                alignItems="center"
+                justifyContent="center"
+              >
+                <Plus size={14} color="#000000" strokeWidth={2.8} />
+              </XStack>
+            ) : null}
+          </YStack>
+
+          <Text color="$textSecondary" fontSize={11} numberOfLines={1} maxWidth={72}>
+            {story.isMe ? 'Votre story' : story.username}
+          </Text>
+        </YStack>
+      ))}
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  avatar: {
+    width: '100%',
+    height: '100%',
+  },
+  content: {
+    gap: 12,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+});

--- a/src/features/feed/components/FeedTabPlaceholder.tsx
+++ b/src/features/feed/components/FeedTabPlaceholder.tsx
@@ -1,0 +1,34 @@
+import type { LucideIcon } from 'lucide-react-native';
+import { Text, YStack } from 'tamagui';
+
+type FeedTabPlaceholderProps = {
+  Icon: LucideIcon;
+  title: string;
+  subtitle: string;
+  manifest?: string;
+};
+
+export function FeedTabPlaceholder({ Icon, title, subtitle, manifest }: FeedTabPlaceholderProps) {
+  return (
+    <YStack flex={1} alignItems="center" justifyContent="center" paddingHorizontal="$6" gap="$3">
+      <Icon size={64} color="#6F6F6F" strokeWidth={1.6} />
+      <Text color="$color" fontSize={18} fontWeight="700" textAlign="center">
+        {title}
+      </Text>
+      <Text color="$textSecondary" fontSize={14} lineHeight={20} textAlign="center">
+        {subtitle}
+      </Text>
+      {manifest ? (
+        <Text
+          color="$textSecondary"
+          fontSize={13}
+          lineHeight={20}
+          textAlign="center"
+          marginTop="$2"
+        >
+          {manifest}
+        </Text>
+      ) : null}
+    </YStack>
+  );
+}

--- a/src/features/feed/hooks/useFeed.ts
+++ b/src/features/feed/hooks/useFeed.ts
@@ -1,0 +1,162 @@
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { PostCardPost } from '@/components/feed/PostCard';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+const PAGE_SIZE = 20;
+
+type FeedRpcRow = PostCardPost & {
+  media_type: 'text' | 'image' | 'video' | string;
+};
+
+function mapFeedPost(row: FeedRpcRow): PostCardPost {
+  return {
+    id: row.id,
+    author_id: row.author_id,
+    author_username: row.author_username,
+    author_full_name: row.author_full_name,
+    author_avatar_url: row.author_avatar_url,
+    author_is_verified: row.author_is_verified,
+    content: row.content ?? '',
+    media_urls: Array.isArray(row.media_urls) ? row.media_urls : [],
+    media_type:
+      row.media_type === 'image' || row.media_type === 'video' || row.media_type === 'text'
+        ? row.media_type
+        : 'text',
+    created_at: row.created_at,
+    like_count: row.like_count ?? 0,
+    comment_count: row.comment_count ?? 0,
+    share_count: row.share_count ?? 0,
+    bookmark_count: row.bookmark_count ?? 0,
+    liked_by_me: row.liked_by_me ?? false,
+    bookmarked_by_me: row.bookmarked_by_me ?? false,
+  };
+}
+
+async function fetchFeedPage(cursor: string | null) {
+  const { data, error } = await supabase.rpc('get_feed', {
+    p_cursor: cursor,
+    p_limit: PAGE_SIZE,
+  });
+
+  if (error) {
+    logger.warn('get_feed foryou failed', { message: error.message });
+    throw error;
+  }
+
+  const posts = ((data ?? []) as FeedRpcRow[]).map(mapFeedPost);
+  const nextCursor =
+    posts.length === PAGE_SIZE ? (posts[posts.length - 1]?.created_at ?? null) : null;
+
+  return { posts, nextCursor };
+}
+
+export function useFeed() {
+  return useInfiniteQuery({
+    queryKey: ['feed', 'social', 'foryou'],
+    queryFn: ({ pageParam }) => fetchFeedPage(pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  });
+}
+
+export function useToggleFeedLike() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (postId: string) => {
+      const { data, error } = await supabase.rpc('toggle_like', { p_post_id: postId });
+      if (error) throw error;
+      return { postId, liked: Boolean(data) };
+    },
+    onMutate: async (postId) => {
+      const queryKey = ['feed', 'social', 'foryou'];
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData(queryKey);
+
+      queryClient.setQueryData<ReturnType<typeof useFeed>['data']>(queryKey, (old) => {
+        if (!old) return old;
+
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            posts: page.posts.map((post) =>
+              post.id === postId
+                ? {
+                    ...post,
+                    liked_by_me: !post.liked_by_me,
+                    like_count: post.liked_by_me
+                      ? Math.max(0, post.like_count - 1)
+                      : post.like_count + 1,
+                  }
+                : post
+            ),
+          })),
+        };
+      });
+
+      return { previous };
+    },
+    onError: (error, _postId, context) => {
+      logger.warn('toggle_like failed', { message: error.message });
+      if (context?.previous) {
+        queryClient.setQueryData(['feed', 'social', 'foryou'], context.previous);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['feed', 'social', 'foryou'] });
+    },
+  });
+}
+
+export function useToggleFeedBookmark() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (postId: string) => {
+      const { data, error } = await supabase.rpc('toggle_bookmark', { p_post_id: postId });
+      if (error) throw error;
+      return { postId, bookmarked: Boolean(data) };
+    },
+    onMutate: async (postId) => {
+      const queryKey = ['feed', 'social', 'foryou'];
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData(queryKey);
+
+      queryClient.setQueryData<ReturnType<typeof useFeed>['data']>(queryKey, (old) => {
+        if (!old) return old;
+
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            posts: page.posts.map((post) =>
+              post.id === postId
+                ? {
+                    ...post,
+                    bookmarked_by_me: !post.bookmarked_by_me,
+                    bookmark_count: post.bookmarked_by_me
+                      ? Math.max(0, post.bookmark_count - 1)
+                      : post.bookmark_count + 1,
+                  }
+                : post
+            ),
+          })),
+        };
+      });
+
+      return { previous };
+    },
+    onError: (error, _postId, context) => {
+      logger.warn('toggle_bookmark failed', { message: error.message });
+      if (context?.previous) {
+        queryClient.setQueryData(['feed', 'social', 'foryou'], context.previous);
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['feed', 'social', 'foryou'] });
+    },
+  });
+}

--- a/src/features/feed/hooks/useFeedStories.ts
+++ b/src/features/feed/hooks/useFeedStories.ts
@@ -1,0 +1,94 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type FeedStory = {
+  id: string;
+  username: string;
+  avatar_url: string | null;
+  isMe: boolean;
+  hasUnseenStory: boolean;
+};
+
+type FollowStoryRow = {
+  followed_id: string;
+  profile:
+    | {
+        id: string;
+        username: string | null;
+        avatar_url: string | null;
+      }
+    | {
+        id: string;
+        username: string | null;
+        avatar_url: string | null;
+      }[]
+    | null;
+};
+
+function firstProfile(row: FollowStoryRow) {
+  return Array.isArray(row.profile) ? row.profile[0] : row.profile;
+}
+
+export function useFeedStories() {
+  return useQuery({
+    queryKey: ['feed', 'stories'],
+    queryFn: async (): Promise<FeedStory[]> => {
+      const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+      if (sessionError || !sessionData.session?.user?.id) {
+        throw new Error('No authenticated user');
+      }
+
+      const userId = sessionData.session.user.id;
+
+      const [meRes, followsRes] = await Promise.all([
+        supabase.from('profiles').select('id, username, avatar_url').eq('id', userId).single(),
+        supabase
+          .from('follows')
+          .select('followed_id, profile:profiles!followed_id(id, username, avatar_url)')
+          .eq('follower_id', userId)
+          .eq('status', 'accepted')
+          .limit(20),
+      ]);
+
+      if (meRes.error) {
+        logger.warn('fetch feed story self failed', { message: meRes.error.message });
+        throw meRes.error;
+      }
+
+      if (followsRes.error) {
+        logger.warn('fetch feed stories failed', { message: followsRes.error.message });
+        throw followsRes.error;
+      }
+
+      const meProfile = meRes.data as {
+        id: string;
+        username: string | null;
+        avatar_url: string | null;
+      };
+      const followingStories = ((followsRes.data ?? []) as FollowStoryRow[])
+        .map((row) => firstProfile(row))
+        .filter((profile): profile is NonNullable<ReturnType<typeof firstProfile>> => !!profile)
+        .map((profile) => ({
+          id: profile.id,
+          username: profile.username ?? 'user',
+          avatar_url: profile.avatar_url,
+          isMe: false,
+          hasUnseenStory: true,
+        }));
+
+      return [
+        {
+          id: meProfile.id,
+          username: meProfile.username ?? 'Moi',
+          avatar_url: meProfile.avatar_url,
+          isMe: true,
+          hasUnseenStory: false,
+        },
+        ...followingStories,
+      ];
+    },
+    staleTime: 60_000,
+  });
+}

--- a/src/features/feed/screens/FeedScreen.tsx
+++ b/src/features/feed/screens/FeedScreen.tsx
@@ -40,25 +40,25 @@ const FEED_TABS: FeedTab[] = [
 const PLACEHOLDERS = {
   business: {
     Icon: Store,
-    title: 'Marketplace bientot disponible',
-    subtitle: 'Achetez, vendez, decouvrez.',
+    title: 'Marketplace bientôt disponible',
+    subtitle: 'Achetez, vendez, découvrez.',
   },
   ai: {
     Icon: Sparkles,
-    title: 'Studio AI bientot disponible',
-    subtitle: "Assistant IA, generation d'images et plus.",
+    title: 'Studio AI bientôt disponible',
+    subtitle: "Assistant IA, génération d'images et plus.",
   },
   wallet: {
     Icon: Wallet,
-    title: 'Dpay bientot disponible',
-    subtitle: 'Votre wallet crypto integre.',
+    title: 'Dpay bientôt disponible',
+    subtitle: 'Votre wallet crypto intégré.',
   },
   soon: {
     Icon: Rocket,
-    title: 'Encore plus a venir',
-    subtitle: 'DOUMASSI evolue. Restez connecte.',
+    title: 'Encore plus à venir',
+    subtitle: 'DOUMASSI évolue. Restez connecté.',
     manifest:
-      'Un espace social, business, creatif et financier pense pour rassembler vos usages dans un seul univers.',
+      'Un espace social, business, créatif et financier pensé pour rassembler vos usages dans un seul univers.',
   },
 } satisfies Record<Exclude<FeedTabId, 'social'>, React.ComponentProps<typeof FeedTabPlaceholder>>;
 
@@ -97,7 +97,7 @@ function FeedHeader({
           hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
           style={styles.headerSideButton}
           accessibilityRole="button"
-          accessibilityLabel="Ouvrir les parametres"
+          accessibilityLabel="Ouvrir les paramètres"
         >
           <Settings size={22} color="#FFFFFF" />
         </TouchableOpacity>
@@ -139,7 +139,7 @@ function FeedHeader({
       <SearchBar
         value={searchValue}
         onChangeText={onSearchChange}
-        placeholder={activeTab === 'social' ? 'Search posts...' : 'Search...'}
+        placeholder={activeTab === 'social' ? 'Rechercher des posts...' : 'Rechercher...'}
       />
     </YStack>
   );
@@ -161,7 +161,7 @@ function FeedEmptyState() {
         onPress={() => router.push('/search')}
         pressStyle={{ opacity: 0.85, scale: 0.98 }}
       >
-        Decouvrir des comptes
+        Découvrir des comptes
       </Button>
     </YStack>
   );

--- a/src/features/feed/screens/FeedScreen.tsx
+++ b/src/features/feed/screens/FeedScreen.tsx
@@ -1,56 +1,359 @@
-// Écran d'accueil post-login — placeholder MVP.
-// Sera enrichi avec le vrai feed (FlashList + posts) lors des Sprints 3-4.
-// Le sign out a été déplacé dans /settings (E2-12).
-// Ticket E2-03 — Sprint 1 Auth & Onboarding.
-
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
+import { Image } from 'expo-image';
 import { router } from 'expo-router';
-import { Search, Settings, User } from 'lucide-react-native';
-import { ScrollView, Text, XStack, YStack } from 'tamagui';
+import { Rocket, Search, Settings, Sparkles, Store, User, Wallet } from 'lucide-react-native';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  ScrollView,
+  StyleSheet,
+  TouchableOpacity,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Button, Spinner, Text, XStack, YStack } from 'tamagui';
 
-export function FeedScreen() {
+import { PostCard, PostCardSkeleton, type PostCardPost } from '@/components/feed/PostCard';
+import { FeedStories } from '@/features/feed/components/FeedStories';
+import { FeedTabPlaceholder } from '@/features/feed/components/FeedTabPlaceholder';
+import { useFeed, useToggleFeedBookmark, useToggleFeedLike } from '@/features/feed/hooks/useFeed';
+import { type FeedStory, useFeedStories } from '@/features/feed/hooks/useFeedStories';
+import { SearchBar } from '@/features/profile/components/SearchBar';
+
+const logoSource = require('../../../../assets/Logo-Doumassi.png') as number;
+
+type FeedTabId = 'social' | 'business' | 'ai' | 'wallet' | 'soon';
+
+type FeedTab = {
+  id: FeedTabId;
+  label: string;
+};
+
+const FEED_TABS: FeedTab[] = [
+  { id: 'social', label: 'Social' },
+  { id: 'business', label: 'Business' },
+  { id: 'ai', label: 'AI' },
+  { id: 'wallet', label: 'Wallet' },
+  { id: 'soon', label: 'Soon' },
+];
+
+const PLACEHOLDERS = {
+  business: {
+    Icon: Store,
+    title: 'Marketplace bientot disponible',
+    subtitle: 'Achetez, vendez, decouvrez.',
+  },
+  ai: {
+    Icon: Sparkles,
+    title: 'Studio AI bientot disponible',
+    subtitle: "Assistant IA, generation d'images et plus.",
+  },
+  wallet: {
+    Icon: Wallet,
+    title: 'Dpay bientot disponible',
+    subtitle: 'Votre wallet crypto integre.',
+  },
+  soon: {
+    Icon: Rocket,
+    title: 'Encore plus a venir',
+    subtitle: 'DOUMASSI evolue. Restez connecte.',
+    manifest:
+      'Un espace social, business, creatif et financier pense pour rassembler vos usages dans un seul univers.',
+  },
+} satisfies Record<Exclude<FeedTabId, 'social'>, React.ComponentProps<typeof FeedTabPlaceholder>>;
+
+function FeedHeader({
+  activeTab,
+  searchValue,
+  onSearchChange,
+  onTabPress,
+}: {
+  activeTab: FeedTabId;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
+  onTabPress: (tab: FeedTabId) => void;
+}) {
   return (
-    <ScrollView flex={1} backgroundColor="$background">
-      <YStack flex={1} padding="$5" gap="$4">
-        {/* Header avec titre + accès Profile / Settings */}
-        <XStack alignItems="center" justifyContent="space-between">
-          <Text fontSize={28} fontWeight="700" color="$color">
-            Feed
-          </Text>
+    <YStack backgroundColor="$background" paddingTop="$3" paddingBottom="$2">
+      <XStack alignItems="center" justifyContent="center" paddingHorizontal="$4" height={42}>
+        <TouchableOpacity
+          onPress={() => router.push('/profile')}
+          activeOpacity={0.65}
+          hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+          style={styles.headerSideButton}
+          accessibilityRole="button"
+          accessibilityLabel="Ouvrir mon profil"
+        >
+          <User size={22} color="#FFFFFF" />
+        </TouchableOpacity>
 
-          <XStack gap="$3" alignItems="center">
+        <YStack flex={1} alignItems="center">
+          <Image source={logoSource} style={styles.logo} contentFit="contain" transition={200} />
+        </YStack>
+
+        <TouchableOpacity
+          onPress={() => router.push('/settings')}
+          activeOpacity={0.65}
+          hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+          style={styles.headerSideButton}
+          accessibilityRole="button"
+          accessibilityLabel="Ouvrir les parametres"
+        >
+          <Settings size={22} color="#FFFFFF" />
+        </TouchableOpacity>
+      </XStack>
+
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.tabsContent}
+      >
+        {FEED_TABS.map((tab) => {
+          const isActive = activeTab === tab.id;
+          return (
             <YStack
-              onPress={() => router.push('/search')}
-              pressStyle={{ opacity: 0.6 }}
-              cursor="pointer"
-              padding="$2"
+              key={tab.id}
+              height={36}
+              paddingHorizontal={14}
+              borderRadius={18}
+              backgroundColor={isActive ? '#FFFFFF' : '$surface'}
+              alignItems="center"
+              justifyContent="center"
+              onPress={() => onTabPress(tab.id)}
+              pressStyle={{ scale: 0.97 }}
+              accessibilityRole="button"
+              accessibilityLabel={`Ouvrir l'onglet ${tab.label}`}
             >
-              <Search size={22} color="#FFFFFF" />
+              <Text
+                color={isActive ? '#000000' : '$textSecondary'}
+                fontSize={14}
+                fontWeight={isActive ? '700' : '500'}
+              >
+                {tab.label}
+              </Text>
             </YStack>
+          );
+        })}
+      </ScrollView>
 
-            <YStack
-              onPress={() => router.push('/profile')}
-              pressStyle={{ opacity: 0.6 }}
-              cursor="pointer"
-              padding="$2"
-            >
-              <User size={22} color="#FFFFFF" />
-            </YStack>
-
-            <YStack
-              onPress={() => router.push('/settings')}
-              pressStyle={{ opacity: 0.6 }}
-              cursor="pointer"
-              padding="$2"
-            >
-              <Settings size={22} color="#FFFFFF" />
-            </YStack>
-          </XStack>
-        </XStack>
-
-        <Text fontSize={15} color="$placeholderColor">
-          Welcome to DOUMASSI.
-        </Text>
-      </YStack>
-    </ScrollView>
+      <SearchBar
+        value={searchValue}
+        onChangeText={onSearchChange}
+        placeholder={activeTab === 'social' ? 'Search posts...' : 'Search...'}
+      />
+    </YStack>
   );
 }
+
+function FeedEmptyState() {
+  return (
+    <YStack alignItems="center" justifyContent="center" padding="$6" gap="$3">
+      <Search size={34} color="#A0A0A0" />
+      <Text color="$color" fontSize={17} fontWeight="700" textAlign="center">
+        Suivez des comptes pour voir leurs posts ici
+      </Text>
+      <Button
+        height={42}
+        borderRadius="$lg"
+        backgroundColor="$color"
+        color="$background"
+        fontWeight="700"
+        onPress={() => router.push('/search')}
+        pressStyle={{ opacity: 0.85, scale: 0.98 }}
+      >
+        Decouvrir des comptes
+      </Button>
+    </YStack>
+  );
+}
+
+function FeedFooter({ isFetchingNextPage }: { isFetchingNextPage: boolean }) {
+  if (!isFetchingNextPage) return null;
+
+  return (
+    <YStack paddingVertical="$5" alignItems="center">
+      <Spinner color="$color" />
+    </YStack>
+  );
+}
+
+export function FeedScreen() {
+  const [activeTab, setActiveTab] = useState<FeedTabId>('social');
+  const [searchValue, setSearchValue] = useState('');
+  const scrollOffsets = useRef<Record<FeedTabId, number>>({
+    social: 0,
+    business: 0,
+    ai: 0,
+    wallet: 0,
+    soon: 0,
+  });
+  const socialListRef = useRef<FlashListRef<PostCardPost>>(null);
+  const placeholderScrollRef = useRef<ScrollView>(null);
+
+  const feedQuery = useFeed();
+  const storiesQuery = useFeedStories();
+  const likeMutation = useToggleFeedLike();
+  const bookmarkMutation = useToggleFeedBookmark();
+
+  const posts = useMemo(
+    () => feedQuery.data?.pages.flatMap((page) => page.posts) ?? [],
+    [feedQuery.data]
+  );
+
+  const restoreScroll = useCallback((tab: FeedTabId) => {
+    requestAnimationFrame(() => {
+      const offset = scrollOffsets.current[tab] ?? 0;
+      if (tab === 'social') {
+        socialListRef.current?.scrollToOffset({ offset, animated: false });
+        return;
+      }
+
+      placeholderScrollRef.current?.scrollTo({ y: offset, animated: false });
+    });
+  }, []);
+
+  const handleTabPress = useCallback(
+    (tab: FeedTabId) => {
+      setActiveTab(tab);
+      restoreScroll(tab);
+    },
+    [restoreScroll]
+  );
+
+  const handleSocialScroll = useCallback((event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    scrollOffsets.current.social = event.nativeEvent.contentOffset.y;
+  }, []);
+
+  const handlePlaceholderScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      scrollOffsets.current[activeTab] = event.nativeEvent.contentOffset.y;
+    },
+    [activeTab]
+  );
+
+  const handleStoryPress = useCallback((story: FeedStory) => {
+    router.push(story.isMe ? '/profile' : `/profile/${story.id}`);
+  }, []);
+
+  const renderPost = useCallback(
+    ({ item }: { item: PostCardPost }) => (
+      <PostCard
+        post={item}
+        onLike={() => likeMutation.mutate(item.id)}
+        onBookmark={() => bookmarkMutation.mutate(item.id)}
+        onOpenDetail={() => router.push(`/post/${item.id}`)}
+        onOpenComments={() => router.push(`/post/${item.id}?focus=comments`)}
+        onOpenProfile={() => router.push(`/profile/${item.author_id}`)}
+      />
+    ),
+    [bookmarkMutation, likeMutation]
+  );
+
+  const keyExtractor = useCallback((item: PostCardPost) => item.id, []);
+
+  const socialHeader = (
+    <>
+      <FeedHeader
+        activeTab={activeTab}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        onTabPress={handleTabPress}
+      />
+      <FeedStories stories={storiesQuery.data ?? []} onStoryPress={handleStoryPress} />
+    </>
+  );
+
+  if (activeTab !== 'social') {
+    const placeholder = PLACEHOLDERS[activeTab];
+
+    return (
+      <SafeAreaView style={styles.safeArea} edges={['top']}>
+        <ScrollView
+          ref={placeholderScrollRef}
+          style={styles.screen}
+          contentContainerStyle={styles.placeholderContent}
+          onScroll={handlePlaceholderScroll}
+          scrollEventThrottle={16}
+        >
+          <FeedHeader
+            activeTab={activeTab}
+            searchValue={searchValue}
+            onSearchChange={setSearchValue}
+            onTabPress={handleTabPress}
+          />
+          <FeedTabPlaceholder {...placeholder} />
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
+      <FlashList<PostCardPost>
+        ref={socialListRef}
+        data={posts}
+        renderItem={renderPost}
+        keyExtractor={keyExtractor}
+        ListHeaderComponent={socialHeader}
+        ListEmptyComponent={
+          feedQuery.isLoading ? (
+            <YStack>
+              <PostCardSkeleton />
+              <PostCardSkeleton />
+            </YStack>
+          ) : (
+            <FeedEmptyState />
+          )
+        }
+        ListFooterComponent={<FeedFooter isFetchingNextPage={feedQuery.isFetchingNextPage} />}
+        onEndReached={() => {
+          if (feedQuery.hasNextPage && !feedQuery.isFetchingNextPage) {
+            void feedQuery.fetchNextPage();
+          }
+        }}
+        onEndReachedThreshold={0.8}
+        onRefresh={() => void feedQuery.refetch()}
+        refreshing={feedQuery.isRefetching && !feedQuery.isFetchingNextPage}
+        onScroll={handleSocialScroll}
+        scrollEventThrottle={16}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.listContent}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  headerSideButton: {
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  listContent: {
+    backgroundColor: '#000000',
+    paddingBottom: 32,
+  },
+  logo: {
+    width: 126,
+    height: 30,
+  },
+  placeholderContent: {
+    backgroundColor: '#000000',
+    flexGrow: 1,
+  },
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#000000',
+  },
+  screen: {
+    flex: 1,
+    backgroundColor: '#000000',
+  },
+  tabsContent: {
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingTop: 12,
+    paddingBottom: 10,
+  },
+});


### PR DESCRIPTION
## Ticket lié

Closes #41

## Résumé

Écran Feed à 5 onglets (Social / Business / AI / Wallet / Soon) conforme à la maquette CEO.

- **Tab Social** : vrai feed via `useInfiniteQuery` → RPC `get_feed(p_cursor, p_limit)`, `FlashList` virtualisée, pagination infinie (`onEndReached` 0.8), pull-to-refresh, empty state, skeleton au chargement
- **4 autres tabs** : placeholders `FeedTabPlaceholder` (Business / AI / Wallet / Soon avec manifest)
- **Stories carrousel** : `FeedStories` + hook `useFeedStories` (mon profil + comptes suivis)
- **Header** : logo centré, accès profil/paramètres, 5 tabs scrollables (capsule active), SearchBar
- **Optimistic updates** like/bookmark via `useToggleFeedLike` / `useToggleFeedBookmark`
- Restauration de la position de scroll par onglet

## Notes review

- Branche **rebasée sur `dev` à jour** par le CTO (elle partait d'avant le merge de #172 PostCard → ghost diff écarté).
- 2 commits de correction CTO : accents des textes UI + placeholders SearchBar traduits en français.

## Checklist

- [x] Le code compile et passe le lint local
- [x] Les critères d'acceptation du ticket sont cochés
- [x] FlashList utilisée (pas FlatList) — conforme stack figée
- [x] Aucun console.log oublié

## Limites connues (hors scope de ce ticket)

- Le menu kebab (`onMenuPress`) n'est pas câblé sur les PostCard du feed — sera branché avec #49 (Supprimer) et #50 (Masquer)
- La SearchBar du feed est affichée mais non fonctionnelle — la vraie recherche posts est le ticket #103 (E8-06)
- `hasUnseenStory` hardcodé à `true` — les vraies Stories arrivent Sprint 4
- Pas de tests unitaires sur `useFeed` / `useFeedStories` — dette à couvrir (ticket tech à ouvrir si besoin)

## Comment tester

1. `git checkout feature/E4-01-ecran-feed-5-onglets` + rebuild Dev Build (modules natifs de #172)
2. Onglet Social : scroll du feed, pull-to-refresh, pagination, like/bookmark optimiste
3. Onglets Business/AI/Wallet/Soon : placeholders
4. Tap sur une story → profil