### PR TITLE
feat(feed): masquer un post (AsyncStorage + filtrage client + écran Paramètres) (E4-10)

### DIFF
--- a/app/(feed)/settings.tsx
+++ b/app/(feed)/settings.tsx
@@ -8,6 +8,7 @@ import {
   Bell,
   ChevronLeft,
   ChevronRight,
+  EyeOff,
   FileText,
   Info,
   KeyRound,
@@ -395,6 +396,11 @@ export default function SettingsScreen() {
               checked={Boolean(profile.is_private)}
               disabled={privacyToggle.isPending}
               onCheckedChange={handlePrivacyChange}
+            />
+            <SettingRow
+              icon={EyeOff}
+              label="Posts masqués"
+              onPress={() => router.push('/settings/hidden-posts')}
               isLast
             />
           </Section>

--- a/app/(feed)/settings/hidden-posts.tsx
+++ b/app/(feed)/settings/hidden-posts.tsx
@@ -1,0 +1,199 @@
+import { FlashList } from '@shopify/flash-list';
+import { Image } from 'expo-image';
+import { router } from 'expo-router';
+import { ArrowLeft, EyeOff } from 'lucide-react-native';
+import { useCallback, useState } from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Spinner, Text, View, XStack, YStack } from 'tamagui';
+
+import { usePostDetail } from '@/features/feed/hooks/useFeed';
+import { useHiddenPosts, useUnhidePost } from '@/features/feed/hooks/useHiddenPosts';
+
+function HiddenPostRow({ postId, onRestored }: { postId: string; onRestored: () => void }) {
+  const postQuery = usePostDetail(postId);
+  const unhidePostMutation = useUnhidePost();
+  const post = postQuery.data;
+
+  const handleRestore = useCallback(() => {
+    unhidePostMutation.mutate(postId, { onSuccess: onRestored });
+  }, [onRestored, postId, unhidePostMutation]);
+
+  return (
+    <XStack
+      minHeight={72}
+      paddingHorizontal="$4"
+      paddingVertical="$3"
+      alignItems="center"
+      gap="$3"
+      borderBottomWidth={StyleSheet.hairlineWidth}
+      borderBottomColor="$borderColor"
+    >
+      <YStack
+        width={44}
+        height={44}
+        borderRadius={9999}
+        backgroundColor="$surfaceElevated"
+        alignItems="center"
+        justifyContent="center"
+        overflow="hidden"
+      >
+        {post?.author_avatar_url ? (
+          <Image
+            source={{ uri: post.author_avatar_url }}
+            style={styles.avatar}
+            contentFit="cover"
+          />
+        ) : (
+          <Text color="$color" fontSize={16} fontWeight="700">
+            {post?.author_username?.charAt(0).toUpperCase() ?? '?'}
+          </Text>
+        )}
+      </YStack>
+
+      <YStack flex={1} minWidth={0} gap={3}>
+        <Text color="$color" fontSize={15} fontWeight="700" numberOfLines={1}>
+          {post
+            ? `@${post.author_username}`
+            : postQuery.isLoading
+              ? 'Chargement...'
+              : 'Post indisponible'}
+        </Text>
+        <Text color="$textSecondary" fontSize={13} numberOfLines={1}>
+          {post?.content?.trim() || postId}
+        </Text>
+      </YStack>
+
+      <Button
+        minHeight={38}
+        paddingHorizontal="$3"
+        backgroundColor="transparent"
+        borderWidth={1}
+        borderColor="$borderColor"
+        borderRadius="$md"
+        onPress={handleRestore}
+        disabled={unhidePostMutation.isPending}
+        pressStyle={{ opacity: 0.72 }}
+      >
+        {unhidePostMutation.isPending ? (
+          <Spinner size="small" color="$accentNeon" />
+        ) : (
+          <Button.Text color="$accentNeon" fontSize={13} fontWeight="700">
+            Réafficher
+          </Button.Text>
+        )}
+      </Button>
+    </XStack>
+  );
+}
+
+export default function HiddenPostsScreen() {
+  const insets = useSafeAreaInsets();
+  const hiddenPostsQuery = useHiddenPosts();
+  const [toastVisible, setToastVisible] = useState(false);
+
+  const showRestoredToast = useCallback(() => {
+    setToastVisible(true);
+    setTimeout(() => setToastVisible(false), 1600);
+  }, []);
+
+  const renderItem = useCallback(
+    ({ item }: { item: string }) => <HiddenPostRow postId={item} onRestored={showRestoredToast} />,
+    [showRestoredToast]
+  );
+
+  const EmptyState = useCallback(() => {
+    if (hiddenPostsQuery.isLoading) {
+      return (
+        <YStack paddingVertical={100} alignItems="center">
+          <Spinner size="large" color="#FFFFFF" />
+        </YStack>
+      );
+    }
+
+    return (
+      <YStack paddingVertical={100} alignItems="center" gap="$3" paddingHorizontal="$6">
+        <EyeOff size={48} color="#A0A0A0" />
+        <Text color="$textSecondary" fontSize={16} fontWeight="600" textAlign="center">
+          Aucun post masqué
+        </Text>
+      </YStack>
+    );
+  }, [hiddenPostsQuery.isLoading]);
+
+  return (
+    <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+      <XStack
+        height={56}
+        paddingHorizontal="$4"
+        alignItems="center"
+        borderBottomWidth={StyleSheet.hairlineWidth}
+        borderBottomColor="$borderColor"
+      >
+        <TouchableOpacity
+          onPress={() => (router.canGoBack() ? router.back() : router.replace('/settings'))}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        >
+          <ArrowLeft size={24} color="#FFFFFF" />
+        </TouchableOpacity>
+        <Text
+          flex={1}
+          marginLeft="$3"
+          color="$color"
+          fontSize={20}
+          fontWeight="700"
+          fontFamily="$heading"
+        >
+          Posts masqués
+        </Text>
+        <View width={24} />
+      </XStack>
+
+      <FlashList
+        data={hiddenPostsQuery.data ?? []}
+        renderItem={renderItem}
+        keyExtractor={(item) => item}
+        ListEmptyComponent={EmptyState}
+        onRefresh={() => void hiddenPostsQuery.refetch()}
+        refreshing={hiddenPostsQuery.isRefetching}
+        contentContainerStyle={styles.listContent}
+      />
+
+      {toastVisible ? (
+        <XStack
+          position="absolute"
+          bottom={96}
+          left={0}
+          right={0}
+          justifyContent="center"
+          pointerEvents="none"
+        >
+          <XStack
+            backgroundColor="$surface"
+            paddingHorizontal="$4"
+            paddingVertical="$3"
+            borderRadius="$lg"
+            alignItems="center"
+            gap="$2"
+          >
+            <EyeOff size={16} color="#FFFFFF" />
+            <Text color="$color" fontSize={14} fontWeight="600">
+              Affichage restauré
+            </Text>
+          </XStack>
+        </XStack>
+      ) : null}
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  avatar: {
+    width: 44,
+    height: 44,
+  },
+  listContent: {
+    backgroundColor: '#000000',
+    paddingBottom: 32,
+  },
+});

--- a/src/components/feed/PostMenuSheet.tsx
+++ b/src/components/feed/PostMenuSheet.tsx
@@ -1,8 +1,9 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Clipboard from 'expo-clipboard';
-import { Trash2, type LucideIcon } from 'lucide-react-native';
+import { EyeOff, Trash2, type LucideIcon } from 'lucide-react-native';
 import { Alert } from 'react-native';
 import { Button, Sheet, Text, XStack, YStack } from 'tamagui';
+
+import { useHidePost } from '@/features/feed/hooks/useHiddenPosts';
 
 export type PostMenuSheetProps = {
   postId: string;
@@ -11,13 +12,12 @@ export type PostMenuSheetProps = {
   onOpenChange: (open: boolean) => void;
   onShare?: () => void;
   onHidden?: () => void;
+  onHideError?: () => void;
   onDelete?: () => Promise<void> | void;
   onDeleted?: () => void;
   onReported?: () => void;
   onCopyLink?: () => void;
 };
-
-const HIDDEN_POSTS_STORAGE_KEY = 'doumassi:hidden_posts';
 
 export function PostMenuSheet({
   postId,
@@ -26,11 +26,13 @@ export function PostMenuSheet({
   onOpenChange,
   onShare,
   onHidden,
+  onHideError,
   onDelete,
   onDeleted,
   onReported,
   onCopyLink,
 }: PostMenuSheetProps) {
+  const hidePostMutation = useHidePost();
   const close = () => onOpenChange(false);
 
   const handleShare = () => {
@@ -46,11 +48,13 @@ export function PostMenuSheet({
   };
 
   const handleHide = async () => {
-    const rawHiddenPosts = await AsyncStorage.getItem(HIDDEN_POSTS_STORAGE_KEY);
-    const hiddenPosts = rawHiddenPosts ? (JSON.parse(rawHiddenPosts) as string[]) : [];
-    const nextHiddenPosts = Array.from(new Set([...hiddenPosts, postId]));
+    try {
+      await hidePostMutation.mutateAsync(postId);
+    } catch {
+      onHideError?.();
+      throw new Error('Hide post failed');
+    }
 
-    await AsyncStorage.setItem(HIDDEN_POSTS_STORAGE_KEY, JSON.stringify(nextHiddenPosts));
     close();
     onHidden?.();
   };
@@ -121,7 +125,7 @@ export function PostMenuSheet({
             <MenuButton label="Supprimer" danger Icon={Trash2} onPress={handleDelete} />
           ) : (
             <>
-              <MenuButton label="Masquer ce post" onPress={() => void handleHide()} />
+              <MenuButton label="Masquer ce post" Icon={EyeOff} onPress={() => void handleHide()} />
               <MenuButton label="Signaler" onPress={handleReport} />
             </>
           )}
@@ -155,7 +159,7 @@ function MenuButton({
       pressStyle={{ backgroundColor: '$surfaceElevated' }}
     >
       <XStack alignItems="center" gap={10}>
-        {Icon ? <Icon size={18} color={iconColor} /> : null}
+        {Icon ? <Icon size={20} color={iconColor} /> : null}
         <Text color={danger ? '$danger' : '$color'} fontSize={15} fontWeight="500">
           {label}
         </Text>

--- a/src/features/feed/hooks/useFeed.ts
+++ b/src/features/feed/hooks/useFeed.ts
@@ -4,6 +4,8 @@ import type { PostCardPost } from '@/components/feed/PostCard';
 import { logger } from '@/lib/logger';
 import { supabase } from '@/lib/supabase';
 
+import { useHiddenPosts } from './useHiddenPosts';
+
 const PAGE_SIZE = 20;
 
 type FeedRpcRow = PostCardPost & {
@@ -78,11 +80,21 @@ async function fetchFeedPage(cursor: string | null) {
 }
 
 export function useFeed() {
+  const hiddenPostsQuery = useHiddenPosts();
+  const hiddenIds = hiddenPostsQuery.data ?? [];
+
   return useInfiniteQuery({
     queryKey: FEED_QUERY_KEY,
     queryFn: ({ pageParam }) => fetchFeedPage(pageParam),
     initialPageParam: null as string | null,
     getNextPageParam: (lastPage) => lastPage.nextCursor,
+    select: (data) => ({
+      ...data,
+      pages: data.pages.map((page) => ({
+        ...page,
+        posts: page.posts.filter((post) => !hiddenIds.includes(post.id)),
+      })),
+    }),
   });
 }
 

--- a/src/features/feed/hooks/useHiddenPosts.ts
+++ b/src/features/feed/hooks/useHiddenPosts.ts
@@ -1,0 +1,46 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const HIDDEN_POSTS_STORAGE_KEY = 'doumassi:hidden_posts';
+export const hiddenPostsQueryKey = ['hidden-posts'] as const;
+
+async function readHiddenPosts() {
+  const raw = await AsyncStorage.getItem(HIDDEN_POSTS_STORAGE_KEY);
+  return raw ? (JSON.parse(raw) as string[]) : [];
+}
+
+export function useHiddenPosts() {
+  return useQuery({
+    queryKey: hiddenPostsQueryKey,
+    queryFn: readHiddenPosts,
+    staleTime: Infinity,
+  });
+}
+
+export function useHidePost() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (postId: string) => {
+      const list = await readHiddenPosts();
+      if (!list.includes(postId)) list.push(postId);
+      await AsyncStorage.setItem(HIDDEN_POSTS_STORAGE_KEY, JSON.stringify(list));
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: hiddenPostsQueryKey }),
+  });
+}
+
+export function useUnhidePost() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (postId: string) => {
+      const list = await readHiddenPosts();
+      await AsyncStorage.setItem(
+        HIDDEN_POSTS_STORAGE_KEY,
+        JSON.stringify(list.filter((id) => id !== postId))
+      );
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: hiddenPostsQueryKey }),
+  });
+}

--- a/src/features/feed/screens/FeedScreen.tsx
+++ b/src/features/feed/screens/FeedScreen.tsx
@@ -21,6 +21,7 @@ import { FeedTabPlaceholder } from '@/features/feed/components/FeedTabPlaceholde
 import { useDeletePost } from '@/features/feed/hooks/useDeletePost';
 import { useFeed, useToggleFeedBookmark, useToggleFeedLike } from '@/features/feed/hooks/useFeed';
 import { type FeedStory, useFeedStories } from '@/features/feed/hooks/useFeedStories';
+import { useUnhidePost } from '@/features/feed/hooks/useHiddenPosts';
 import { SearchBar } from '@/features/profile/components/SearchBar';
 import { supabase } from '@/lib/supabase';
 
@@ -31,6 +32,12 @@ type FeedTabId = 'social' | 'business' | 'ai' | 'wallet' | 'soon';
 type FeedTab = {
   id: FeedTabId;
   label: string;
+};
+
+type FeedToast = {
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
 };
 
 const FEED_TABS: FeedTab[] = [
@@ -187,7 +194,8 @@ export function FeedScreen() {
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [selectedPost, setSelectedPost] = useState<PostCardPost | null>(null);
   const [isPostMenuOpen, setIsPostMenuOpen] = useState(false);
-  const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [toast, setToast] = useState<FeedToast | null>(null);
+  const toastTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollOffsets = useRef<Record<FeedTabId, number>>({
     social: 0,
     business: 0,
@@ -203,6 +211,7 @@ export function FeedScreen() {
   const likeMutation = useToggleFeedLike();
   const bookmarkMutation = useToggleFeedBookmark();
   const deletePostMutation = useDeletePost();
+  const unhidePostMutation = useUnhidePost();
 
   const posts = useMemo(
     () => feedQuery.data?.pages.flatMap((page) => page.posts) ?? [],
@@ -215,10 +224,23 @@ export function FeedScreen() {
     });
   }, []);
 
-  const showToast = useCallback((message: string) => {
-    setToastMessage(message);
-    setTimeout(() => setToastMessage(null), 1800);
+  const showToast = useCallback((nextToast: FeedToast, durationMs = 1800) => {
+    if (toastTimeoutRef.current) {
+      clearTimeout(toastTimeoutRef.current);
+    }
+
+    setToast(nextToast);
+    toastTimeoutRef.current = setTimeout(() => setToast(null), durationMs);
   }, []);
+
+  useEffect(
+    () => () => {
+      if (toastTimeoutRef.current) {
+        clearTimeout(toastTimeoutRef.current);
+      }
+    },
+    []
+  );
 
   const restoreScroll = useCallback((tab: FeedTabId) => {
     requestAnimationFrame(() => {
@@ -269,7 +291,7 @@ export function FeedScreen() {
         await supabase.rpc('increment_share_count', { p_post_id: selectedPost.id });
       }
     } catch {
-      showToast('Partage impossible, réessayez');
+      showToast({ message: 'Partage impossible, réessayez' });
     }
   }, [selectedPost, showToast]);
 
@@ -278,12 +300,30 @@ export function FeedScreen() {
 
     try {
       await deletePostMutation.mutateAsync(selectedPost.id);
-      showToast('Post supprimé');
+      showToast({ message: 'Post supprimé' });
     } catch {
-      showToast('Suppression impossible, réessayez');
+      showToast({ message: 'Suppression impossible, réessayez' });
       throw new Error('Delete post failed');
     }
   }, [deletePostMutation, selectedPost, showToast]);
+
+  const handleHiddenSelectedPost = useCallback(() => {
+    if (!selectedPost) return;
+    const hiddenPostId = selectedPost.id;
+
+    showToast(
+      {
+        message: 'Post masqué',
+        actionLabel: 'Annuler',
+        onAction: () => {
+          unhidePostMutation.mutate(hiddenPostId, {
+            onSuccess: () => showToast({ message: 'Affichage restauré' }),
+          });
+        },
+      },
+      5000
+    );
+  }, [selectedPost, showToast, unhidePostMutation]);
 
   const renderPost = useCallback(
     ({ item }: { item: PostCardPost }) => (
@@ -380,13 +420,14 @@ export function FeedScreen() {
             onOpenChange={setIsPostMenuOpen}
             onShare={() => void handleMenuShare()}
             onDelete={handleDeleteSelectedPost}
-            onHidden={() => showToast('Post masqué')}
-            onCopyLink={() => showToast('Lien copié')}
+            onHidden={handleHiddenSelectedPost}
+            onHideError={() => showToast({ message: 'Masquage impossible, réessayez' })}
+            onCopyLink={() => showToast({ message: 'Lien copié' })}
           />
         ) : null}
 
-        {toastMessage ? (
-          <YStack
+        {toast ? (
+          <XStack
             position="absolute"
             bottom={24}
             alignSelf="center"
@@ -396,11 +437,24 @@ export function FeedScreen() {
             borderRadius="$4"
             paddingHorizontal="$4"
             paddingVertical="$2"
+            alignItems="center"
+            gap="$4"
           >
             <Text color="$color" fontSize={13} fontWeight="700">
-              {toastMessage}
+              {toast.message}
             </Text>
-          </YStack>
+            {toast.actionLabel && toast.onAction ? (
+              <Text
+                color="$accentNeon"
+                fontSize={13}
+                fontWeight="700"
+                onPress={toast.onAction}
+                pressStyle={{ opacity: 0.72 }}
+              >
+                {toast.actionLabel}
+              </Text>
+            ) : null}
+          </XStack>
         ) : null}
       </YStack>
     </SafeAreaView>


### PR DESCRIPTION
## Ticket lié

Closes #50

## Résumé

Masquer un post — persistance locale (AsyncStorage) + filtrage côté client + écran Paramètres pour réafficher.

- Hook `useHiddenPosts` (`useQuery` sur AsyncStorage, `staleTime: Infinity`) + `useHidePost` / `useUnhidePost` (mutations avec invalidation)
- Clé AsyncStorage : `doumassi:hidden_posts` (cohérente avec `PostMenuSheet`)
- `useFeed` filtre les IDs masqués via `select` — pas de mutation du cache, transformation pure côté client (le post réapparaît au unhide sans refetch)
- `PostMenuSheet` : appel via le hook (plus d'AsyncStorage inline), try/catch + nouvelle prop `onHideError` (pattern identique à `onDelete`/`handleDeleteSelectedPost`), icône `EyeOff`
- `FeedScreen` :
  - refactor du toast pour supporter un **bouton d'action** (pattern Twitter « Annuler ») — type `FeedToast { message, actionLabel?, onAction? }`
  - clear timeout pour éviter les race conditions entre toasts successifs
  - toast masquage : `Post masqué` + bouton `Annuler` pendant 5s → appelle `useUnhidePost`, puis toast `Affichage restauré`
  - toast d'erreur : `Masquage impossible, réessayez` via `onHideError`
- Écran `app/(feed)/settings/hidden-posts.tsx` : FlashList, row simplifiée (avatar + @username + preview content + bouton `Réafficher`), empty state, pull-to-refresh
- Entrée « Posts masqués » dans `app/(feed)/settings.tsx` (section Confidentialité)

## Checklist

- [x] Le code compile et passe le lint local
- [x] Toast avec action « Annuler » 5s
- [x] Empty state et accès depuis les Paramètres
- [x] Aucun console.log oublié

## Limite connue (non-bloquante)

`HiddenPostsScreen` fait un `usePostDetail` par row → N+1 requêtes. Pour MVP / usage réel (poignée de posts masqués), c'est acceptable. Une RPC batch `get_posts_batch(uuid[])` pourra être ajoutée plus tard si l'usage le justifie.

## Comment tester

1. `git checkout` cette branche + rebuild Dev Build
2. Feed → kebab d'un post (pas le tien) → « Masquer ce post » → le post disparaît + toast « Post masqué » avec bouton « Annuler »
3. Tap « Annuler » avant 5s → le post réapparaît + toast « Affichage restauré »
4. Paramètres → « Posts masqués » → liste, bouton « Réafficher » → le post réapparaît dans le feed