### PR TITLE
feat(feed): écran détail post full-screen TikTok (E4-08)

### DIFF
--- a/app/(feed)/post/[id].tsx
+++ b/app/(feed)/post/[id].tsx
@@ -1,0 +1,516 @@
+import * as Haptics from 'expo-haptics';
+import { Image } from 'expo-image';
+import { router, useLocalSearchParams } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { useVideoPlayer, VideoView } from 'expo-video';
+import { Bookmark, Heart, MessageCircle, Send, X } from 'lucide-react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Animated,
+  Pressable,
+  Share,
+  StyleSheet,
+  Text as RNText,
+  type NativeSyntheticEvent,
+  type TextLayoutEventData,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Text, XStack, YStack } from 'tamagui';
+
+import type { PostCardPost } from '@/components/feed/PostCard';
+import {
+  useIncrementPostShare,
+  usePostDetail,
+  useTogglePostBookmark,
+  useTogglePostLike,
+} from '@/features/feed/hooks/useFeed';
+import { formatViewCount } from '@/utils/formatCount';
+
+const HIT_SLOP = { top: 14, right: 14, bottom: 14, left: 14 };
+const ACTION_RIGHT = 16;
+const ACTION_BOTTOM = 110;
+const ACCENT_NEON = '#10D970';
+const LIKE_RED = '#FF3B30';
+const SCRIM_BANDS = Array.from({ length: 10 }, (_, index) => {
+  const progress = index / 9;
+  return Number((progress * progress * 0.7).toFixed(3));
+});
+
+function formatRelativeTime(value: string) {
+  const createdAt = new Date(value).getTime();
+  if (Number.isNaN(createdAt)) return 'Il y a quelques instants';
+
+  const elapsedMs = Math.max(0, Date.now() - createdAt);
+  const minutes = Math.floor(elapsedMs / 60_000);
+
+  if (minutes < 1) return 'Il y a quelques instants';
+  if (minutes < 60) return `Il y a ${minutes}min`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `Il y a ${hours}h`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `Il y a ${days}j`;
+
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `Il y a ${weeks}sem`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `Il y a ${months}mois`;
+
+  return `Il y a ${Math.floor(days / 365)}an`;
+}
+
+function ActionButton({
+  label,
+  count,
+  children,
+  onPress,
+}: {
+  label: string;
+  count: number;
+  children: React.ReactNode;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      onPress={onPress}
+      hitSlop={HIT_SLOP}
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      style={styles.actionButton}
+    >
+      {children}
+      <Text color="#FFFFFF" fontSize={12} fontWeight="700" marginTop={4} textAlign="center">
+        {formatViewCount(count)}
+      </Text>
+    </Pressable>
+  );
+}
+
+function VideoBackground({ uri }: { uri: string }) {
+  const player = useVideoPlayer(uri, (instance) => {
+    instance.loop = true;
+    instance.muted = true;
+    instance.play();
+  });
+
+  return (
+    <VideoView
+      player={player}
+      style={StyleSheet.absoluteFill}
+      contentFit="cover"
+      nativeControls={false}
+    />
+  );
+}
+
+function PostBackground({ post }: { post: PostCardPost }) {
+  const mediaUrl = post.media_urls[0];
+
+  if (!mediaUrl) {
+    return <View style={styles.emptyBackground} />;
+  }
+
+  if (post.media_type === 'video') {
+    return <VideoBackground uri={mediaUrl} />;
+  }
+
+  return (
+    <Image
+      source={{ uri: mediaUrl }}
+      style={StyleSheet.absoluteFill}
+      contentFit="cover"
+      recyclingKey={`${post.id}-${mediaUrl}`}
+      transition={180}
+    />
+  );
+}
+
+function Avatar({
+  username,
+  avatarUrl,
+  onPress,
+}: {
+  username: string;
+  avatarUrl: string | null;
+  onPress: () => void;
+}) {
+  const initial = username.trim().charAt(0).toUpperCase() || '?';
+
+  return (
+    <Pressable
+      onPress={onPress}
+      hitSlop={HIT_SLOP}
+      accessibilityRole="button"
+      accessibilityLabel={`Voir le profil de @${username}`}
+      style={styles.avatarButton}
+    >
+      {avatarUrl ? (
+        <Image source={{ uri: avatarUrl }} style={styles.avatarImage} contentFit="cover" />
+      ) : (
+        <Text color="#FFFFFF" fontSize={16} fontWeight="700">
+          {initial}
+        </Text>
+      )}
+    </Pressable>
+  );
+}
+
+function BottomScrim() {
+  return (
+    <View pointerEvents="none" style={styles.scrim}>
+      {SCRIM_BANDS.map((opacity) => (
+        <View key={opacity} style={[styles.scrimBand, { opacity }]} />
+      ))}
+    </View>
+  );
+}
+
+function Footer({ post, onOpenProfile }: { post: PostCardPost; onOpenProfile: () => void }) {
+  const [captionTruncated, setCaptionTruncated] = useState(false);
+  const [captionMeasured, setCaptionMeasured] = useState(false);
+  const relativeTime = useMemo(() => formatRelativeTime(post.created_at), [post.created_at]);
+
+  const handleCaptionLayout = useCallback(
+    (event: NativeSyntheticEvent<TextLayoutEventData>) => {
+      if (captionMeasured) return;
+      setCaptionMeasured(true);
+      setCaptionTruncated(event.nativeEvent.lines.length > 3);
+    },
+    [captionMeasured]
+  );
+
+  return (
+    <YStack position="absolute" left={16} right={88} bottom={28} gap={10}>
+      <XStack alignItems="center" gap={10}>
+        <Avatar
+          username={post.author_username}
+          avatarUrl={post.author_avatar_url}
+          onPress={onOpenProfile}
+        />
+
+        <Pressable
+          onPress={onOpenProfile}
+          hitSlop={HIT_SLOP}
+          accessibilityRole="button"
+          accessibilityLabel={`Voir le profil de @${post.author_username}`}
+          style={styles.authorButton}
+        >
+          <Text color="#FFFFFF" fontSize={15} fontWeight="700" numberOfLines={1}>
+            @{post.author_username}
+          </Text>
+          <Text color="rgba(255,255,255,0.78)" fontSize={12} marginTop={2} numberOfLines={1}>
+            {relativeTime}
+          </Text>
+        </Pressable>
+      </XStack>
+
+      {post.content.trim() ? (
+        <YStack>
+          <RNText style={styles.captionText} numberOfLines={3} onTextLayout={handleCaptionLayout}>
+            {post.content}
+          </RNText>
+          {captionTruncated ? <RNText style={styles.moreText}>...plus</RNText> : null}
+        </YStack>
+      ) : null}
+    </YStack>
+  );
+}
+
+function LiveBadge({ visible }: { visible: boolean }) {
+  const opacity = useRef(new Animated.Value(1)).current;
+
+  useEffect(() => {
+    if (!visible) return undefined;
+
+    const animation = Animated.loop(
+      Animated.sequence([
+        Animated.timing(opacity, {
+          toValue: 0.45,
+          duration: 520,
+          useNativeDriver: true,
+        }),
+        Animated.timing(opacity, {
+          toValue: 1,
+          duration: 520,
+          useNativeDriver: true,
+        }),
+      ])
+    );
+
+    animation.start();
+    return () => animation.stop();
+  }, [opacity, visible]);
+
+  if (!visible) return null;
+
+  return (
+    <Animated.View style={[styles.liveBadge, { opacity }]}>
+      <Text color="#FFFFFF" fontSize={12} fontWeight="700">
+        LIVE
+      </Text>
+    </Animated.View>
+  );
+}
+
+function LoadingState() {
+  return (
+    <View style={styles.centerState}>
+      <StatusBar hidden />
+      <ActivityIndicator color="#FFFFFF" size="large" />
+    </View>
+  );
+}
+
+function ErrorState() {
+  return (
+    <YStack flex={1} backgroundColor="#000000" alignItems="center" justifyContent="center" gap={16}>
+      <StatusBar hidden />
+      <Text color="#FFFFFF" fontSize={18} fontWeight="700">
+        Post indisponible
+      </Text>
+      <Button
+        height={44}
+        borderRadius="$lg"
+        backgroundColor="#FFFFFF"
+        color="#000000"
+        fontWeight="700"
+        onPress={() => router.back()}
+        pressStyle={{ opacity: 0.86, scale: 0.98 }}
+      >
+        Retour
+      </Button>
+    </YStack>
+  );
+}
+
+export default function PostDetailRoute() {
+  const params = useLocalSearchParams<{ id?: string }>();
+  const postId = typeof params.id === 'string' ? params.id : undefined;
+  const insets = useSafeAreaInsets();
+  const [overlaysVisible, setOverlaysVisible] = useState(true);
+
+  const postQuery = usePostDetail(postId);
+  const likeMutation = useTogglePostLike(postId ?? '');
+  const bookmarkMutation = useTogglePostBookmark(postId ?? '');
+  const shareMutation = useIncrementPostShare(postId ?? '');
+
+  const post = postQuery.data;
+
+  const handleToggleOverlays = useCallback(() => {
+    setOverlaysVisible((current) => !current);
+  }, []);
+
+  const handleLike = useCallback(() => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    likeMutation.mutate();
+  }, [likeMutation]);
+
+  const handleBookmark = useCallback(() => {
+    void Haptics.selectionAsync();
+    bookmarkMutation.mutate();
+  }, [bookmarkMutation]);
+
+  const handleComments = useCallback(() => {
+    Alert.alert('Bientôt disponible', 'Les commentaires arrivent bientôt.');
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    if (!post) return;
+
+    try {
+      const result = await Share.share({
+        message: post.content.trim()
+          ? `${post.content}\n\ndoumassi://post/${post.id}`
+          : `doumassi://post/${post.id}`,
+      });
+
+      if (result.action === Share.sharedAction) {
+        shareMutation.mutate();
+      }
+    } catch {
+      Alert.alert('Partage indisponible', 'Impossible d’ouvrir le partage pour le moment.');
+    }
+  }, [post, shareMutation]);
+
+  const handleOpenProfile = useCallback(() => {
+    if (!post) return;
+    router.push(`/profile/${post.author_id}`);
+  }, [post]);
+
+  if (postQuery.isLoading) {
+    return <LoadingState />;
+  }
+
+  if (postQuery.isError || !post) {
+    return <ErrorState />;
+  }
+
+  const isLive = Boolean((post as PostCardPost & { is_live?: boolean }).is_live);
+
+  return (
+    <View style={styles.screen}>
+      <StatusBar hidden />
+      <Pressable
+        onPress={handleToggleOverlays}
+        onLongPress={() => {}}
+        delayLongPress={240}
+        style={StyleSheet.absoluteFill}
+        accessibilityRole="button"
+        accessibilityLabel="Afficher ou masquer les contrôles du post"
+      >
+        <PostBackground post={post} />
+      </Pressable>
+
+      {overlaysVisible ? (
+        <>
+          <BottomScrim />
+          <LiveBadge visible={isLive} />
+
+          <Pressable
+            onPress={() => router.back()}
+            hitSlop={HIT_SLOP}
+            accessibilityRole="button"
+            accessibilityLabel="Fermer le post"
+            style={[styles.closeButton, { top: insets.top + 12 }]}
+          >
+            <X size={24} color="#FFFFFF" strokeWidth={2.5} />
+          </Pressable>
+
+          <YStack position="absolute" right={ACTION_RIGHT} bottom={ACTION_BOTTOM} gap={24}>
+            <ActionButton
+              label={`Aimer le post de @${post.author_username}`}
+              count={post.like_count}
+              onPress={handleLike}
+            >
+              <Animated.View>
+                <Heart
+                  size={32}
+                  color={post.liked_by_me ? LIKE_RED : '#FFFFFF'}
+                  fill={post.liked_by_me ? LIKE_RED : 'transparent'}
+                />
+              </Animated.View>
+            </ActionButton>
+
+            <ActionButton
+              label={`Commenter le post de @${post.author_username}`}
+              count={post.comment_count}
+              onPress={handleComments}
+            >
+              <MessageCircle size={32} color="#FFFFFF" />
+            </ActionButton>
+
+            <ActionButton
+              label={`Partager le post de @${post.author_username}`}
+              count={post.share_count}
+              onPress={() => void handleShare()}
+            >
+              <Send size={32} color="#FFFFFF" />
+            </ActionButton>
+
+            <ActionButton
+              label={`Sauvegarder le post de @${post.author_username}`}
+              count={post.bookmark_count}
+              onPress={handleBookmark}
+            >
+              <Bookmark
+                size={32}
+                color={post.bookmarked_by_me ? ACCENT_NEON : '#FFFFFF'}
+                fill={post.bookmarked_by_me ? ACCENT_NEON : 'transparent'}
+              />
+            </ActionButton>
+          </YStack>
+
+          <Footer post={post} onOpenProfile={handleOpenProfile} />
+        </>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  actionButton: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 52,
+    minWidth: 48,
+  },
+  authorButton: {
+    flexShrink: 1,
+    minWidth: 0,
+  },
+  avatarButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    alignItems: 'center',
+    justifyContent: 'center',
+    overflow: 'hidden',
+  },
+  avatarImage: {
+    width: 40,
+    height: 40,
+  },
+  captionText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    lineHeight: 19,
+    fontWeight: '400',
+  },
+  centerState: {
+    flex: 1,
+    backgroundColor: '#000000',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButton: {
+    position: 'absolute',
+    right: 16,
+    width: 44,
+    height: 44,
+    borderRadius: 999,
+    backgroundColor: 'rgba(0,0,0,0.4)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  emptyBackground: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: '#000000',
+  },
+  liveBadge: {
+    position: 'absolute',
+    top: 54,
+    left: 16,
+    borderRadius: 999,
+    backgroundColor: '#FF2D55',
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  moreText: {
+    color: '#FFFFFF',
+    fontSize: 14,
+    lineHeight: 19,
+    fontWeight: '700',
+    marginTop: 1,
+  },
+  screen: {
+    flex: 1,
+    backgroundColor: '#000000',
+  },
+  scrim: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    bottom: 0,
+    height: 260,
+  },
+  scrimBand: {
+    flex: 1,
+    backgroundColor: '#000000',
+  },
+});

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -332,8 +332,10 @@ export const PostCard = memo(function PostCard({
     }
 
     try {
-      await Share.share({ message: `doumassi://post/${post.id}` });
-      await supabase.rpc('increment_share_count', { p_post_id: post.id });
+      const result = await Share.share({ message: `doumassi://post/${post.id}` });
+      if (result.action === Share.sharedAction) {
+        await supabase.rpc('increment_share_count', { p_post_id: post.id });
+      }
     } catch {
       // Annulation par l'utilisateur ou erreur native : le caller peut passer
       // onShare pour gérer l'état lui-même.

--- a/src/features/feed/hooks/useFeed.ts
+++ b/src/features/feed/hooks/useFeed.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { PostCardPost } from '@/components/feed/PostCard';
 import { logger } from '@/lib/logger';
@@ -9,6 +9,13 @@ const PAGE_SIZE = 20;
 type FeedRpcRow = PostCardPost & {
   media_type: 'text' | 'image' | 'video' | string;
 };
+
+type FeedQueryData = {
+  pages: { posts: PostCardPost[]; nextCursor: string | null }[];
+  pageParams: unknown[];
+};
+
+const FEED_QUERY_KEY = ['feed', 'social', 'foryou'] as const;
 
 function mapFeedPost(row: FeedRpcRow): PostCardPost {
   return {
@@ -34,6 +41,24 @@ function mapFeedPost(row: FeedRpcRow): PostCardPost {
   };
 }
 
+function updateFeedPost(
+  queryClient: ReturnType<typeof useQueryClient>,
+  postId: string,
+  updater: (post: PostCardPost) => PostCardPost
+) {
+  queryClient.setQueryData<FeedQueryData>(FEED_QUERY_KEY, (old) => {
+    if (!old) return old;
+
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        posts: page.posts.map((post) => (post.id === postId ? updater(post) : post)),
+      })),
+    };
+  });
+}
+
 async function fetchFeedPage(cursor: string | null) {
   const { data, error } = await supabase.rpc('get_feed', {
     p_cursor: cursor,
@@ -54,10 +79,32 @@ async function fetchFeedPage(cursor: string | null) {
 
 export function useFeed() {
   return useInfiniteQuery({
-    queryKey: ['feed', 'social', 'foryou'],
+    queryKey: FEED_QUERY_KEY,
     queryFn: ({ pageParam }) => fetchFeedPage(pageParam),
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
+  });
+}
+
+export function usePostDetail(postId: string | undefined) {
+  return useQuery({
+    queryKey: ['post', postId],
+    enabled: Boolean(postId),
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc('get_post_with_counts', {
+        p_post_id: postId,
+      });
+
+      if (error) {
+        logger.warn('get_post_with_counts failed', { message: error.message, postId });
+        throw error;
+      }
+
+      const row = Array.isArray(data) ? data[0] : data;
+      if (!row) return null;
+
+      return mapFeedPost(row as FeedRpcRow);
+    },
   });
 }
 
@@ -71,42 +118,25 @@ export function useToggleFeedLike() {
       return { postId, liked: Boolean(data) };
     },
     onMutate: async (postId) => {
-      const queryKey = ['feed', 'social', 'foryou'];
-      await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData(queryKey);
+      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
+      const previous = queryClient.getQueryData(FEED_QUERY_KEY);
 
-      queryClient.setQueryData<ReturnType<typeof useFeed>['data']>(queryKey, (old) => {
-        if (!old) return old;
-
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            posts: page.posts.map((post) =>
-              post.id === postId
-                ? {
-                    ...post,
-                    liked_by_me: !post.liked_by_me,
-                    like_count: post.liked_by_me
-                      ? Math.max(0, post.like_count - 1)
-                      : post.like_count + 1,
-                  }
-                : post
-            ),
-          })),
-        };
-      });
+      updateFeedPost(queryClient, postId, (post) => ({
+        ...post,
+        liked_by_me: !post.liked_by_me,
+        like_count: post.liked_by_me ? Math.max(0, post.like_count - 1) : post.like_count + 1,
+      }));
 
       return { previous };
     },
     onError: (error, _postId, context) => {
       logger.warn('toggle_like failed', { message: error.message });
       if (context?.previous) {
-        queryClient.setQueryData(['feed', 'social', 'foryou'], context.previous);
+        queryClient.setQueryData(FEED_QUERY_KEY, context.previous);
       }
     },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: ['feed', 'social', 'foryou'] });
+      void queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
     },
   });
 }
@@ -121,45 +151,152 @@ export function useToggleFeedBookmark() {
       return { postId, bookmarked: Boolean(data) };
     },
     onMutate: async (postId) => {
-      const queryKey = ['feed', 'social', 'foryou'];
-      await queryClient.cancelQueries({ queryKey });
-      const previous = queryClient.getQueryData(queryKey);
+      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
+      const previous = queryClient.getQueryData(FEED_QUERY_KEY);
 
-      queryClient.setQueryData<ReturnType<typeof useFeed>['data']>(queryKey, (old) => {
-        if (!old) return old;
-
-        return {
-          ...old,
-          pages: old.pages.map((page) => ({
-            ...page,
-            posts: page.posts.map((post) =>
-              post.id === postId
-                ? {
-                    ...post,
-                    bookmarked_by_me: !post.bookmarked_by_me,
-                    bookmark_count: post.bookmarked_by_me
-                      ? Math.max(0, post.bookmark_count - 1)
-                      : post.bookmark_count + 1,
-                  }
-                : post
-            ),
-          })),
-        };
-      });
+      updateFeedPost(queryClient, postId, (post) => ({
+        ...post,
+        bookmarked_by_me: !post.bookmarked_by_me,
+        bookmark_count: post.bookmarked_by_me
+          ? Math.max(0, post.bookmark_count - 1)
+          : post.bookmark_count + 1,
+      }));
 
       return { previous };
     },
     onError: (error, _postId, context) => {
       logger.warn('toggle_bookmark failed', { message: error.message });
       if (context?.previous) {
-        queryClient.setQueryData(['feed', 'social', 'foryou'], context.previous);
+        queryClient.setQueryData(FEED_QUERY_KEY, context.previous);
       }
     },
     onSettled: () => {
-      void queryClient.invalidateQueries({ queryKey: ['feed', 'social', 'foryou'] });
+      void queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
       // E4-07 : un un-bookmark depuis le feed (ou l'écran /bookmarks lui-même)
       // doit aussi rafraîchir la liste des sauvegardés.
       void queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
+    },
+  });
+}
+
+export function useTogglePostLike(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.rpc('toggle_like', { p_post_id: postId });
+      if (error) throw error;
+      return Boolean(data);
+    },
+    onMutate: async () => {
+      const queryKey = ['post', postId];
+      await queryClient.cancelQueries({ queryKey });
+      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
+      const previousPost = queryClient.getQueryData<PostCardPost | null>(queryKey);
+      const previousFeed = queryClient.getQueryData(FEED_QUERY_KEY);
+
+      const updater = (post: PostCardPost) => ({
+        ...post,
+        liked_by_me: !post.liked_by_me,
+        like_count: post.liked_by_me ? Math.max(0, post.like_count - 1) : post.like_count + 1,
+      });
+
+      queryClient.setQueryData<PostCardPost | null>(queryKey, (old) => (old ? updater(old) : old));
+      updateFeedPost(queryClient, postId, updater);
+
+      return { previousPost, previousFeed };
+    },
+    onError: (error, _variables, context) => {
+      logger.warn('toggle_like detail failed', { message: error.message, postId });
+      queryClient.setQueryData(['post', postId], context?.previousPost);
+      queryClient.setQueryData(FEED_QUERY_KEY, context?.previousFeed);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['post', postId] });
+      void queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
+    },
+  });
+}
+
+export function useTogglePostBookmark(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.rpc('toggle_bookmark', { p_post_id: postId });
+      if (error) throw error;
+      return Boolean(data);
+    },
+    onMutate: async () => {
+      const queryKey = ['post', postId];
+      await queryClient.cancelQueries({ queryKey });
+      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
+      const previousPost = queryClient.getQueryData<PostCardPost | null>(queryKey);
+      const previousFeed = queryClient.getQueryData(FEED_QUERY_KEY);
+
+      const updater = (post: PostCardPost) => ({
+        ...post,
+        bookmarked_by_me: !post.bookmarked_by_me,
+        bookmark_count: post.bookmarked_by_me
+          ? Math.max(0, post.bookmark_count - 1)
+          : post.bookmark_count + 1,
+      });
+
+      queryClient.setQueryData<PostCardPost | null>(queryKey, (old) => (old ? updater(old) : old));
+      updateFeedPost(queryClient, postId, updater);
+
+      return { previousPost, previousFeed };
+    },
+    onError: (error, _variables, context) => {
+      logger.warn('toggle_bookmark detail failed', { message: error.message, postId });
+      queryClient.setQueryData(['post', postId], context?.previousPost);
+      queryClient.setQueryData(FEED_QUERY_KEY, context?.previousFeed);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['post', postId] });
+      void queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
+    },
+  });
+}
+
+export function useIncrementPostShare(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async () => {
+      const { data, error } = await supabase.rpc('increment_share_count', { p_post_id: postId });
+      if (error) throw error;
+      return Number(data ?? 0);
+    },
+    onMutate: async () => {
+      const queryKey = ['post', postId];
+      await queryClient.cancelQueries({ queryKey });
+      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
+      const previousPost = queryClient.getQueryData<PostCardPost | null>(queryKey);
+      const previousFeed = queryClient.getQueryData(FEED_QUERY_KEY);
+
+      const updater = (post: PostCardPost) => ({
+        ...post,
+        share_count: post.share_count + 1,
+      });
+
+      queryClient.setQueryData<PostCardPost | null>(queryKey, (old) => (old ? updater(old) : old));
+      updateFeedPost(queryClient, postId, updater);
+
+      return { previousPost, previousFeed };
+    },
+    onError: (error, _variables, context) => {
+      logger.warn('increment_share_count detail failed', { message: error.message, postId });
+      queryClient.setQueryData(['post', postId], context?.previousPost);
+      queryClient.setQueryData(FEED_QUERY_KEY, context?.previousFeed);
+    },
+    onSuccess: (shareCount) => {
+      if (!shareCount) return;
+      const updater = (post: PostCardPost) => ({ ...post, share_count: shareCount });
+      queryClient.setQueryData<PostCardPost | null>(['post', postId], (old) =>
+        old ? updater(old) : old
+      );
+      updateFeedPost(queryClient, postId, updater);
     },
   });
 }


### PR DESCRIPTION
## Ticket lié

Closes #48

## Résumé

Écran détail post en mode TikTok full-screen.

- Route `app/(feed)/post/[id].tsx` — plein écran, sans header ni TabBar
- Background image (`expo-image`) ou vidéo (`expo-video`, loop + muted + autoplay)
- Tap sur la zone vide → toggle visibilité des overlays
- Bouton X (halo sombre) en haut à droite
- Overlay actions vertical à droite : Like / Comment / Share / Bookmark avec compteurs
- Footer : avatar + @username + temps relatif + caption (3 lignes max + « ...plus »)
- Gradient bas simulé en 10 bandes à opacité quadratique (pas de dépendance `expo-linear-gradient`)
- `LiveBadge` clignotant — placeholder, `is_live` pas encore en BDD
- Loading state (spinner) + error state (« Post indisponible » + Retour)

## Hooks ajoutés (`useFeed.ts`)

- `usePostDetail` → `get_post_with_counts`
- `useTogglePostLike` / `useTogglePostBookmark` / `useIncrementPostShare` — optimistic update sur le cache `['post', id]` **et** le cache feed (cohérence détail ↔ feed)
- Refactor : extraction de `FEED_QUERY_KEY` + helper `updateFeedPost` (factorise les updates optimistes)

## Notes review CTO

- Branche **rebasée sur `dev`** par le CTO (elle partait d'avant le merge #177). Conflit sur `useToggleFeedBookmark.onSettled` résolu en conservant **les deux** invalidations : `FEED_QUERY_KEY` (refactor #176) + `['bookmarks']` (#177).
- `handleShare` incrémente `share_count` seulement sur `Share.sharedAction` (pas sur dismiss).
- `PostCard.handleShare` aligné sur le même check.

## Checklist

- [x] Le code compile et passe le lint local
- [x] Les critères d'acceptation du ticket sont cochés
- [x] Aucun console.log oublié

## Comment tester

1. `git checkout` cette branche + rebuild Dev Build
2. Feed → tap sur l'image d'un post → détail TikTok plein écran
3. Like / bookmark / share (vérifier l'optimistic + la cohérence avec le feed au retour)
4. Tap zone vide → overlays toggle
5. Post avec vidéo → lecture auto en boucle