### PR TITLE
feat(notifications): écran Notifications + badge TabBar (E4-17)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -8,6 +8,7 @@ import { Platform, StyleSheet, View } from 'react-native';
 
 import GuardLoader from '@/components/GuardLoader';
 import { useAuthGuard } from '@/features/auth/hooks/useAuthGuard';
+import { useNotificationsUnreadCount } from '@/features/notifications/hooks/useNotifications';
 
 const ACTIVE_COLOR = '#FFFFFF';
 const INACTIVE_COLOR = '#A0A0A0';
@@ -31,25 +32,12 @@ function TabIcon({ Icon, focused }: TabIconProps) {
   );
 }
 
-export default function TabsLayout() {
-  const status = useAuthGuard();
-
-  if (status === 'loading') {
-    return <GuardLoader />;
-  }
-
-  if (status === 'unauthenticated') {
-    return <Redirect href="/(auth)/welcome" />;
-  }
-
-  if (status === 'incomplete' || status === 'onboarding') {
-    return <Redirect href="/(onboarding)" />;
-  }
-
-  if (status === 'incomplete-google') {
-    return <Redirect href="/(onboarding)/complete-account" />;
-  }
-
+// Sous-composant rendu UNIQUEMENT après le guard auth — c'est ici qu'on peut
+// appeler `useNotificationsUnreadCount` sans risquer de tirer la RPC avant
+// qu'il y ait une session valide (et sans violer les règles des hooks au
+// niveau du parent qui short-circuit avec des Redirect).
+function AuthenticatedTabs() {
+  const unreadCount = useNotificationsUnreadCount();
   return (
     <Tabs
       screenOptions={{
@@ -72,6 +60,9 @@ export default function TabsLayout() {
         options={{
           tabBarIcon: ({ focused }) => <TabIcon Icon={Bell} focused={focused} />,
           tabBarAccessibilityLabel: 'Notifications',
+          // Cap à "99+" pour éviter un débordement visuel du badge sur les
+          // gros volumes (la cible MVP n'y arrivera pas mais c'est défensif).
+          tabBarBadge: unreadCount > 99 ? '99+' : unreadCount > 0 ? unreadCount : undefined,
         }}
       />
       <Tabs.Screen
@@ -97,6 +88,28 @@ export default function TabsLayout() {
       />
     </Tabs>
   );
+}
+
+export default function TabsLayout() {
+  const status = useAuthGuard();
+
+  if (status === 'loading') {
+    return <GuardLoader />;
+  }
+
+  if (status === 'unauthenticated') {
+    return <Redirect href="/(auth)/welcome" />;
+  }
+
+  if (status === 'incomplete' || status === 'onboarding') {
+    return <Redirect href="/(onboarding)" />;
+  }
+
+  if (status === 'incomplete-google') {
+    return <Redirect href="/(onboarding)/complete-account" />;
+  }
+
+  return <AuthenticatedTabs />;
 }
 
 const styles = StyleSheet.create({

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -1,28 +1,9 @@
-// Tab Bell — placeholder MVP, vrai écran livré en E4-17 (Sprint 3).
+// Tab Bell — écran Notifications (E4-17).
+// L'écran lui-même vit dans src/features/notifications/ (pattern projet :
+// route fine + screen séparé).
 
-import { Bell } from 'lucide-react-native';
-import { StyleSheet, View } from 'react-native';
-import { Text, YStack } from 'tamagui';
+import { NotificationsScreen } from '@/features/notifications/screens/NotificationsScreen';
 
 export default function NotificationsRoute() {
-  return (
-    <View style={styles.screen}>
-      <YStack flex={1} alignItems="center" justifyContent="center" gap="$3" paddingHorizontal="$6">
-        <Bell size={64} color="#A0A0A0" strokeWidth={1.5} />
-        <Text color="$color" fontSize={18} fontWeight="700" textAlign="center">
-          Notifications bientôt disponibles
-        </Text>
-        <Text color="$textSecondary" fontSize={14} textAlign="center">
-          Vos likes, commentaires et nouveaux abonnés apparaîtront ici.
-        </Text>
-      </YStack>
-    </View>
-  );
+  return <NotificationsScreen />;
 }
-
-const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: '#000000',
-  },
-});

--- a/src/features/notifications/components/FollowRequestCard.tsx
+++ b/src/features/notifications/components/FollowRequestCard.tsx
@@ -1,0 +1,151 @@
+// FollowRequestCard — E4-17.
+// Card affichée en haut de l'écran Notifications pour chaque demande de
+// suivi (`type='follow_request'`). 2 boutons inline : Confirmer / Refuser,
+// avec optimistic remove de la row au tap (les hooks accept/reject
+// invalident la liste côté success / rollback côté erreur).
+
+import { Image } from 'expo-image';
+import { router } from 'expo-router';
+import { memo } from 'react';
+import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
+import { Button, Text, XStack, YStack } from 'tamagui';
+
+import {
+  useAcceptFollowRequest,
+  useRejectFollowRequest,
+  type NotificationItem,
+} from '@/features/notifications/hooks/useNotifications';
+
+const AVATAR_SIZE = 40;
+
+export interface FollowRequestCardProps {
+  notif: NotificationItem;
+}
+
+export const FollowRequestCard = memo(function FollowRequestCard({
+  notif,
+}: FollowRequestCardProps) {
+  const accept = useAcceptFollowRequest();
+  const reject = useRejectFollowRequest();
+  const isPending = accept.isPending || reject.isPending;
+  const requesterId = notif.actor_id;
+  const username = notif.actor_username ?? 'inconnu';
+
+  if (!requesterId) {
+    // Notif sans acteur : on ne devrait jamais arriver ici pour follow_request.
+    return null;
+  }
+
+  const handleAccept = () => {
+    if (isPending) return;
+    accept.mutate(requesterId);
+  };
+
+  const handleReject = () => {
+    if (isPending) return;
+    reject.mutate(requesterId);
+  };
+
+  const handleOpenProfile = () => {
+    router.push(`/profile/${requesterId}`);
+  };
+
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderRadius="$4"
+      marginHorizontal="$4"
+      marginBottom="$2"
+      padding="$3"
+      gap="$3"
+    >
+      <XStack alignItems="center" gap="$3">
+        <Pressable onPress={handleOpenProfile}>
+          {notif.actor_avatar_url ? (
+            <Image
+              source={{ uri: notif.actor_avatar_url }}
+              style={styles.avatar}
+              contentFit="cover"
+            />
+          ) : (
+            <YStack
+              width={AVATAR_SIZE}
+              height={AVATAR_SIZE}
+              borderRadius={9999}
+              backgroundColor="$backgroundFocus"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Text color="$color" fontSize={16} fontWeight="700">
+                {username.charAt(0).toUpperCase()}
+              </Text>
+            </YStack>
+          )}
+        </Pressable>
+
+        <Pressable onPress={handleOpenProfile} style={styles.textPressable}>
+          <Text color="$color" fontSize={15} fontWeight="700">
+            @{username}{' '}
+            <Text color="$textSecondary" fontWeight="400">
+              veut vous suivre
+            </Text>
+          </Text>
+        </Pressable>
+
+        {!notif.is_seen ? <YStack style={styles.unreadDot} /> : null}
+      </XStack>
+
+      <XStack gap="$2">
+        <Button
+          flex={1}
+          height={36}
+          borderRadius={8}
+          backgroundColor="#FFFFFF"
+          color="#000000"
+          fontWeight="700"
+          fontSize={14}
+          disabled={isPending}
+          opacity={isPending ? 0.6 : 1}
+          onPress={handleAccept}
+          pressStyle={{ opacity: 0.85 }}
+        >
+          {accept.isPending ? <ActivityIndicator color="#000000" /> : 'Confirmer'}
+        </Button>
+        <Button
+          flex={1}
+          height={36}
+          borderRadius={8}
+          backgroundColor="$surface"
+          borderWidth={1}
+          borderColor="$borderColor"
+          color="$color"
+          fontWeight="600"
+          fontSize={14}
+          disabled={isPending}
+          opacity={isPending ? 0.6 : 1}
+          onPress={handleReject}
+          pressStyle={{ opacity: 0.85 }}
+        >
+          {reject.isPending ? <ActivityIndicator color="#FFFFFF" /> : 'Refuser'}
+        </Button>
+      </XStack>
+    </YStack>
+  );
+});
+
+const styles = StyleSheet.create({
+  avatar: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    borderRadius: 9999,
+  },
+  textPressable: {
+    flex: 1,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#EF4444',
+  },
+});

--- a/src/features/notifications/components/NotificationRow.tsx
+++ b/src/features/notifications/components/NotificationRow.tsx
@@ -1,0 +1,169 @@
+// NotificationRow — E4-17.
+// Row affichée pour chaque notif non-follow_request (follow/like/comment/
+// mention/system/payment). Le tap déclenche onPress (le screen route en
+// conséquence du type + marque lu).
+
+import { Image } from 'expo-image';
+import { Bell, Sparkles } from 'lucide-react-native';
+import { memo } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, XStack, YStack } from 'tamagui';
+
+import type {
+  NotificationItem,
+  NotificationType,
+} from '@/features/notifications/hooks/useNotifications';
+
+const AVATAR_SIZE = 40;
+
+function formatNotifTime(value: string): string {
+  const createdAt = new Date(value).getTime();
+  if (Number.isNaN(createdAt)) return '';
+  const elapsedMs = Math.max(0, Date.now() - createdAt);
+  const minutes = Math.floor(elapsedMs / 60_000);
+  if (minutes < 1) return 'à l’instant';
+  if (minutes < 60) return `${minutes}min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}j`;
+  const weeks = Math.floor(days / 7);
+  if (days < 30) return `${weeks}sem`;
+  // Au-delà de 30 jours : date format JJ/MM/AAAA.
+  const d = new Date(value);
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  return `${dd}/${mm}/${d.getFullYear()}`;
+}
+
+function buildText(notif: NotificationItem): string {
+  const handle = notif.actor_username ? `@${notif.actor_username}` : 'Un utilisateur';
+  switch (notif.type) {
+    case 'follow':
+      return `${handle} a commencé à vous suivre`;
+    case 'like':
+      return `${handle} a aimé votre post`;
+    case 'comment': {
+      const preview = (notif.payload?.preview as string | undefined)?.trim();
+      return preview
+        ? `${handle} a commenté votre post : « ${preview} »`
+        : `${handle} a commenté votre post`;
+    }
+    case 'mention':
+      return `${handle} vous a mentionné dans son post`;
+    case 'system': {
+      const title = (notif.payload?.title as string | undefined) ?? 'Doumassi AI news';
+      return `Doumassi AI news : ${title}`;
+    }
+    case 'payment': {
+      const from = (notif.payload?.from as string | undefined) ?? 'un utilisateur';
+      const amount = (notif.payload?.amount as string | undefined) ?? '';
+      return amount ? `Paiement accepté de ${from} : ${amount}` : `Paiement accepté de ${from}`;
+    }
+    case 'follow_request':
+      // Ne devrait pas atterrir ici (rendu via FollowRequestCard) — fallback.
+      return `${handle} veut vous suivre`;
+    default:
+      return '';
+  }
+}
+
+const SYSTEM_TYPES: NotificationType[] = ['system', 'payment'];
+
+function ActorAvatar({ notif }: { notif: NotificationItem }) {
+  if (notif.actor_avatar_url) {
+    return (
+      <Image source={{ uri: notif.actor_avatar_url }} style={styles.avatar} contentFit="cover" />
+    );
+  }
+  // Pas d'acteur (notif système) → icône d'avatar à la place.
+  if (SYSTEM_TYPES.includes(notif.type) || !notif.actor_id) {
+    return (
+      <YStack
+        width={AVATAR_SIZE}
+        height={AVATAR_SIZE}
+        borderRadius={9999}
+        backgroundColor="$surface"
+        alignItems="center"
+        justifyContent="center"
+      >
+        {notif.type === 'system' ? (
+          <Sparkles size={20} color="#FFFFFF" />
+        ) : (
+          <Bell size={20} color="#FFFFFF" />
+        )}
+      </YStack>
+    );
+  }
+  const initial = notif.actor_username?.trim().charAt(0).toUpperCase() ?? '?';
+  return (
+    <YStack
+      width={AVATAR_SIZE}
+      height={AVATAR_SIZE}
+      borderRadius={9999}
+      backgroundColor="$surface"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Text color="$color" fontSize={16} fontWeight="700">
+        {initial}
+      </Text>
+    </YStack>
+  );
+}
+
+export interface NotificationRowProps {
+  notif: NotificationItem;
+  onPress: (notif: NotificationItem) => void;
+}
+
+export const NotificationRow = memo(function NotificationRow({
+  notif,
+  onPress,
+}: NotificationRowProps) {
+  const text = buildText(notif);
+  const time = formatNotifTime(notif.created_at);
+
+  return (
+    <Pressable
+      onPress={() => onPress(notif)}
+      style={styles.pressable}
+      accessibilityRole="button"
+      accessibilityLabel={text}
+    >
+      <XStack alignItems="center" paddingHorizontal="$4" paddingVertical="$3" gap="$3">
+        <ActorAvatar notif={notif} />
+
+        <YStack flex={1} gap={2}>
+          <Text color="$color" fontSize={15} fontWeight={notif.is_read ? '400' : '600'}>
+            {text}
+          </Text>
+        </YStack>
+
+        <XStack alignItems="center" gap="$2">
+          <Text color="$textSecondary" fontSize={12}>
+            {time}
+          </Text>
+          {!notif.is_seen ? <YStack style={styles.unreadDot} /> : null}
+        </XStack>
+      </XStack>
+    </Pressable>
+  );
+});
+
+const styles = StyleSheet.create({
+  pressable: {
+    backgroundColor: '#000000',
+  },
+  avatar: {
+    width: AVATAR_SIZE,
+    height: AVATAR_SIZE,
+    borderRadius: 9999,
+  },
+  unreadDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: '#EF4444',
+  },
+});

--- a/src/features/notifications/hooks/useNotifications.ts
+++ b/src/features/notifications/hooks/useNotifications.ts
@@ -1,0 +1,251 @@
+// Hooks notifications — E4-17.
+// Consomme les RPCs déjà en place (cf. supabase/migrations/20260517100006_notifications_rpcs.sql) :
+//   - get_notifications(p_filter, p_limit)            : liste filtrée
+//   - count_unread_notifications()                    : badge TabBar
+//   - mark_all_notifications_seen()                   : appelé à l'ouverture de l'écran
+//   - mark_notification_read(p_notification_id)       : tap individuel
+//
+// Accept / Reject follow request : direct sur `follows` (le trigger
+// fn_notify_follow gère la suppression de la notif follow_request côté serveur
+// au passage status=accepted). Pour Reject, on supprime aussi la notif côté
+// client (le DELETE de la row follows ne déclenche pas la suppression de notif).
+//
+// Pagination : la RPC actuelle n'expose pas de cursor → useQuery simple à
+// limite 30. À passer en useInfiniteQuery quand la RPC sera étendue.
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type NotificationType =
+  | 'follow'
+  | 'follow_request'
+  | 'like'
+  | 'comment'
+  | 'mention'
+  | 'system'
+  | 'payment';
+
+export type NotificationFilter = 'all' | 'unread' | 'social' | 'payment' | 'ai';
+
+export interface NotificationItem {
+  id: string;
+  recipient_id: string;
+  actor_id: string | null;
+  actor_username: string | null;
+  actor_full_name: string | null;
+  actor_avatar_url: string | null;
+  actor_is_verified: boolean;
+  type: NotificationType;
+  entity_type: string | null;
+  entity_id: string | null;
+  payload: Record<string, unknown> | null;
+  is_seen: boolean;
+  is_read: boolean;
+  created_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constantes
+// ---------------------------------------------------------------------------
+
+const PAGE_LIMIT = 30;
+const STALE_MS = 30_000;
+const UNREAD_COUNT_REFETCH_MS = 30_000;
+
+const LIST_KEY = ['notifications', 'list'] as const;
+const UNREAD_COUNT_KEY = ['notifications', 'unread-count'] as const;
+
+// ---------------------------------------------------------------------------
+// useNotifications(filter) — liste filtrée
+// ---------------------------------------------------------------------------
+
+export function useNotifications(filter: NotificationFilter) {
+  return useQuery({
+    queryKey: [...LIST_KEY, filter],
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc('get_notifications', {
+        p_filter: filter,
+        p_limit: PAGE_LIMIT,
+      });
+      if (error) {
+        logger.warn('get_notifications failed', { message: error.message, filter });
+        throw error;
+      }
+      return (data ?? []) as NotificationItem[];
+    },
+    staleTime: STALE_MS,
+    refetchOnWindowFocus: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useNotificationsUnreadCount — badge TabBar (refetch 30s + on focus)
+// ---------------------------------------------------------------------------
+
+export function useNotificationsUnreadCount() {
+  const query = useQuery({
+    queryKey: UNREAD_COUNT_KEY,
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc('count_unread_notifications');
+      if (error) {
+        logger.warn('count_unread_notifications failed', { message: error.message });
+        throw error;
+      }
+      return typeof data === 'number' ? data : 0;
+    },
+    staleTime: STALE_MS,
+    refetchInterval: UNREAD_COUNT_REFETCH_MS,
+    refetchOnWindowFocus: true,
+  });
+  return query.data ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// useMarkAllNotificationsSeen — appelé 1s après le mount de l'écran
+// ---------------------------------------------------------------------------
+
+export function useMarkAllNotificationsSeen() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      const { error } = await supabase.rpc('mark_all_notifications_seen');
+      if (error) {
+        logger.warn('mark_all_notifications_seen failed', { message: error.message });
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      // Le badge tombe à 0 immédiatement.
+      queryClient.setQueryData(UNREAD_COUNT_KEY, 0);
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useMarkNotificationRead — tap individuel sur une row
+// ---------------------------------------------------------------------------
+
+export function useMarkNotificationRead() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (notificationId: string) => {
+      const { error } = await supabase.rpc('mark_notification_read', {
+        p_notification_id: notificationId,
+      });
+      if (error) {
+        logger.warn('mark_notification_read failed', { message: error.message });
+        throw error;
+      }
+    },
+    onMutate: async (notificationId) => {
+      await queryClient.cancelQueries({ queryKey: LIST_KEY });
+      const previous = queryClient.getQueriesData<NotificationItem[]>({ queryKey: LIST_KEY });
+      queryClient.setQueriesData<NotificationItem[]>({ queryKey: LIST_KEY }, (old) => {
+        if (!Array.isArray(old)) return old;
+        return old.map((n) =>
+          n.id === notificationId ? { ...n, is_read: true, is_seen: true } : n
+        );
+      });
+      return { previous };
+    },
+    onError: (err, _id, context) => {
+      logger.warn('mark_notification_read rollback', { message: err.message });
+      if (context?.previous) {
+        for (const [key, data] of context.previous) {
+          queryClient.setQueryData(key, data);
+        }
+      }
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useAcceptFollowRequest / useRejectFollowRequest
+// ---------------------------------------------------------------------------
+
+/**
+ * Helper : supprime localement (optimistic) la notif follow_request d'un
+ * requester de toutes les caches de liste, renvoie le snapshot pour rollback.
+ */
+function removeFollowRequestFromCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  requesterId: string
+) {
+  const previous = queryClient.getQueriesData<NotificationItem[]>({ queryKey: LIST_KEY });
+  queryClient.setQueriesData<NotificationItem[]>({ queryKey: LIST_KEY }, (old) => {
+    if (!Array.isArray(old)) return old;
+    return old.filter((n) => !(n.type === 'follow_request' && n.actor_id === requesterId));
+  });
+  return previous;
+}
+
+export function useAcceptFollowRequest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (requesterId: string) => {
+      // RPC SECURITY DEFINER (cf. migration 20260523120000_follow_request_rpcs.sql)
+      // — contourne la RLS de `follows` qui empêchait l'UPDATE direct par le
+      // followed_id et faisait un silent no-op.
+      const { error } = await supabase.rpc('accept_follow_request', {
+        p_requester_id: requesterId,
+      });
+      if (error) throw error;
+    },
+    onMutate: async (requesterId) => {
+      await queryClient.cancelQueries({ queryKey: LIST_KEY });
+      const previous = removeFollowRequestFromCache(queryClient, requesterId);
+      return { previous };
+    },
+    onError: (err, _, context) => {
+      logger.warn('accept_follow_request failed', { message: err.message });
+      if (context?.previous) {
+        for (const [key, data] of context.previous) {
+          queryClient.setQueryData(key, data);
+        }
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] });
+      // Notre count de followers a augmenté côté profil perso.
+      void queryClient.invalidateQueries({ queryKey: ['profile', 'me', 'counters'] });
+    },
+  });
+}
+
+export function useRejectFollowRequest() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (requesterId: string) => {
+      // RPC SECURITY DEFINER : DELETE atomique sur `follows` (la row pending)
+      // + `notifications` (la notif follow_request). Évite la RLS qui empêche
+      // le followed_id de DELETE et garantit l'atomicité des 2 cleanups.
+      const { error } = await supabase.rpc('reject_follow_request', {
+        p_requester_id: requesterId,
+      });
+      if (error) throw error;
+    },
+    onMutate: async (requesterId) => {
+      await queryClient.cancelQueries({ queryKey: LIST_KEY });
+      const previous = removeFollowRequestFromCache(queryClient, requesterId);
+      return { previous };
+    },
+    onError: (err, _, context) => {
+      logger.warn('reject_follow_request failed', { message: err.message });
+      if (context?.previous) {
+        for (const [key, data] of context.previous) {
+          queryClient.setQueryData(key, data);
+        }
+      }
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['notifications'] });
+    },
+  });
+}

--- a/src/features/notifications/screens/NotificationsScreen.tsx
+++ b/src/features/notifications/screens/NotificationsScreen.tsx
@@ -1,0 +1,350 @@
+// Écran Notifications — E4-17.
+// 5 tabs filtres + section « Demandes de suivis » prioritaire + groupes
+// par période (Cette semaine / Ce mois / Plus ancien) + empty state par tab.
+// mark_all_notifications_seen() appelé 1s après le mount.
+
+import { Image } from 'expo-image';
+import { router } from 'expo-router';
+import { Bell } from 'lucide-react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  RefreshControl,
+  ScrollView as RNScrollView,
+  StyleSheet,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ScrollView, Spinner, Text, XStack, YStack } from 'tamagui';
+
+import { FollowRequestCard } from '@/features/notifications/components/FollowRequestCard';
+import { NotificationRow } from '@/features/notifications/components/NotificationRow';
+import {
+  useMarkAllNotificationsSeen,
+  useMarkNotificationRead,
+  useNotifications,
+  type NotificationFilter,
+  type NotificationItem,
+} from '@/features/notifications/hooks/useNotifications';
+
+const logoSource = require('../../../../assets/Logo-Doumassi.png') as number;
+
+const FILTERS: { id: NotificationFilter; label: string }[] = [
+  { id: 'all', label: 'Toutes' },
+  { id: 'unread', label: 'Non lus' },
+  { id: 'social', label: 'Social' },
+  { id: 'payment', label: 'Paiement' },
+  { id: 'ai', label: 'IA' },
+];
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const SEEN_DELAY_MS = 1000;
+
+// Mock affiché en empty state sur l'onglet IA (cf. ticket : "toujours
+// afficher au moins 1 notif mock pour la démo"). created_at épinglé 7 jours
+// avant le chargement du module pour éviter la dérive cosmétique de l'âge
+// affiché pendant la session ("à l'instant" → "1min" → "2min"…).
+const AI_MOCK: NotificationItem = {
+  id: 'mock-ai-welcome',
+  recipient_id: '',
+  actor_id: null,
+  actor_username: null,
+  actor_full_name: null,
+  actor_avatar_url: null,
+  actor_is_verified: false,
+  type: 'system',
+  entity_type: null,
+  entity_id: null,
+  payload: { title: 'Bienvenue sur l’app' },
+  is_seen: true,
+  is_read: true,
+  created_at: new Date(Date.now() - 7 * DAY_MS).toISOString(),
+};
+
+function NotificationsHeader() {
+  return (
+    <YStack backgroundColor="$background" paddingTop="$3" paddingBottom="$2">
+      <XStack alignItems="center" justifyContent="center" paddingHorizontal="$4" height={42}>
+        <Image source={logoSource} style={styles.logo} contentFit="contain" transition={200} />
+      </XStack>
+      <Text color="$color" fontSize={26} fontWeight="700" paddingHorizontal={20} marginTop="$2">
+        Notifications
+      </Text>
+    </YStack>
+  );
+}
+
+function FilterTabs({
+  active,
+  onChange,
+}: {
+  active: NotificationFilter;
+  onChange: (filter: NotificationFilter) => void;
+}) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.filterTabsContent}
+    >
+      {FILTERS.map((f) => {
+        const isActive = active === f.id;
+        return (
+          <YStack
+            key={f.id}
+            height={36}
+            paddingHorizontal={14}
+            borderRadius={18}
+            backgroundColor={isActive ? '#FFFFFF' : '$surface'}
+            alignItems="center"
+            justifyContent="center"
+            onPress={() => onChange(f.id)}
+            pressStyle={{ scale: 0.97 }}
+            accessibilityRole="button"
+            accessibilityLabel={`Filtre ${f.label}`}
+          >
+            <Text
+              color={isActive ? '#000000' : '$textSecondary'}
+              fontSize={14}
+              fontWeight={isActive ? '700' : '500'}
+            >
+              {f.label}
+            </Text>
+          </YStack>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+function PeriodHeader({ label }: { label: string }) {
+  return (
+    <Text
+      color="$textSecondary"
+      fontSize={12}
+      fontWeight="700"
+      paddingHorizontal="$4"
+      paddingTop="$4"
+      paddingBottom="$2"
+      style={styles.periodHeader}
+    >
+      {label}
+    </Text>
+  );
+}
+
+function EmptyState({ filter }: { filter: NotificationFilter }) {
+  const { title, subtitle } = useMemo(() => {
+    switch (filter) {
+      case 'unread':
+        return { title: 'Aucune notification non lue', subtitle: '' };
+      case 'social':
+        return { title: 'Pas d’activité sociale récente', subtitle: '' };
+      case 'payment':
+        return { title: 'Pas de transaction récente', subtitle: '' };
+      case 'ai':
+        // L'onglet IA injecte AI_MOCK quand il n'y a rien — cet empty
+        // state ne devrait jamais être atteint, sauf si la mock est retirée.
+        return { title: 'Pas de news IA pour l’instant', subtitle: '' };
+      default:
+        return {
+          title: 'Vous êtes à jour',
+          subtitle: 'Les likes et commentaires apparaîtront ici bientôt.',
+        };
+    }
+  }, [filter]);
+  return (
+    <YStack alignItems="center" justifyContent="center" padding="$6" gap="$3" marginTop="$10">
+      <Bell size={32} color="#A0A0A0" />
+      <Text color="$color" fontSize={17} fontWeight="700" textAlign="center">
+        {title}
+      </Text>
+      {subtitle ? (
+        <Text color="$textSecondary" fontSize={14} textAlign="center" maxWidth={300}>
+          {subtitle}
+        </Text>
+      ) : null}
+    </YStack>
+  );
+}
+
+function partitionByPeriod(notifs: NotificationItem[]) {
+  const now = Date.now();
+  const followRequests: NotificationItem[] = [];
+  const week: NotificationItem[] = [];
+  const month: NotificationItem[] = [];
+  const older: NotificationItem[] = [];
+  for (const n of notifs) {
+    if (n.type === 'follow_request') {
+      followRequests.push(n);
+      continue;
+    }
+    const ageMs = now - new Date(n.created_at).getTime();
+    if (ageMs < 7 * DAY_MS) week.push(n);
+    else if (ageMs < 30 * DAY_MS) month.push(n);
+    else older.push(n);
+  }
+  return { followRequests, week, month, older };
+}
+
+export function NotificationsScreen() {
+  const [filter, setFilter] = useState<NotificationFilter>('all');
+  const query = useNotifications(filter);
+  const markAllSeen = useMarkAllNotificationsSeen();
+  const markRead = useMarkNotificationRead();
+  const seenSentRef = useRef(false);
+
+  // Marquage 'seen' au mount, après 1s — laisse à l'user le temps de voir
+  // les dots rouges. Ne s'exécute qu'une fois par session de l'écran.
+  useEffect(() => {
+    if (seenSentRef.current) return;
+    const timer = setTimeout(() => {
+      seenSentRef.current = true;
+      markAllSeen.mutate();
+    }, SEEN_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [markAllSeen]);
+
+  // Tab IA : on injecte la mock en tête si la liste est vide ou ne contient
+  // pas déjà au moins une notif système. `list` est memoizé pour stabiliser
+  // sa référence (sinon le useMemo de partitionByPeriod invalide à chaque
+  // render).
+  const list = useMemo(() => {
+    const raw = query.data ?? [];
+    return filter === 'ai' && !raw.some((n) => n.type === 'system') ? [AI_MOCK, ...raw] : raw;
+  }, [filter, query.data]);
+
+  const { followRequests, week, month, older } = useMemo(() => partitionByPeriod(list), [list]);
+
+  // useCallback : sinon `memo(NotificationRow)` est inefficace (nouvelle
+  // référence d'`onPress` à chaque render du screen → toutes les rows
+  // re-render).
+  const handlePressNotif = useCallback(
+    (notif: NotificationItem) => {
+      // Marquer lu (optimistic) — ignoré pour la mock IA (id non-uuid).
+      if (notif.id !== AI_MOCK.id) markRead.mutate(notif.id);
+      // Route selon le type.
+      switch (notif.type) {
+        case 'follow':
+          if (notif.actor_id) router.push(`/profile/${notif.actor_id}`);
+          return;
+        case 'like':
+        case 'comment':
+        case 'mention':
+          if (notif.entity_id) router.push(`/post/${notif.entity_id}`);
+          return;
+        case 'system':
+        case 'payment':
+          // Placeholder MVP — pas d'écran dédié encore.
+          return;
+        default:
+          return;
+      }
+    },
+    [markRead]
+  );
+
+  const isEmpty =
+    !query.isLoading &&
+    followRequests.length === 0 &&
+    week.length === 0 &&
+    month.length === 0 &&
+    older.length === 0;
+
+  const onScroll = (_e: NativeSyntheticEvent<NativeScrollEvent>) => {
+    // Hook pour de futures interactions (scroll-to-top reset, etc.) — no-op MVP.
+  };
+
+  return (
+    <SafeAreaView style={styles.safe} edges={['top']}>
+      <RNScrollView
+        style={styles.flex1}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        onScroll={onScroll}
+        scrollEventThrottle={16}
+        refreshControl={
+          <RefreshControl
+            refreshing={query.isRefetching}
+            onRefresh={() => void query.refetch()}
+            tintColor="#FFFFFF"
+          />
+        }
+      >
+        <NotificationsHeader />
+        <FilterTabs active={filter} onChange={setFilter} />
+
+        {query.isLoading ? (
+          <YStack alignItems="center" paddingVertical="$8">
+            <Spinner color="$color" size="large" />
+          </YStack>
+        ) : null}
+
+        {isEmpty ? <EmptyState filter={filter} /> : null}
+
+        {followRequests.length > 0 ? (
+          <YStack marginTop="$3">
+            <Text
+              color="$color"
+              fontSize={15}
+              fontWeight="700"
+              paddingHorizontal="$4"
+              paddingBottom="$2"
+            >
+              Demandes de suivis ({followRequests.length})
+            </Text>
+            {followRequests.map((n) => (
+              <FollowRequestCard key={n.id} notif={n} />
+            ))}
+          </YStack>
+        ) : null}
+
+        {week.length > 0 ? (
+          <YStack>
+            <PeriodHeader label="CETTE SEMAINE" />
+            {week.map((n) => (
+              <NotificationRow key={n.id} notif={n} onPress={handlePressNotif} />
+            ))}
+          </YStack>
+        ) : null}
+
+        {month.length > 0 ? (
+          <YStack>
+            <PeriodHeader label="CE MOIS" />
+            {month.map((n) => (
+              <NotificationRow key={n.id} notif={n} onPress={handlePressNotif} />
+            ))}
+          </YStack>
+        ) : null}
+
+        {older.length > 0 ? (
+          <YStack>
+            <PeriodHeader label="PLUS ANCIEN" />
+            {older.map((n) => (
+              <NotificationRow key={n.id} notif={n} onPress={handlePressNotif} />
+            ))}
+          </YStack>
+        ) : null}
+      </RNScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: '#000000' },
+  flex1: { flex: 1, backgroundColor: '#000000' },
+  scrollContent: {
+    backgroundColor: '#000000',
+    paddingBottom: 32,
+  },
+  logo: { width: 126, height: 30 },
+  filterTabsContent: {
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  periodHeader: {
+    letterSpacing: 0.5,
+  },
+});

--- a/supabase/migrations/20260523120000_follow_request_rpcs.sql
+++ b/supabase/migrations/20260523120000_follow_request_rpcs.sql
@@ -1,0 +1,69 @@
+-- E4-17 — RPCs pour gérer les demandes de suivi inline (Accepter / Refuser).
+--
+-- La RLS de `follows` n'autorise pas le followed_id à UPDATE/DELETE la row
+-- pending (seul le follower_id pourrait, ce qui n'a pas de sens ici). Ces
+-- RPCs SECURITY DEFINER contournent proprement la RLS, et vérifient elles-
+-- mêmes que c'est bien le followed_id courant qui agit (auth.uid()).
+--
+-- Appliquées via AI Supabase sur dev + staging le 23 mai 2026
+-- (migration follow_request_rpcs).
+
+-- ---------------------------------------------------------------------------
+-- accept_follow_request : passe le statut pending → accepted.
+-- Le trigger trg_notify_follow (cf. 20260517100005_notifications_triggers.sql)
+-- se déclenche sur l'UPDATE et :
+--   - supprime la notif follow_request reçue par le followed_id
+--   - crée la notif follow envoyée au requester (le follower_id)
+-- ---------------------------------------------------------------------------
+
+create or replace function public.accept_follow_request(p_requester_id uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_me uuid := auth.uid();
+begin
+  if v_me is null then raise exception 'Not authenticated'; end if;
+  update public.follows
+  set status = 'accepted'
+  where follower_id = p_requester_id
+    and followed_id = v_me
+    and status = 'pending';
+end;
+$$;
+
+grant execute on function public.accept_follow_request(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- reject_follow_request : DELETE atomique de la row follows ET de la notif
+-- follow_request associée. Le trigger fn_notify_follow ne se déclenche pas
+-- sur DELETE, donc le nettoyage de la notif doit être fait ici.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.reject_follow_request(p_requester_id uuid)
+returns void
+language plpgsql security definer set search_path = public as $$
+declare
+  v_me uuid := auth.uid();
+begin
+  if v_me is null then raise exception 'Not authenticated'; end if;
+
+  delete from public.follows
+  where follower_id = p_requester_id
+    and followed_id = v_me
+    and status = 'pending';
+
+  delete from public.notifications
+  where recipient_id = v_me
+    and actor_id = p_requester_id
+    and type = 'follow_request';
+end;
+$$;
+
+grant execute on function public.reject_follow_request(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Hygiène : pas appelables par anon/public (cohérent avec soft_delete_post)
+-- ---------------------------------------------------------------------------
+
+revoke execute on function public.accept_follow_request(uuid) from anon, public;
+revoke execute on function public.reject_follow_request(uuid) from anon, public;


### PR DESCRIPTION
## Ticket lié

Closes #165

## Résumé

Écran Notifications (tab Bell) — 5 filtres + section « Demandes de suivis » prioritaire + groupement par période + badge TabBar.

- Route `app/(tabs)/notifications.tsx` (remplace le placeholder)
- 5 tabs filtres : **Toutes / Non lus / Social / Paiement / IA** (capsule blanche actif, surface inactif — cohérent avec FeedScreen)
- **Section « Demandes de suivis » prioritaire** : `FollowRequestCard` avec boutons inline `Confirmer` / `Refuser` (optimistic remove, états pending)
- **Groupement par période** : CETTE SEMAINE (< 7j) / CE MOIS (< 30j) / PLUS ANCIEN (≥ 30j)
- `NotificationRow` : format texte selon `type` (follow / like / comment / mention / system / payment), dot rouge non-vu, tap → route contextuelle (`/profile/[id]` ou `/post/[id]`)
- Mock IA injectée si tab IA vide (`title: 'Bienvenue sur l'app'`, conforme ticket)
- `mark_all_notifications_seen` appelé 1s après le mount
- `mark_notification_read` optimistic sur tap individuel
- Pull-to-refresh, empty states par tab
- **Badge TabBar** sur l'onglet Bell : nombre d'unread, cap visuel `99+`, `undefined` si 0

## RPCs Supabase ajoutées

Nouvelles RPCs `accept_follow_request` / `reject_follow_request` (`SECURITY DEFINER`) — contournent la RLS de `follows` qui empêchait le `followed_id` d'`UPDATE`/`DELETE` ses propres demandes. Le `reject` fait un **DELETE atomique** sur `follows` + `notifications` (le trigger ne se déclenche pas sur DELETE).

Migration `20260523120000_follow_request_rpcs.sql` — appliquée sur dev + staging.

## Notes review CTO

- **Migration commitée vide initialement** — j'ai rempli avec le SQL exact appliqué.
- **Branche pas rebasée à la création** (manquait #179 Masquer) — rebasé sans conflit.
- Pattern défensif sur `AuthenticatedTabs` (sous-composant) pour éviter d'appeler `useNotificationsUnreadCount` avant le guard auth : très propre.
- `useCallback` sur `handlePressNotif` avec commentaire explicite — `memo()` sur les rows resterait inutile sinon.

## Checklist

- [x] Le code compile et passe le lint local
- [x] Migration DB commitée + appliquée
- [x] Optimistic + rollback
- [x] Aucun console.log oublié

## Comment tester

1. `git checkout` cette branche + rebuild Dev Build pas nécessaire (pas de natif ajouté)
2. Recevoir une demande de suivi (compte privé) → tab Bell → badge → écran Notifications → carte « Demandes de suivis » → Confirmer ou Refuser
3. Liker / commenter un post d'un autre compte → l'auteur voit la notif dans la liste
4. Tester chaque filtre (Toutes / Non lus / Social / Paiement / IA)