### PR TITLE
feat(feed): écran /bookmarks + correction RPC get_bookmarks (E4-07)

### DIFF
--- a/app/(feed)/bookmarks.tsx
+++ b/app/(feed)/bookmarks.tsx
@@ -1,0 +1,8 @@
+// Route /bookmarks (groupe (feed)) — E4-07.
+// Hors TabBar : push depuis le profil (kebab menu).
+
+import { BookmarksScreen } from '@/features/feed/screens/BookmarksScreen';
+
+export default function BookmarksRoute() {
+  return <BookmarksScreen />;
+}

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -8,7 +8,6 @@ import {
   Share,
   StyleSheet,
   Text as RNText,
-  type LayoutChangeEvent,
   type NativeSyntheticEvent,
   type TextLayoutEventData,
 } from 'react-native';
@@ -289,7 +288,6 @@ export const PostCard = memo(function PostCard({
 }: PostCardProps) {
   const likeScale = useRef(new Animated.Value(1)).current;
   const bookmarkSpin = useRef(new Animated.Value(0)).current;
-  const [contentWidth, setContentWidth] = useState(0);
 
   useEffect(() => {
     bookmarkSpin.setValue(0);
@@ -347,10 +345,6 @@ export const PostCard = memo(function PostCard({
     outputRange: ['0deg', '360deg'],
   });
 
-  const onCardLayout = useCallback((event: LayoutChangeEvent) => {
-    setContentWidth(event.nativeEvent.layout.width);
-  }, []);
-
   if (!hasContent && !hasMedia) return null;
 
   if (variant === 'thumbnail') {
@@ -366,7 +360,6 @@ export const PostCard = memo(function PostCard({
       borderBottomWidth={StyleSheet.hairlineWidth}
       borderBottomColor="$borderColor"
       backgroundColor="$background"
-      onLayout={onCardLayout}
     >
       <XStack alignItems="center" gap={10}>
         <Avatar
@@ -412,7 +405,7 @@ export const PostCard = memo(function PostCard({
       </YStack>
 
       {variant === 'detail' ? null : (
-        <XStack alignItems="center" gap={20} marginTop={12} width={contentWidth || undefined}>
+        <XStack alignItems="center" gap={20} marginTop={12} width="100%">
           <CountAction
             label={`Aimer le post de @${post.author_username}`}
             count={post.like_count}

--- a/src/features/feed/hooks/useBookmarks.ts
+++ b/src/features/feed/hooks/useBookmarks.ts
@@ -1,0 +1,74 @@
+// E4-07 — Liste paginée des posts bookmarkés par l'user courant.
+// Mêmes choix que useFeed (cf. ./useFeed.ts) :
+//   - cursor pagination via RPC get_bookmarks(p_cursor, p_limit)
+//   - mapping RPC row → PostCardPost (on ignore location/view_count, non
+//     affichés par PostCard)
+//   - logger.warn sur échec (Sentry breadcrumb)
+// Le cursor est `bookmarked_at` (= b.created_at), pas `created_at` du post.
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import type { PostCardPost } from '@/components/feed/PostCard';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+const PAGE_SIZE = 20;
+const STALE_TIME_MS = 30_000;
+
+type BookmarksRpcRow = PostCardPost & {
+  bookmarked_at: string;
+  media_type: 'text' | 'image' | 'video' | string;
+};
+
+function mapBookmarkRow(row: BookmarksRpcRow): PostCardPost {
+  return {
+    id: row.id,
+    author_id: row.author_id,
+    author_username: row.author_username,
+    author_full_name: row.author_full_name,
+    author_avatar_url: row.author_avatar_url,
+    author_is_verified: row.author_is_verified,
+    content: row.content ?? '',
+    media_urls: Array.isArray(row.media_urls) ? row.media_urls : [],
+    media_type:
+      row.media_type === 'image' || row.media_type === 'video' || row.media_type === 'text'
+        ? row.media_type
+        : 'text',
+    created_at: row.created_at,
+    like_count: row.like_count ?? 0,
+    comment_count: row.comment_count ?? 0,
+    share_count: row.share_count ?? 0,
+    bookmark_count: row.bookmark_count ?? 0,
+    liked_by_me: row.liked_by_me ?? false,
+    bookmarked_by_me: row.bookmarked_by_me ?? true,
+  };
+}
+
+async function fetchBookmarksPage(cursor: string | null) {
+  const { data, error } = await supabase.rpc('get_bookmarks', {
+    p_cursor: cursor,
+    p_limit: PAGE_SIZE,
+  });
+
+  if (error) {
+    logger.warn('get_bookmarks failed', { message: error.message });
+    throw error;
+  }
+
+  const rows = (data ?? []) as BookmarksRpcRow[];
+  const posts = rows.map(mapBookmarkRow);
+  const lastRow = rows[rows.length - 1];
+  const nextCursor = posts.length === PAGE_SIZE && lastRow ? lastRow.bookmarked_at : null;
+
+  return { posts, nextCursor };
+}
+
+export function useBookmarks() {
+  return useInfiniteQuery({
+    queryKey: ['bookmarks'],
+    queryFn: ({ pageParam }) => fetchBookmarksPage(pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    staleTime: STALE_TIME_MS,
+  });
+}

--- a/src/features/feed/hooks/useFeed.ts
+++ b/src/features/feed/hooks/useFeed.ts
@@ -157,6 +157,9 @@ export function useToggleFeedBookmark() {
     },
     onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: ['feed', 'social', 'foryou'] });
+      // E4-07 : un un-bookmark depuis le feed (ou l'écran /bookmarks lui-même)
+      // doit aussi rafraîchir la liste des sauvegardés.
+      void queryClient.invalidateQueries({ queryKey: ['bookmarks'] });
     },
   });
 }

--- a/src/features/feed/screens/BookmarksScreen.tsx
+++ b/src/features/feed/screens/BookmarksScreen.tsx
@@ -1,0 +1,131 @@
+// E4-07 — Écran /bookmarks : liste paginée des posts sauvegardés par l'user.
+// Réutilise PostCard (E4-02) ; les actions like / bookmark passent par
+// useToggleFeedLike / useToggleFeedBookmark (cf. useFeed.ts), qui font
+// déjà l'update optimiste — et qui invalident ['bookmarks'] pour que
+// l'écran se rafraîchisse quand on un-bookmark un post depuis ici.
+
+import { FlashList } from '@shopify/flash-list';
+import { router } from 'expo-router';
+import { ArrowLeft, Bookmark } from 'lucide-react-native';
+import { useCallback } from 'react';
+import { StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { Spinner, Text, XStack, YStack } from 'tamagui';
+
+import { PostCard, PostCardSkeleton, type PostCardPost } from '@/components/feed/PostCard';
+import { useBookmarks } from '@/features/feed/hooks/useBookmarks';
+import { useToggleFeedBookmark, useToggleFeedLike } from '@/features/feed/hooks/useFeed';
+
+function BookmarksHeader() {
+  return (
+    <XStack
+      alignItems="center"
+      paddingHorizontal="$3"
+      paddingVertical="$2"
+      borderBottomWidth={StyleSheet.hairlineWidth}
+      borderBottomColor="$borderColor"
+    >
+      <YStack
+        onPress={() => router.back()}
+        pressStyle={{ opacity: 0.6 }}
+        padding="$2"
+        width={40}
+        accessibilityRole="button"
+        accessibilityLabel="Retour"
+      >
+        <ArrowLeft size={24} color="#FFFFFF" />
+      </YStack>
+      <Text flex={1} textAlign="center" color="$color" fontSize={17} fontWeight="700">
+        Sauvegardés
+      </Text>
+      {/* spacer pour centrer le titre malgré le bouton retour à gauche */}
+      <YStack width={40} />
+    </XStack>
+  );
+}
+
+function BookmarksEmptyState() {
+  return (
+    <YStack alignItems="center" justifyContent="center" padding="$6" gap="$3" marginTop="$10">
+      <Bookmark size={40} color="#A0A0A0" />
+      <Text color="$color" fontSize={17} fontWeight="700" textAlign="center">
+        Vous n’avez encore rien sauvegardé
+      </Text>
+      <Text color="$textSecondary" fontSize={14} textAlign="center" maxWidth={280}>
+        Tap sur le marque-page d’un post pour le retrouver ici
+      </Text>
+    </YStack>
+  );
+}
+
+function BookmarksFooter({ isFetchingNextPage }: { isFetchingNextPage: boolean }) {
+  if (!isFetchingNextPage) return null;
+  return (
+    <YStack paddingVertical="$5" alignItems="center">
+      <Spinner color="$color" />
+    </YStack>
+  );
+}
+
+export function BookmarksScreen() {
+  const bookmarksQuery = useBookmarks();
+  const likeMutation = useToggleFeedLike();
+  const bookmarkMutation = useToggleFeedBookmark();
+
+  const posts = bookmarksQuery.data?.pages.flatMap((page) => page.posts) ?? [];
+
+  const renderPost = useCallback(
+    ({ item }: { item: PostCardPost }) => (
+      <PostCard
+        post={item}
+        onLike={() => likeMutation.mutate(item.id)}
+        onBookmark={() => bookmarkMutation.mutate(item.id)}
+        onOpenDetail={() => router.push(`/post/${item.id}`)}
+        onOpenComments={() => router.push(`/post/${item.id}?focus=comments`)}
+        onOpenProfile={() => router.push(`/profile/${item.author_id}`)}
+      />
+    ),
+    [bookmarkMutation, likeMutation]
+  );
+
+  const keyExtractor = useCallback((item: PostCardPost) => item.id, []);
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <BookmarksHeader />
+      <FlashList<PostCardPost>
+        data={posts}
+        renderItem={renderPost}
+        keyExtractor={keyExtractor}
+        ListEmptyComponent={
+          bookmarksQuery.isLoading ? (
+            <YStack>
+              <PostCardSkeleton />
+              <PostCardSkeleton />
+            </YStack>
+          ) : (
+            <BookmarksEmptyState />
+          )
+        }
+        ListFooterComponent={
+          <BookmarksFooter isFetchingNextPage={bookmarksQuery.isFetchingNextPage} />
+        }
+        onEndReached={() => {
+          if (bookmarksQuery.hasNextPage && !bookmarksQuery.isFetchingNextPage) {
+            void bookmarksQuery.fetchNextPage();
+          }
+        }}
+        onEndReachedThreshold={0.8}
+        onRefresh={() => void bookmarksQuery.refetch()}
+        refreshing={bookmarksQuery.isRefetching && !bookmarksQuery.isFetchingNextPage}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.listContent}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#000000' },
+  listContent: { backgroundColor: '#000000', paddingBottom: 32 },
+});

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -6,7 +6,7 @@
 
 import { FlashList } from '@shopify/flash-list';
 import { router } from 'expo-router';
-import { Settings, Share2 } from 'lucide-react-native';
+import { Bookmark, Settings, Share2 } from 'lucide-react-native';
 import { useCallback, useState } from 'react';
 import { Share, StyleSheet, useWindowDimensions } from 'react-native';
 import { Button, Sheet, Text, XStack, YStack } from 'tamagui';
@@ -54,6 +54,13 @@ export function ProfileScreen() {
   const handleMenuSettings = useCallback(() => {
     setIsMenuOpen(false);
     router.push('/settings');
+  }, []);
+
+  // E4-07 : raccourci kebab → /bookmarks (visible uniquement sur mon profil,
+  // ProfileScreen étant le rendu du profil personnel).
+  const handleMenuBookmarks = useCallback(() => {
+    setIsMenuOpen(false);
+    router.push('/bookmarks');
   }, []);
 
   const handleMenuShare = useCallback(() => {
@@ -220,6 +227,21 @@ export function ProfileScreen() {
             >
               <Text color="$color" fontSize={15} fontWeight="500">
                 {copy.kebabMenu.settings}
+              </Text>
+            </Button>
+
+            <Button
+              backgroundColor="transparent"
+              height={48}
+              justifyContent="flex-start"
+              paddingHorizontal="$3"
+              onPress={handleMenuBookmarks}
+              pressStyle={{ backgroundColor: '$surfaceElevated' }}
+              borderRadius="$md"
+              icon={<Bookmark size={20} color="#FFFFFF" />}
+            >
+              <Text color="$color" fontSize={15} fontWeight="500">
+                Sauvegardés
               </Text>
             </Button>
 

--- a/supabase/migrations/20260521090000_get_bookmarks_rpc.sql
+++ b/supabase/migrations/20260521090000_get_bookmarks_rpc.sql
@@ -1,0 +1,79 @@
+-- E4-07 — RPC get_bookmarks : liste paginée des posts bookmarkés par l'user
+-- courant, ordonnée par date de bookmark (b.created_at) décroissante.
+--
+-- Le cursor du ticket est `b.created_at` (≠ `p.created_at`) — bookmarker un
+-- vieux post le place en tête de la liste. On expose donc `bookmarked_at`
+-- dans le retour pour que le caller (useInfiniteQuery, cf.
+-- src/features/feed/hooks/useBookmarks.ts) puisse calculer la page suivante.
+--
+-- Visibilité : on réutilise can_view_post(author_id) (cf.
+-- 20260514120000_rls_private_profiles_posts.sql) pour ne pas exposer un
+-- post devenu non visible (compte passé en privé, bloqué, etc.) — la RPC
+-- est SECURITY DEFINER, donc on ne court-circuite pas la RLS posts SELECT
+-- par mégarde.
+
+create or replace function public.get_bookmarks(
+  p_cursor timestamptz default null,
+  p_limit int default 20
+)
+returns table (
+  id uuid,
+  author_id uuid,
+  author_username text,
+  author_full_name text,
+  author_avatar_url text,
+  author_is_verified boolean,
+  content text,
+  media_urls text[],
+  media_type text,
+  location text,
+  created_at timestamptz,
+  bookmarked_at timestamptz,
+  like_count int,
+  comment_count int,
+  share_count int,
+  bookmark_count int,
+  view_count int,
+  liked_by_me boolean,
+  bookmarked_by_me boolean
+)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select
+    p.id,
+    p.author_id,
+    pr.username,
+    pr.full_name,
+    pr.avatar_url,
+    coalesce(pr.is_verified, false),
+    p.content,
+    p.media_urls,
+    p.media_type,
+    p.location,
+    p.created_at,
+    b.created_at as bookmarked_at,
+    p.like_count,
+    p.comment_count,
+    p.share_count,
+    p.bookmark_count,
+    p.view_count,
+    exists (
+      select 1 from public.likes l
+      where l.post_id = p.id and l.user_id = auth.uid()
+    ),
+    true as bookmarked_by_me
+  from public.bookmarks b
+  join public.posts p on p.id = b.post_id
+  join public.profiles pr on pr.id = p.author_id
+  where b.user_id = auth.uid()
+    and p.deleted_at is null
+    and public.can_view_post(p.author_id)
+    and (p_cursor is null or b.created_at < p_cursor)
+  order by b.created_at desc
+  limit p_limit;
+$$;
+
+grant execute on function public.get_bookmarks(timestamptz, int) to authenticated;

--- a/supabase/migrations/20260521133000_get_bookmarks_add_bookmarked_at.sql
+++ b/supabase/migrations/20260521133000_get_bookmarks_add_bookmarked_at.sql
@@ -1,18 +1,25 @@
--- E4-07 — RPC get_bookmarks : liste paginée des posts bookmarkés par l'user
--- courant, ordonnée par date de bookmark (b.created_at) décroissante.
+-- E4-07 — Correction de get_bookmarks : ajout de bookmarked_at au retour.
 --
--- Le cursor du ticket est `b.created_at` (≠ `p.created_at`) — bookmarker un
--- vieux post le place en tête de la liste. On expose donc `bookmarked_at`
--- dans le retour pour que le caller (useInfiniteQuery, cf.
--- src/features/feed/hooks/useBookmarks.ts) puisse calculer la page suivante.
+-- La version initiale (20260521120000_get_bookmarks_rpc.sql) ordonnait par
+-- date de bookmark (b.created_at) mais ne la retournait pas → le
+-- useInfiniteQuery ne pouvait pas calculer le curseur de la page suivante
+-- (pagination cassée au-delà de 20 posts).
+--
+-- On expose donc `bookmarked_at` (= b.created_at) dans le retour. Le
+-- RETURNS TABLE change de signature → DROP + CREATE obligatoire
+-- (`create or replace` refuse un changement de type de retour).
 --
 -- Visibilité : on réutilise can_view_post(author_id) (cf.
 -- 20260514120000_rls_private_profiles_posts.sql) pour ne pas exposer un
 -- post devenu non visible (compte passé en privé, bloqué, etc.) — la RPC
--- est SECURITY DEFINER, donc on ne court-circuite pas la RLS posts SELECT
--- par mégarde.
+-- est SECURITY DEFINER, donc on ne court-circuite pas la RLS posts SELECT.
+--
+-- Appliqué via AI Supabase (DROP + CREATE) sur dev + staging le 21 mai 2026
+-- (migration get_bookmarks_add_bookmarked_at).
 
-create or replace function public.get_bookmarks(
+drop function if exists public.get_bookmarks(timestamptz, int);
+
+create function public.get_bookmarks(
   p_cursor timestamptz default null,
   p_limit int default 20
 )


### PR DESCRIPTION
## Ticket lié

Closes #47

## Résumé

Écran `/bookmarks` — liste paginée des posts sauvegardés par l'utilisateur.

- Route `app/(feed)/bookmarks.tsx` (hors TabBar, ouverte via push)
- `BookmarksScreen` : `FlashList` virtualisée, pull-to-refresh, pagination infinie, empty state, skeleton au chargement
- Hook `useBookmarks` : `useInfiniteQuery` sur la RPC `get_bookmarks`, curseur sur `bookmarked_at`
- Accès depuis le menu kebab du profil personnel (entrée « Sauvegardés »)
- Réutilise `PostCard` + `useToggleFeedLike` / `useToggleFeedBookmark`

## Correction de la RPC `get_bookmarks`

La version initiale (`20260521120000`, livrée via #175) ordonnait par date de bookmark mais ne la **retournait pas** → le `useInfiniteQuery` ne pouvait pas calculer le curseur de la page suivante (pagination cassée au-delà de 20 posts).

Cette PR ajoute la migration corrective `20260521133000_get_bookmarks_add_bookmarked_at.sql` : expose `bookmarked_at` dans le retour. Changement de signature → `DROP + CREATE`. **Déjà appliquée via AI Supabase sur dev + staging** le 21/05.

## Modifs hors-ticket (légitimes)

- `useFeed.ts` : `useToggleFeedBookmark` invalide aussi `['bookmarks']` (demandé par le ticket — un un-bookmark doit rafraîchir la liste)
- `PostCard.tsx` : suppression du `contentWidth` / `onCardLayout` inutile (mesure de largeur jamais nécessaire — point relevé en review #172)

## Checklist

- [x] Le code compile et passe le lint local
- [x] Migration DB commitée + appliquée sur dev + staging
- [x] Aucun console.log oublié

## Comment tester

1. `git checkout` cette branche + `pnpm install`
2. Profil → menu kebab → « Sauvegardés »
3. Bookmarker des posts depuis le feed → ils apparaissent dans la liste
4. Un-bookmark depuis l'écran → la ligne disparaît (invalidation `['bookmarks']`)