### PR TITLE
feat(feed): suppression d'un post (soft delete + RPC) (E4-09)

### DIFF
--- a/app/(feed)/post/[id].tsx
+++ b/app/(feed)/post/[id].tsx
@@ -300,6 +300,19 @@ export default function PostDetailRoute() {
   const shareMutation = useIncrementPostShare(postId ?? '');
 
   const post = postQuery.data;
+  const hadAvailablePost = useRef(false);
+
+  useEffect(() => {
+    if (post) {
+      hadAvailablePost.current = true;
+    }
+  }, [post]);
+
+  useEffect(() => {
+    if (hadAvailablePost.current && postQuery.data === null && !postQuery.isLoading) {
+      router.back();
+    }
+  }, [postQuery.data, postQuery.isLoading]);
 
   const handleToggleOverlays = useCallback(() => {
     setOverlaysVisible((current) => !current);

--- a/src/components/feed/PostMenuSheet.tsx
+++ b/src/components/feed/PostMenuSheet.tsx
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Clipboard from 'expo-clipboard';
+import { Trash2, type LucideIcon } from 'lucide-react-native';
 import { Alert } from 'react-native';
 import { Button, Sheet, Text, XStack, YStack } from 'tamagui';
 
@@ -61,35 +62,29 @@ export function PostMenuSheet({
   };
 
   const handleDelete = () => {
-    if (!onDelete) {
-      Alert.alert(
-        'Suppression indisponible',
-        'La suppression sera active quand la RPC delete_post sera livrée avec E4-09.'
-      );
-      return;
-    }
+    if (!onDelete) return;
 
-    Alert.alert('Supprimer le post ?', 'Cette action est définitive.', [
-      { text: 'Annuler', style: 'cancel' },
-      {
-        text: 'Supprimer',
-        style: 'destructive',
-        onPress: async () => {
-          try {
-            await onDelete();
-          } catch (error) {
-            Alert.alert(
-              'Suppression impossible',
-              error instanceof Error ? error.message : 'Une erreur est survenue.'
-            );
-            return;
-          }
+    Alert.alert(
+      'Supprimer ce post ?',
+      'Cette action est irréversible. Le post sera retiré du feed.',
+      [
+        { text: 'Annuler', style: 'cancel' },
+        {
+          text: 'Supprimer',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await onDelete();
+            } catch {
+              return;
+            }
 
-          close();
-          onDeleted?.();
+            close();
+            onDeleted?.();
+          },
         },
-      },
-    ]);
+      ]
+    );
   };
 
   return (
@@ -123,7 +118,7 @@ export function PostMenuSheet({
           <MenuButton label="Copier le lien" onPress={() => void handleCopyLink()} />
 
           {isAuthor ? (
-            <MenuButton label="Supprimer" danger onPress={handleDelete} />
+            <MenuButton label="Supprimer" danger Icon={Trash2} onPress={handleDelete} />
           ) : (
             <>
               <MenuButton label="Masquer ce post" onPress={() => void handleHide()} />
@@ -139,12 +134,16 @@ export function PostMenuSheet({
 function MenuButton({
   label,
   danger = false,
+  Icon,
   onPress,
 }: {
   label: string;
   danger?: boolean;
+  Icon?: LucideIcon;
   onPress: () => void;
 }) {
+  const iconColor = danger ? '#FF3B30' : '#FFFFFF';
+
   return (
     <Button
       backgroundColor="transparent"
@@ -155,9 +154,12 @@ function MenuButton({
       onPress={onPress}
       pressStyle={{ backgroundColor: '$surfaceElevated' }}
     >
-      <Text color={danger ? '$danger' : '$color'} fontSize={15} fontWeight="500">
-        {label}
-      </Text>
+      <XStack alignItems="center" gap={10}>
+        {Icon ? <Icon size={18} color={iconColor} /> : null}
+        <Text color={danger ? '$danger' : '$color'} fontSize={15} fontWeight="500">
+          {label}
+        </Text>
+      </XStack>
     </Button>
   );
 }

--- a/src/features/feed/hooks/useDeletePost.ts
+++ b/src/features/feed/hooks/useDeletePost.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import type { PostCardPost } from '@/components/feed/PostCard';
+import { FEED_QUERY_KEY } from '@/features/feed/hooks/useFeed';
 import { logger } from '@/lib/logger';
 import { supabase } from '@/lib/supabase';
 
@@ -15,7 +16,7 @@ type ProfilePostItem = {
 };
 
 type DeletePostContext = {
-  previousFeeds: [readonly unknown[], unknown][];
+  previousFeed: FeedCacheData | undefined;
   previousProfilePosts: [readonly unknown[], unknown][];
   previousPost: unknown;
 };
@@ -49,11 +50,11 @@ export function useDeletePost() {
       }
     },
     onMutate: async (postId) => {
-      await queryClient.cancelQueries({ queryKey: ['feed'] });
+      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
       await queryClient.cancelQueries({ queryKey: ['profile'] });
       await queryClient.cancelQueries({ queryKey: ['post', postId] });
 
-      const previousFeeds = queryClient.getQueriesData({ queryKey: ['feed'] });
+      const previousFeed = queryClient.getQueryData<FeedCacheData>(FEED_QUERY_KEY);
       const previousProfilePosts = queryClient.getQueriesData({
         predicate: (query) => {
           const queryKey = query.queryKey;
@@ -62,7 +63,7 @@ export function useDeletePost() {
       });
       const previousPost = queryClient.getQueryData(['post', postId]);
 
-      queryClient.setQueriesData<FeedCacheData>({ queryKey: ['feed'] }, (old) =>
+      queryClient.setQueryData<FeedCacheData>(FEED_QUERY_KEY, (old) =>
         removePostFromFeedCache(old, postId)
       );
       queryClient.setQueriesData<ProfilePostItem[]>(
@@ -76,21 +77,19 @@ export function useDeletePost() {
       );
       queryClient.setQueryData(['post', postId], null);
 
-      return { previousFeeds, previousProfilePosts, previousPost };
+      return { previousFeed, previousProfilePosts, previousPost };
     },
     onError: (error, postId, context) => {
       logger.warn('delete post failed', { message: error.message, postId });
 
-      context?.previousFeeds.forEach(([queryKey, data]) => {
-        queryClient.setQueryData(queryKey, data);
-      });
+      queryClient.setQueryData(FEED_QUERY_KEY, context?.previousFeed);
       context?.previousProfilePosts.forEach(([queryKey, data]) => {
         queryClient.setQueryData(queryKey, data);
       });
       queryClient.setQueryData(['post', postId], context?.previousPost);
     },
     onSettled: (_data, _error, postId) => {
-      void queryClient.invalidateQueries({ queryKey: ['feed'] });
+      void queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
       void queryClient.invalidateQueries({ queryKey: ['profile'] });
       void queryClient.invalidateQueries({ queryKey: ['post', postId] });
     },

--- a/src/features/feed/hooks/useDeletePost.ts
+++ b/src/features/feed/hooks/useDeletePost.ts
@@ -1,0 +1,98 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { PostCardPost } from '@/components/feed/PostCard';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+type FeedCacheData = {
+  pages: { posts: PostCardPost[]; nextCursor: string | null }[];
+  pageParams: unknown[];
+};
+
+type ProfilePostItem = {
+  id: string;
+  [key: string]: unknown;
+};
+
+type DeletePostContext = {
+  previousFeeds: [readonly unknown[], unknown][];
+  previousProfilePosts: [readonly unknown[], unknown][];
+  previousPost: unknown;
+};
+
+function removePostFromFeedCache(old: FeedCacheData | undefined, postId: string) {
+  if (!old) return old;
+
+  return {
+    ...old,
+    pages: old.pages.map((page) => ({
+      ...page,
+      posts: page.posts.filter((post) => post.id !== postId),
+    })),
+  };
+}
+
+function removePostFromProfilePostsCache(old: ProfilePostItem[] | undefined, postId: string) {
+  if (!old) return old;
+  return old.filter((post) => post.id !== postId);
+}
+
+export function useDeletePost() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string, DeletePostContext>({
+    mutationFn: async (postId: string) => {
+      const { data, error } = await supabase.rpc('soft_delete_post', { p_post_id: postId });
+      if (error) throw error;
+      if (data !== true) {
+        throw new Error('Post not deleted');
+      }
+    },
+    onMutate: async (postId) => {
+      await queryClient.cancelQueries({ queryKey: ['feed'] });
+      await queryClient.cancelQueries({ queryKey: ['profile'] });
+      await queryClient.cancelQueries({ queryKey: ['post', postId] });
+
+      const previousFeeds = queryClient.getQueriesData({ queryKey: ['feed'] });
+      const previousProfilePosts = queryClient.getQueriesData({
+        predicate: (query) => {
+          const queryKey = query.queryKey;
+          return queryKey[0] === 'profile' && queryKey[queryKey.length - 1] === 'posts';
+        },
+      });
+      const previousPost = queryClient.getQueryData(['post', postId]);
+
+      queryClient.setQueriesData<FeedCacheData>({ queryKey: ['feed'] }, (old) =>
+        removePostFromFeedCache(old, postId)
+      );
+      queryClient.setQueriesData<ProfilePostItem[]>(
+        {
+          predicate: (query) => {
+            const queryKey = query.queryKey;
+            return queryKey[0] === 'profile' && queryKey[queryKey.length - 1] === 'posts';
+          },
+        },
+        (old) => removePostFromProfilePostsCache(old, postId)
+      );
+      queryClient.setQueryData(['post', postId], null);
+
+      return { previousFeeds, previousProfilePosts, previousPost };
+    },
+    onError: (error, postId, context) => {
+      logger.warn('delete post failed', { message: error.message, postId });
+
+      context?.previousFeeds.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+      context?.previousProfilePosts.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
+      queryClient.setQueryData(['post', postId], context?.previousPost);
+    },
+    onSettled: (_data, _error, postId) => {
+      void queryClient.invalidateQueries({ queryKey: ['feed'] });
+      void queryClient.invalidateQueries({ queryKey: ['profile'] });
+      void queryClient.invalidateQueries({ queryKey: ['post', postId] });
+    },
+  });
+}

--- a/src/features/feed/hooks/useFeed.ts
+++ b/src/features/feed/hooks/useFeed.ts
@@ -15,7 +15,7 @@ type FeedQueryData = {
   pageParams: unknown[];
 };
 
-const FEED_QUERY_KEY = ['feed', 'social', 'foryou'] as const;
+export const FEED_QUERY_KEY = ['feed', 'social', 'foryou'] as const;
 
 function mapFeedPost(row: FeedRpcRow): PostCardPost {
   return {

--- a/src/features/feed/screens/FeedScreen.tsx
+++ b/src/features/feed/screens/FeedScreen.tsx
@@ -2,11 +2,12 @@ import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { Image } from 'expo-image';
 import { router } from 'expo-router';
 import { Rocket, Search, Settings, Sparkles, Store, User, Wallet } from 'lucide-react-native';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   NativeScrollEvent,
   NativeSyntheticEvent,
   ScrollView,
+  Share,
   StyleSheet,
   TouchableOpacity,
 } from 'react-native';
@@ -14,11 +15,14 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, Spinner, Text, XStack, YStack } from 'tamagui';
 
 import { PostCard, PostCardSkeleton, type PostCardPost } from '@/components/feed/PostCard';
+import { PostMenuSheet } from '@/components/feed/PostMenuSheet';
 import { FeedStories } from '@/features/feed/components/FeedStories';
 import { FeedTabPlaceholder } from '@/features/feed/components/FeedTabPlaceholder';
+import { useDeletePost } from '@/features/feed/hooks/useDeletePost';
 import { useFeed, useToggleFeedBookmark, useToggleFeedLike } from '@/features/feed/hooks/useFeed';
 import { type FeedStory, useFeedStories } from '@/features/feed/hooks/useFeedStories';
 import { SearchBar } from '@/features/profile/components/SearchBar';
+import { supabase } from '@/lib/supabase';
 
 const logoSource = require('../../../../assets/Logo-Doumassi.png') as number;
 
@@ -180,6 +184,10 @@ function FeedFooter({ isFetchingNextPage }: { isFetchingNextPage: boolean }) {
 export function FeedScreen() {
   const [activeTab, setActiveTab] = useState<FeedTabId>('social');
   const [searchValue, setSearchValue] = useState('');
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [selectedPost, setSelectedPost] = useState<PostCardPost | null>(null);
+  const [isPostMenuOpen, setIsPostMenuOpen] = useState(false);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
   const scrollOffsets = useRef<Record<FeedTabId, number>>({
     social: 0,
     business: 0,
@@ -194,11 +202,23 @@ export function FeedScreen() {
   const storiesQuery = useFeedStories();
   const likeMutation = useToggleFeedLike();
   const bookmarkMutation = useToggleFeedBookmark();
+  const deletePostMutation = useDeletePost();
 
   const posts = useMemo(
     () => feedQuery.data?.pages.flatMap((page) => page.posts) ?? [],
     [feedQuery.data]
   );
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data }) => {
+      setCurrentUserId(data.session?.user.id ?? null);
+    });
+  }, []);
+
+  const showToast = useCallback((message: string) => {
+    setToastMessage(message);
+    setTimeout(() => setToastMessage(null), 1800);
+  }, []);
 
   const restoreScroll = useCallback((tab: FeedTabId) => {
     requestAnimationFrame(() => {
@@ -235,6 +255,36 @@ export function FeedScreen() {
     router.push(story.isMe ? '/profile' : `/profile/${story.id}`);
   }, []);
 
+  const handleMenuPress = useCallback((post: PostCardPost) => {
+    setSelectedPost(post);
+    setIsPostMenuOpen(true);
+  }, []);
+
+  const handleMenuShare = useCallback(async () => {
+    if (!selectedPost) return;
+
+    try {
+      const result = await Share.share({ message: `doumassi://post/${selectedPost.id}` });
+      if (result.action === Share.sharedAction) {
+        await supabase.rpc('increment_share_count', { p_post_id: selectedPost.id });
+      }
+    } catch {
+      showToast('Partage impossible, réessayez');
+    }
+  }, [selectedPost, showToast]);
+
+  const handleDeleteSelectedPost = useCallback(async () => {
+    if (!selectedPost) return;
+
+    try {
+      await deletePostMutation.mutateAsync(selectedPost.id);
+      showToast('Post supprimé');
+    } catch {
+      showToast('Suppression impossible, réessayez');
+      throw new Error('Delete post failed');
+    }
+  }, [deletePostMutation, selectedPost, showToast]);
+
   const renderPost = useCallback(
     ({ item }: { item: PostCardPost }) => (
       <PostCard
@@ -244,9 +294,10 @@ export function FeedScreen() {
         onOpenDetail={() => router.push(`/post/${item.id}`)}
         onOpenComments={() => router.push(`/post/${item.id}?focus=comments`)}
         onOpenProfile={() => router.push(`/profile/${item.author_id}`)}
+        onMenuPress={() => handleMenuPress(item)}
       />
     ),
-    [bookmarkMutation, likeMutation]
+    [bookmarkMutation, handleMenuPress, likeMutation]
   );
 
   const keyExtractor = useCallback((item: PostCardPost) => item.id, []);
@@ -289,36 +340,69 @@ export function FeedScreen() {
 
   return (
     <SafeAreaView style={styles.safeArea} edges={['top']}>
-      <FlashList<PostCardPost>
-        ref={socialListRef}
-        data={posts}
-        renderItem={renderPost}
-        keyExtractor={keyExtractor}
-        ListHeaderComponent={socialHeader}
-        ListEmptyComponent={
-          feedQuery.isLoading ? (
-            <YStack>
-              <PostCardSkeleton />
-              <PostCardSkeleton />
-            </YStack>
-          ) : (
-            <FeedEmptyState />
-          )
-        }
-        ListFooterComponent={<FeedFooter isFetchingNextPage={feedQuery.isFetchingNextPage} />}
-        onEndReached={() => {
-          if (feedQuery.hasNextPage && !feedQuery.isFetchingNextPage) {
-            void feedQuery.fetchNextPage();
+      <YStack flex={1}>
+        <FlashList<PostCardPost>
+          ref={socialListRef}
+          data={posts}
+          renderItem={renderPost}
+          keyExtractor={keyExtractor}
+          ListHeaderComponent={socialHeader}
+          ListEmptyComponent={
+            feedQuery.isLoading ? (
+              <YStack>
+                <PostCardSkeleton />
+                <PostCardSkeleton />
+              </YStack>
+            ) : (
+              <FeedEmptyState />
+            )
           }
-        }}
-        onEndReachedThreshold={0.8}
-        onRefresh={() => void feedQuery.refetch()}
-        refreshing={feedQuery.isRefetching && !feedQuery.isFetchingNextPage}
-        onScroll={handleSocialScroll}
-        scrollEventThrottle={16}
-        showsVerticalScrollIndicator={false}
-        contentContainerStyle={styles.listContent}
-      />
+          ListFooterComponent={<FeedFooter isFetchingNextPage={feedQuery.isFetchingNextPage} />}
+          onEndReached={() => {
+            if (feedQuery.hasNextPage && !feedQuery.isFetchingNextPage) {
+              void feedQuery.fetchNextPage();
+            }
+          }}
+          onEndReachedThreshold={0.8}
+          onRefresh={() => void feedQuery.refetch()}
+          refreshing={feedQuery.isRefetching && !feedQuery.isFetchingNextPage}
+          onScroll={handleSocialScroll}
+          scrollEventThrottle={16}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.listContent}
+        />
+
+        {selectedPost ? (
+          <PostMenuSheet
+            postId={selectedPost.id}
+            isAuthor={selectedPost.author_id === currentUserId}
+            open={isPostMenuOpen}
+            onOpenChange={setIsPostMenuOpen}
+            onShare={() => void handleMenuShare()}
+            onDelete={handleDeleteSelectedPost}
+            onHidden={() => showToast('Post masqué')}
+            onCopyLink={() => showToast('Lien copié')}
+          />
+        ) : null}
+
+        {toastMessage ? (
+          <YStack
+            position="absolute"
+            bottom={24}
+            alignSelf="center"
+            backgroundColor="$surfaceElevated"
+            borderWidth={1}
+            borderColor="$accentNeon"
+            borderRadius="$4"
+            paddingHorizontal="$4"
+            paddingVertical="$2"
+          >
+            <Text color="$color" fontSize={13} fontWeight="700">
+              {toastMessage}
+            </Text>
+          </YStack>
+        ) : null}
+      </YStack>
     </SafeAreaView>
   );
 }

--- a/supabase/migrations/20260521150000_soft_delete_post_rpc.sql
+++ b/supabase/migrations/20260521150000_soft_delete_post_rpc.sql
@@ -1,0 +1,30 @@
+-- E4-09 — RPC soft_delete_post : soft delete d'un post par son auteur.
+--
+-- Pas de policy UPDATE sur public.posts (volontaire) : une policy UPDATE
+-- ouvrirait TOUS les champs du post (content, compteurs...) à la modification
+-- par l'auteur via REST — trop large. Cette RPC SECURITY DEFINER ne permet
+-- QUE le passage de deleted_at, et vérifie author_id = auth.uid() en interne.
+--
+-- Retourne true si un post a bien été soft-deleted, false sinon (post
+-- inexistant, pas l'auteur, ou déjà supprimé).
+--
+-- Appliquée via AI Supabase sur dev + staging le 21 mai 2026
+-- (migration soft_delete_post_rpc).
+
+create or replace function public.soft_delete_post(p_post_id uuid)
+returns boolean
+language plpgsql security definer set search_path = public as $$
+declare
+  v_deleted int;
+begin
+  update public.posts
+  set deleted_at = now()
+  where id = p_post_id
+    and author_id = auth.uid()
+    and deleted_at is null;
+  get diagnostics v_deleted = row_count;
+  return v_deleted > 0;
+end;
+$$;
+
+grant execute on function public.soft_delete_post(uuid) to authenticated;

--- a/supabase/migrations/20260521150001_soft_delete_post_revoke_anon.sql
+++ b/supabase/migrations/20260521150001_soft_delete_post_revoke_anon.sql
@@ -1,0 +1,8 @@
+-- Hygiène sécurité : soft_delete_post ne doit pas être appelable
+-- directement via REST par les utilisateurs anonymes ou le PUBLIC.
+-- Seul `authenticated` doit pouvoir exécuter cette RPC.
+--
+-- Appliquée via AI Supabase sur dev + staging le 21 mai 2026
+-- (migration soft_delete_post_revoke_anon).
+
+revoke execute on function public.soft_delete_post(uuid) from anon, public;


### PR DESCRIPTION
## Ticket lié

Closes #49

## Résumé

Suppression d'un post par son auteur — soft delete via RPC.

- Hook `useDeletePost` : appelle la RPC `soft_delete_post`, lève si `data !== true`
- Optimistic update : retire le post du cache feed (`FEED_QUERY_KEY` exact), des grids profil, et du détail (`['post', id]` → null) — rollback complet en cas d'erreur
- Menu kebab `PostMenuSheet` : action « Supprimer » (icône `Trash2`, rouge) avec Alert de confirmation, visible uniquement pour l'auteur
- `FeedScreen` : câblage `onMenuPress` → ouverture du `PostMenuSheet`, `isAuthor` calculé via la session, toasts succès/erreur
- `post/[id].tsx` : `router.back()` automatique si le post regardé est supprimé

## Migrations BDD

2 fichiers (RPC déjà appliquée sur dev + staging) :
- `20260521150000_soft_delete_post_rpc.sql` — RPC `SECURITY DEFINER`, vérifie `author_id = auth.uid()`, ne touche que `deleted_at`
- `20260521150001_soft_delete_post_revoke_anon.sql` — revoke `anon`/`public` (hygiène)

Pas de policy UPDATE sur `posts` (volontaire — trop large).

## Checklist

- [x] Le code compile et passe le lint local
- [x] Migrations DB commitées + appliquées sur dev + staging
- [x] Optimistic update + rollback
- [x] Aucun console.log oublié

## Comment tester

1. `git checkout` cette branche + rebuild Dev Build
2. Feed → kebab d'un de **tes** posts → Supprimer → confirmer → le post disparaît + toast
3. Le kebab d'un post d'**un autre** user ne montre pas « Supprimer »
4. Cas d'erreur (wifi coupé) → toast « Suppression impossible » + le post réapparaît (rollback)