### PR TITLE
feat(notifications): infra Push Expo (E4-14 préreqs CTO)

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,14 +24,12 @@
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "permissions": [
+        "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO",
         "android.permission.MODIFY_AUDIO_SETTINGS",
         "android.permission.FOREGROUND_SERVICE",
         "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK",
-        "android.permission.RECORD_AUDIO",
-        "android.permission.MODIFY_AUDIO_SETTINGS",
-        "android.permission.FOREGROUND_SERVICE",
-        "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"
+        "android.permission.POST_NOTIFICATIONS"
       ],
       "package": "com.doumassi.app"
     },
@@ -46,7 +44,21 @@
       "expo-video",
       "expo-localization",
       "expo-secure-store",
-      "expo-web-browser"
+      "expo-web-browser",
+      [
+        "expo-camera",
+        {
+          "cameraPermission": "DOUMASSI a besoin d'accéder à votre caméra pour publier des photos et des stories.",
+          "microphonePermission": "DOUMASSI a besoin du microphone pour enregistrer des stories vidéo.",
+          "recordAudioAndroid": true
+        }
+      ],
+      [
+        "expo-notifications",
+        {
+          "color": "#10D970"
+        }
+      ]
     ],
     "extra": {
       "router": {},

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -46,6 +46,9 @@ module.exports = defineConfig([
       'web-build/**',
       'babel.config.js',
       'metro.config.js',
+      // Edge Functions Supabase tournent en Deno (imports URL, env.Deno...).
+      // Pas le même runtime que l'app RN ; on les exclut du lint Node/RN.
+      'supabase/functions/**',
     ],
   },
 

--- a/supabase/functions/send-push/index.ts
+++ b/supabase/functions/send-push/index.ts
@@ -1,0 +1,197 @@
+// Edge Function `send-push` — E4-14.
+//
+// Appelée par un trigger DB sur INSERT dans `public.notifications`.
+// Récupère le push_token du recipient (table `profiles`), construit un
+// message localisé selon le type (`follow`, `like`, `comment`, etc.),
+// puis appelle l'Expo Push API.
+//
+// Secrets attendus (à setter via `supabase secrets set` ou interface admin) :
+//   - EXPO_ACCESS_TOKEN : token Bearer pour l'API Expo Push
+// Secrets injectés automatiquement par Supabase Edge Functions :
+//   - SUPABASE_URL
+//   - SUPABASE_SERVICE_ROLE_KEY
+//
+// Side-effect : si Expo retourne `DeviceNotRegistered`, on reset le token
+// du profil concerné (sinon on continuerait à push sur un token invalide).
+
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const EXPO_PUSH_API = 'https://exp.host/--/api/v2/push/send';
+
+type NotificationType =
+  | 'follow'
+  | 'follow_request'
+  | 'like'
+  | 'comment'
+  | 'mention'
+  | 'system'
+  | 'payment';
+
+interface NotificationRow {
+  id: string;
+  recipient_id: string;
+  actor_id: string | null;
+  type: NotificationType;
+  entity_type: string | null;
+  entity_id: string | null;
+  payload: Record<string, unknown> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildMessage(
+  notif: NotificationRow,
+  actorUsername: string | null
+): { title: string; body: string; data: Record<string, unknown> } {
+  const handle = actorUsername ? `@${actorUsername}` : 'Quelqu’un';
+
+  let body: string;
+  switch (notif.type) {
+    case 'follow':
+      body = `${handle} a commencé à vous suivre`;
+      break;
+    case 'follow_request':
+      body = `${handle} veut vous suivre`;
+      break;
+    case 'like':
+      body = `${handle} a aimé votre post`;
+      break;
+    case 'comment': {
+      const preview = (notif.payload?.preview as string | undefined)?.trim();
+      body = preview ? `${handle} a commenté : « ${preview} »` : `${handle} a commenté votre post`;
+      break;
+    }
+    case 'mention':
+      body = `${handle} vous a mentionné`;
+      break;
+    case 'payment': {
+      const from = (notif.payload?.from as string | undefined) ?? 'un utilisateur';
+      body = `Paiement reçu de ${from}`;
+      break;
+    }
+    case 'system': {
+      const title = (notif.payload?.title as string | undefined) ?? 'Nouveauté';
+      body = title;
+      break;
+    }
+    default:
+      body = 'Vous avez une nouvelle notification';
+  }
+
+  return {
+    title: 'DOUMASSI',
+    body,
+    data: {
+      notification_id: notif.id,
+      type: notif.type,
+      entity_type: notif.entity_type,
+      entity_id: notif.entity_id,
+      actor_id: notif.actor_id,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+serve(async (req) => {
+  try {
+    // Le trigger DB envoie le payload { type: 'INSERT', table: 'notifications',
+    // record: <NotificationRow>, schema: 'public' }. On accepte aussi un appel
+    // direct avec { notification: <NotificationRow> } pour faciliter les tests.
+    const payload = await req.json();
+    const notification: NotificationRow | undefined = payload.record ?? payload.notification;
+
+    if (!notification?.id || !notification?.recipient_id) {
+      return new Response(JSON.stringify({ error: 'Missing notification payload' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Ne pas envoyer de push pour les notifs `follow_request` qui ont déjà
+    // un placeholder UX (les demandes de suivi sont surtout traitées in-app).
+    // À ajuster selon les retours d'usage post-bêta.
+    if (notification.type === 'follow_request') {
+      return new Response(JSON.stringify({ ok: true, skipped: 'follow_request' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
+    );
+
+    const { data: recipient, error: recipientErr } = await supabase
+      .from('profiles')
+      .select('push_token, username')
+      .eq('id', notification.recipient_id)
+      .single();
+
+    if (recipientErr) throw recipientErr;
+    if (!recipient?.push_token) {
+      return new Response(JSON.stringify({ ok: true, skipped: 'no_push_token' }), {
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    let actorUsername: string | null = null;
+    if (notification.actor_id) {
+      const { data: actor } = await supabase
+        .from('profiles')
+        .select('username')
+        .eq('id', notification.actor_id)
+        .single();
+      actorUsername = actor?.username ?? null;
+    }
+
+    const message = buildMessage(notification, actorUsername);
+
+    const expoToken = Deno.env.get('EXPO_ACCESS_TOKEN');
+    const expoRes = await fetch(EXPO_PUSH_API, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'Accept-Encoding': 'gzip, deflate',
+        // EXPO_ACCESS_TOKEN n'est requis que pour les comptes Expo en mode
+        // "enhanced security" — sinon les push fonctionnent en anonyme. On le
+        // passe quand même si présent pour éviter les rate limits.
+        ...(expoToken ? { Authorization: `Bearer ${expoToken}` } : {}),
+      },
+      body: JSON.stringify({
+        to: recipient.push_token,
+        sound: 'default',
+        priority: 'high',
+        ...message,
+      }),
+    });
+
+    const expoData = await expoRes.json();
+
+    // Si Expo nous dit que le token n'est plus valide, on le retire du profil.
+    // Évite de continuer à essayer un device désinstallé / désinscrit.
+    const errorDetails = expoData?.data?.details?.error;
+    if (errorDetails === 'DeviceNotRegistered') {
+      await supabase
+        .from('profiles')
+        .update({ push_token: null })
+        .eq('id', notification.recipient_id);
+    }
+
+    return new Response(JSON.stringify({ ok: true, expo: expoData }), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('send-push error:', err);
+    return new Response(JSON.stringify({ error: (err as Error).message }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+});

--- a/supabase/migrations/20260526110000_enable_pg_net.sql
+++ b/supabase/migrations/20260526110000_enable_pg_net.sql
@@ -1,0 +1,18 @@
+-- E4-14 — Préreq de l'infra push notifications.
+--
+-- L'extension pg_net est utilisée par le trigger fn_trigger_push_notification
+-- (cf. 20260526120000_trigger_push_on_notification_insert.sql) pour appeler
+-- l'Edge Function `send-push` via net.http_post.
+--
+-- Sans cette extension, l'INSERT dans `notifications` échoue avec
+-- « schema 'net' does not exist » dès le premier appel au trigger
+-- (PostgreSQL ne valide les références à la compilation pour les fonctions
+-- plpgsql, donc le CREATE FUNCTION passe mais l'exécution plante).
+--
+-- Le schéma `extensions` est le pattern Supabase standard (cohérent avec
+-- le `set search_path = public, extensions` du trigger).
+--
+-- Appliquée via AI Supabase sur dev + staging le 26 mai 2026
+-- (migration enable_pg_net).
+
+create extension if not exists pg_net with schema extensions;

--- a/supabase/migrations/20260526120000_trigger_push_on_notification_insert.sql
+++ b/supabase/migrations/20260526120000_trigger_push_on_notification_insert.sql
@@ -1,0 +1,61 @@
+-- Sprint 4 — Trigger push notification sur INSERT dans `notifications`.
+--
+-- Quand une notification est insérée (via les triggers existants
+-- fn_notify_follow / fn_notify_like / fn_notify_comment), ce trigger
+-- appelle l'Edge Function `send-push` qui envoie un push Expo au
+-- destinataire (récupère son push_token côté profiles, build le message,
+-- appelle l'Expo Push API).
+--
+-- Appliqué via AI Supabase sur dev + staging le 26 mai 2026
+-- (migration trigger_push_on_notification_insert).
+--
+-- ⚠️ URL HARDCODÉE PAR PROJET
+-- Le `v_edge_function_url` doit être adapté à chaque environnement :
+--   dev     : https://kbysmkhalnolbsojzahf.supabase.co/functions/v1/send-push
+--   staging : https://sdapojfdwduhuyduymxk.supabase.co/functions/v1/send-push
+--   prod    : <à créer lors du déploiement prod>
+-- Lors de l'application sur un nouvel env, REMPLACER `<PROJECT_REF>` ci-
+-- dessous par le bon ref avant exécution.
+--
+-- ⚠️ Dette MVP : `app.settings.service_role_key` n'est pas setté.
+-- L'Edge Function tourne en `verify_jwt: false`, donc le `Bearer` envoyé
+-- ici peut être vide. Pour la prod, exécuter une fois :
+--   alter database postgres set "app.settings.service_role_key" = '<KEY>';
+
+create or replace function public.fn_trigger_push_notification()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, extensions
+as $$
+declare
+  v_service_role_key text;
+  v_edge_function_url text := 'https://<PROJECT_REF>.supabase.co/functions/v1/send-push';
+begin
+  begin
+    v_service_role_key := current_setting('app.settings.service_role_key', true);
+  exception when others then
+    v_service_role_key := null;
+  end;
+
+  perform net.http_post(
+    url := v_edge_function_url,
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || coalesce(v_service_role_key, '')
+    ),
+    body := jsonb_build_object('record', row_to_json(NEW))
+  );
+
+  return NEW;
+end;
+$$;
+
+drop trigger if exists trg_push_on_notification_insert on public.notifications;
+create trigger trg_push_on_notification_insert
+  after insert on public.notifications
+  for each row
+  execute function public.fn_trigger_push_notification();
+
+-- Hygiène : trigger function pas appelable via REST
+revoke execute on function public.fn_trigger_push_notification() from anon, authenticated;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,5 +10,14 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx"]
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": [
+    "node_modules",
+    ".expo",
+    "android",
+    "ios",
+    "dist",
+    "web-build",
+    "supabase/functions/**"
+  ]
 }


### PR DESCRIPTION
## Ticket lié

Partie 1/2 de #54 (E4-14 Push notifications). Cette PR couvre **uniquement l'infra côté serveur**. Le client (enregistrement `push_token`, handler de tap, écran préférences) viendra dans une PR séparée par @fdissou.

## Contenu

### 1. `app.json` — config native
- Ajout plugin `expo-camera` (préreq #52 Stories d'Ilias)
- Ajout plugin `expo-notifications` (couleur `#10D970`)
- Permissions Android : `CAMERA`, `POST_NOTIFICATIONS`
- Nettoyage des doublons `RECORD_AUDIO`

> ⚠️ **Rebuild Dev Build EAS obligatoire après ce merge** — les 3 modules natifs (clipboard, haptics, notifications) + camera entrent dans le nouveau build. Je lance `pnpm build:dev:android` et balance le lien sur #dev-builds.

### 2. Edge Function `supabase/functions/send-push/index.ts`
- Déployée sur **dev + staging** via AI Supabase
- Récupère `push_token` + `actor username` → build message localisé selon `type` (follow / like / comment / mention / payment / system)
- Skip `follow_request` (traité in-app uniquement)
- Reset `push_token = null` si Expo retourne `DeviceNotRegistered`
- `verify_jwt: false` (auth via service_role bearer côté trigger)

### 3. Migration `trigger_push_on_notification_insert`
- Trigger AFTER INSERT sur `notifications` appelant l'Edge Function via `pg_net.http_post`
- Appliqué dev + staging (PROJECT_REF substitué par AI Supabase)
- :warning: URL hardcodée par projet — `<PROJECT_REF>` à substituer pour la prod (documenté en tête)

### 4. `eslint.config.js`
- Ignore `supabase/functions/**` (code Deno, imports URL non-résolvables par eslint Node)

## Dette MVP (non-bloquante)

- `app.settings.service_role_key` non setté → l'Edge Function tourne en `verify_jwt:false` donc OK pour MVP. À setter en prod avant la mise en prod.
- `EXPO_ACCESS_TOKEN` optionnel — sans lui, les push fonctionnent en anonyme avec rate limits.

## Test plan

- [x] Edge Function déployée dev + staging
- [x] Trigger DB appliqué dev + staging
- [ ] À tester de bout en bout une fois la partie client #54 livrée par Farah + le rebuild EAS effectué

🤖 Generated with [Claude Code](https://claude.com/claude-code)