### PR TITLE
chore(db): migrations Sprint 4 appliquées en dev + staging

### DIFF
--- a/supabase/migrations/20260525120000_extend_stories_for_photo_support.sql
+++ b/supabase/migrations/20260525120000_extend_stories_for_photo_support.sql
@@ -1,0 +1,15 @@
+-- Sprint 4 : support photo + vidéo dans les stories (cf maquette).
+-- Le ticket #52 (E4-12) demandait vidéo only mais la maquette montre les 2
+-- formats. On aligne sur la maquette : rename video_url → media_url + ajout
+-- media_type. duration_seconds rendu nullable (pas pertinent pour les photos).
+--
+-- Appliquée via AI Supabase sur dev + staging le 25 mai 2026
+-- (migration extend_stories_for_photo_support).
+
+alter table public.stories rename column video_url to media_url;
+
+alter table public.stories
+  add column if not exists media_type text not null default 'video'
+    check (media_type in ('image', 'video'));
+
+alter table public.stories alter column duration_seconds drop not null;

--- a/supabase/migrations/20260525120001_comments_like_count_and_likes_table.sql
+++ b/supabase/migrations/20260525120001_comments_like_count_and_likes_table.sql
@@ -1,0 +1,53 @@
+-- Sprint 4 : likes sur les commentaires (cf maquette).
+-- Même pattern que posts.like_count + table likes + trigger compteur :
+-- une colonne dénormalisée pour l'affichage rapide + table de liaison pour
+-- la source de vérité, maintenue cohérente par un trigger.
+--
+-- Appliquée via AI Supabase sur dev + staging le 25 mai 2026
+-- (migration comments_like_count_and_likes_table).
+
+-- Compteur dénormalisé sur comments
+alter table public.comments
+  add column if not exists like_count int not null default 0;
+
+-- Table de liaison user ↔ comment
+create table if not exists public.comment_likes (
+  comment_id uuid not null references public.comments(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (comment_id, user_id)
+);
+
+alter table public.comment_likes enable row level security;
+
+create policy "comment_likes select all" on public.comment_likes
+  for select to authenticated using (true);
+
+create policy "comment_likes insert own" on public.comment_likes
+  for insert to authenticated with check (user_id = auth.uid());
+
+create policy "comment_likes delete own" on public.comment_likes
+  for delete to authenticated using (user_id = auth.uid());
+
+-- Trigger qui maintient comments.like_count cohérent
+create or replace function public.fn_comments_like_count()
+returns trigger language plpgsql security definer set search_path = public as $$
+begin
+  if TG_OP = 'INSERT' then
+    update public.comments set like_count = like_count + 1 where id = NEW.comment_id;
+    return NEW;
+  elsif TG_OP = 'DELETE' then
+    update public.comments set like_count = greatest(0, like_count - 1) where id = OLD.comment_id;
+    return OLD;
+  end if;
+  return null;
+end;
+$$;
+
+drop trigger if exists trg_comments_like_count on public.comment_likes;
+create trigger trg_comments_like_count
+  after insert or delete on public.comment_likes
+  for each row execute function public.fn_comments_like_count();
+
+-- Hygiène : trigger function pas appelable via REST
+revoke execute on function public.fn_comments_like_count() from anon, authenticated;

--- a/supabase/migrations/20260525120002_comments_rpcs.sql
+++ b/supabase/migrations/20260525120002_comments_rpcs.sql
@@ -1,0 +1,134 @@
+-- Sprint 4 : RPCs commentaires (E4-11).
+--
+-- Toutes SECURITY DEFINER + set search_path = public.
+-- get_post_comments retourne déjà liked_by_me pour économiser un round-trip.
+-- create_comment valide la visibilité du post + cohérence du parent.
+-- delete_comment fait du soft delete par l'auteur (pattern soft_delete_post).
+-- toggle_comment_like : INSERT/DELETE sur comment_likes, le trigger
+-- maintient comments.like_count.
+--
+-- Appliquées via AI Supabase sur dev + staging le 25 mai 2026
+-- (migration comments_rpcs).
+
+-- ---------------------------------------------------------------------------
+-- get_post_comments : threadés. Top-level d'abord, puis enfants chrono asc.
+-- L'ordre composite garantit que chaque thread (root + ses enfants) reste
+-- groupé dans le retour.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.get_post_comments(p_post_id uuid, p_limit int default 50)
+returns table (
+  id uuid, post_id uuid, author_id uuid,
+  author_username text, author_full_name text, author_avatar_url text, author_is_verified boolean,
+  parent_comment_id uuid, content text, created_at timestamptz,
+  like_count int, liked_by_me boolean
+)
+language sql security definer set search_path = public stable as $$
+  select
+    c.id, c.post_id, c.author_id,
+    pr.username, pr.full_name, pr.avatar_url, coalesce(pr.is_verified, false),
+    c.parent_comment_id, c.content, c.created_at,
+    c.like_count,
+    exists (select 1 from public.comment_likes cl where cl.comment_id = c.id and cl.user_id = auth.uid())
+  from public.comments c
+  join public.profiles pr on pr.id = c.author_id
+  where c.post_id = p_post_id
+    and c.deleted_at is null
+    and public.can_view_post((select author_id from public.posts where id = c.post_id))
+  order by
+    coalesce(c.parent_comment_id, c.id),
+    case when c.parent_comment_id is null then 0 else 1 end,
+    c.created_at asc
+  limit p_limit;
+$$;
+
+grant execute on function public.get_post_comments(uuid, int) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- create_comment : valide post visible + parent top-level même post (1 seul
+-- niveau de profondeur, pas de réponse à une réponse).
+-- ---------------------------------------------------------------------------
+
+create or replace function public.create_comment(
+  p_post_id uuid, p_content text, p_parent_comment_id uuid default null
+)
+returns uuid language plpgsql security definer set search_path = public as $$
+declare
+  v_user uuid := auth.uid();
+  v_new_id uuid;
+begin
+  if v_user is null then raise exception 'Not authenticated'; end if;
+  if length(trim(p_content)) = 0 then raise exception 'Empty content'; end if;
+
+  if not exists (
+    select 1 from public.posts p
+    where p.id = p_post_id and p.deleted_at is null and public.can_view_post(p.author_id)
+  ) then
+    raise exception 'Post not visible';
+  end if;
+
+  if p_parent_comment_id is not null then
+    if not exists (
+      select 1 from public.comments c
+      where c.id = p_parent_comment_id and c.post_id = p_post_id
+        and c.deleted_at is null and c.parent_comment_id is null
+    ) then
+      raise exception 'Invalid parent comment';
+    end if;
+  end if;
+
+  insert into public.comments (post_id, author_id, content, parent_comment_id)
+  values (p_post_id, v_user, p_content, p_parent_comment_id)
+  returning id into v_new_id;
+
+  return v_new_id;
+end;
+$$;
+
+grant execute on function public.create_comment(uuid, text, uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- delete_comment : soft delete par l'auteur (pattern soft_delete_post)
+-- ---------------------------------------------------------------------------
+
+create or replace function public.delete_comment(p_comment_id uuid)
+returns boolean language plpgsql security definer set search_path = public as $$
+declare v_deleted int;
+begin
+  if auth.uid() is null then raise exception 'Not authenticated'; end if;
+  update public.comments set deleted_at = now()
+  where id = p_comment_id and author_id = auth.uid() and deleted_at is null;
+  get diagnostics v_deleted = row_count;
+  return v_deleted > 0;
+end;
+$$;
+
+grant execute on function public.delete_comment(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- toggle_comment_like : like/unlike. Le trigger trg_comments_like_count
+-- maintient comments.like_count cohérent.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.toggle_comment_like(p_comment_id uuid)
+returns boolean language plpgsql security definer set search_path = public as $$
+declare v_user uuid := auth.uid();
+begin
+  if v_user is null then raise exception 'Not authenticated'; end if;
+  if exists (select 1 from public.comment_likes where comment_id = p_comment_id and user_id = v_user) then
+    delete from public.comment_likes where comment_id = p_comment_id and user_id = v_user;
+    return false;
+  else
+    insert into public.comment_likes (comment_id, user_id) values (p_comment_id, v_user);
+    return true;
+  end if;
+end;
+$$;
+
+grant execute on function public.toggle_comment_like(uuid) to authenticated;
+
+-- Hygiène : revoke anon/public sur les 4 RPCs
+revoke execute on function public.get_post_comments(uuid, int) from anon, public;
+revoke execute on function public.create_comment(uuid, text, uuid) from anon, public;
+revoke execute on function public.delete_comment(uuid) from anon, public;
+revoke execute on function public.toggle_comment_like(uuid) from anon, public;

--- a/supabase/migrations/20260525120003_stories_rpcs.sql
+++ b/supabase/migrations/20260525120003_stories_rpcs.sql
@@ -1,0 +1,88 @@
+-- Sprint 4 : RPCs stories (E4-12 / E4-13).
+--
+-- get_stories_feed : liste des stories actives groupées par auteur, mes
+-- stories en 1er. Le client groupera par author_id côté UI (Instagram-like).
+-- create_story_view : idempotent via PK composite (story_id, viewer_id).
+-- get_story_viewers : réservé à l'auteur de la story.
+--
+-- Appliquées via AI Supabase sur dev + staging le 25 mai 2026
+-- (migration stories_rpcs).
+
+-- ---------------------------------------------------------------------------
+-- get_stories_feed : stories actives (mes follows acceptés + moi).
+-- expires_at > now() filtre les stories expirées (purge pg_cron à 3h, mais
+-- on filtre quand même pour la fenêtre d'inertie entre l'expiration et la purge).
+-- ---------------------------------------------------------------------------
+
+create or replace function public.get_stories_feed()
+returns table (
+  id uuid, author_id uuid,
+  author_username text, author_avatar_url text, author_is_verified boolean,
+  media_url text, media_type text, thumbnail_url text, duration_seconds int,
+  created_at timestamptz, expires_at timestamptz,
+  viewed_by_me boolean, is_mine boolean
+)
+language sql security definer set search_path = public stable as $$
+  with my_follows as (
+    select followed_id from public.follows
+    where follower_id = auth.uid() and status = 'accepted'
+  )
+  select
+    s.id, s.author_id,
+    pr.username, pr.avatar_url, coalesce(pr.is_verified, false),
+    s.media_url, s.media_type, s.thumbnail_url, s.duration_seconds,
+    s.created_at, s.expires_at,
+    exists (select 1 from public.story_views v where v.story_id = s.id and v.viewer_id = auth.uid()),
+    s.author_id = auth.uid()
+  from public.stories s
+  join public.profiles pr on pr.id = s.author_id
+  where s.expires_at > now()
+    and (s.author_id = auth.uid() or s.author_id in (select followed_id from my_follows))
+  order by
+    case when s.author_id = auth.uid() then 0 else 1 end,
+    s.created_at desc;
+$$;
+
+grant execute on function public.get_stories_feed() to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- create_story_view : marque une story comme vue. Idempotent via la PK
+-- composite (story_id, viewer_id) — pas de doublon si le viewer revoit.
+-- ---------------------------------------------------------------------------
+
+create or replace function public.create_story_view(p_story_id uuid)
+returns void language plpgsql security definer set search_path = public as $$
+declare v_user uuid := auth.uid();
+begin
+  if v_user is null then raise exception 'Not authenticated'; end if;
+  insert into public.story_views (story_id, viewer_id) values (p_story_id, v_user)
+  on conflict (story_id, viewer_id) do nothing;
+end;
+$$;
+
+grant execute on function public.create_story_view(uuid) to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- get_story_viewers : liste « vu par » pour l'auteur de la story uniquement.
+-- Le where s.author_id = auth.uid() empêche un viewer de voir qui d'autre
+-- a vu (même si la RLS de story_views permettait déjà au viewer de voir
+-- sa propre ligne).
+-- ---------------------------------------------------------------------------
+
+create or replace function public.get_story_viewers(p_story_id uuid)
+returns table (viewer_id uuid, viewer_username text, viewer_avatar_url text, viewed_at timestamptz)
+language sql security definer set search_path = public stable as $$
+  select v.viewer_id, pr.username, pr.avatar_url, v.viewed_at
+  from public.story_views v
+  join public.profiles pr on pr.id = v.viewer_id
+  join public.stories s on s.id = v.story_id
+  where v.story_id = p_story_id and s.author_id = auth.uid()
+  order by v.viewed_at desc;
+$$;
+
+grant execute on function public.get_story_viewers(uuid) to authenticated;
+
+-- Hygiène : revoke anon/public
+revoke execute on function public.get_stories_feed() from anon, public;
+revoke execute on function public.create_story_view(uuid) from anon, public;
+revoke execute on function public.get_story_viewers(uuid) from anon, public;


### PR DESCRIPTION
## Summary

Cohérence repo ↔ BDD : reflète les 4 migrations exécutées via **AI Supabase** sur dev + staging le 25 mai 2026.

## Migrations

| # | Nom | Rôle |
|---|---|---|
| 1 | `extend_stories_for_photo_support` | rename `video_url` → `media_url`, ajout `media_type` (image/video, default video), `duration_seconds` nullable. Aligne sur la maquette qui montre photo + vidéo. |
| 2 | `comments_like_count_and_likes_table` | `comments.like_count` + table `comment_likes` + RLS (3 policies) + trigger compteur. Pattern identique à `posts.like_count`. |
| 3 | `comments_rpcs` | `get_post_comments` (threadés), `create_comment` (valide visibilité + parent top-level), `delete_comment` (soft), `toggle_comment_like`. |
| 4 | `stories_rpcs` | `get_stories_feed` (follows acceptés + moi, mes stories en 1er), `create_story_view` (idempotent), `get_story_viewers` (auteur seulement). |

Toutes les RPCs : `SECURITY DEFINER` + `set search_path = public` + `revoke anon/public` par hygiène (cohérent avec Sprint 3).

## Bonne nouvelle Sprint 0

Tables `comments` / `stories` / `story_views` étaient **déjà en place avec RLS**, idem `profiles.push_token` et les crons de purge (`purge-expired-stories` 24h, `purge-old-read-notifications` 90j). Beaucoup de travail Sprint 0 qui paie pour le Sprint 4.

## Préreq par ticket Sprint 4

- **#51 Commentaires** : migrations 2 + 3 ✅
- **#52 + #53 Stories** : migrations 1 + 4 ✅
- **#54 Push notifs** : pas de migration BDD ce sprint (Edge Function à venir)
- **#56 Deep links** : pas de migration BDD

## Test plan

- [x] 4/4 appliquées dev (AI Supabase confirmé)
- [x] 4/4 appliquées staging (AI Supabase confirmé)
- [ ] À tester côté client une fois les tickets Sprint 4 implémentés

🤖 Generated with [Claude Code](https://claude.com/claude-code)