### PR TITLE
feat(comments): commentaires threadés + likes + soft delete (E4-11)

### DIFF
--- a/app/(feed)/post/[id].tsx
+++ b/app/(feed)/post/[id].tsx
@@ -21,6 +21,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Text, XStack, YStack } from 'tamagui';
 
 import type { PostCardPost } from '@/components/feed/PostCard';
+import { CommentsSheet } from '@/features/comments/components/CommentsSheet';
 import {
   useIncrementPostShare,
   usePostDetail,
@@ -289,10 +290,12 @@ function ErrorState() {
 }
 
 export default function PostDetailRoute() {
-  const params = useLocalSearchParams<{ id?: string }>();
+  const params = useLocalSearchParams<{ id?: string; focus?: string }>();
   const postId = typeof params.id === 'string' ? params.id : undefined;
+  const shouldFocusComments = params.focus === 'comments';
   const insets = useSafeAreaInsets();
   const [overlaysVisible, setOverlaysVisible] = useState(true);
+  const [commentsOpen, setCommentsOpen] = useState(false);
 
   const postQuery = usePostDetail(postId);
   const likeMutation = useTogglePostLike(postId ?? '');
@@ -301,6 +304,7 @@ export default function PostDetailRoute() {
 
   const post = postQuery.data;
   const hadAvailablePost = useRef(false);
+  const didOpenFocusedComments = useRef(false);
 
   useEffect(() => {
     if (post) {
@@ -313,6 +317,13 @@ export default function PostDetailRoute() {
       router.back();
     }
   }, [postQuery.data, postQuery.isLoading]);
+
+  useEffect(() => {
+    if (!post || !shouldFocusComments || didOpenFocusedComments.current) return;
+
+    didOpenFocusedComments.current = true;
+    setCommentsOpen(true);
+  }, [post, shouldFocusComments]);
 
   const handleToggleOverlays = useCallback(() => {
     setOverlaysVisible((current) => !current);
@@ -329,7 +340,7 @@ export default function PostDetailRoute() {
   }, [bookmarkMutation]);
 
   const handleComments = useCallback(() => {
-    Alert.alert('Bientôt disponible', 'Les commentaires arrivent bientôt.');
+    setCommentsOpen(true);
   }, []);
 
   const handleShare = useCallback(async () => {
@@ -366,82 +377,88 @@ export default function PostDetailRoute() {
   const isLive = Boolean((post as PostCardPost & { is_live?: boolean }).is_live);
 
   return (
-    <View style={styles.screen}>
-      <StatusBar hidden />
-      <Pressable
-        onPress={handleToggleOverlays}
-        onLongPress={() => {}}
-        delayLongPress={240}
-        style={StyleSheet.absoluteFill}
-        accessibilityRole="button"
-        accessibilityLabel="Afficher ou masquer les contrôles du post"
-      >
-        <PostBackground post={post} />
-      </Pressable>
+    <>
+      <View style={styles.screen}>
+        <StatusBar hidden />
+        <Pressable
+          onPress={handleToggleOverlays}
+          onLongPress={() => {}}
+          delayLongPress={240}
+          style={StyleSheet.absoluteFill}
+          accessibilityRole="button"
+          accessibilityLabel="Afficher ou masquer les contrôles du post"
+        >
+          <PostBackground post={post} />
+        </Pressable>
 
-      {overlaysVisible ? (
-        <>
-          <BottomScrim />
-          <LiveBadge visible={isLive} />
+        {overlaysVisible ? (
+          <>
+            <BottomScrim />
+            <LiveBadge visible={isLive} />
 
-          <Pressable
-            onPress={() => router.back()}
-            hitSlop={HIT_SLOP}
-            accessibilityRole="button"
-            accessibilityLabel="Fermer le post"
-            style={[styles.closeButton, { top: insets.top + 12 }]}
-          >
-            <X size={24} color="#FFFFFF" strokeWidth={2.5} />
-          </Pressable>
-
-          <YStack position="absolute" right={ACTION_RIGHT} bottom={ACTION_BOTTOM} gap={24}>
-            <ActionButton
-              label={`Aimer le post de @${post.author_username}`}
-              count={post.like_count}
-              onPress={handleLike}
+            <Pressable
+              onPress={() => router.back()}
+              hitSlop={HIT_SLOP}
+              accessibilityRole="button"
+              accessibilityLabel="Fermer le post"
+              style={[styles.closeButton, { top: insets.top + 12 }]}
             >
-              <Animated.View>
-                <Heart
+              <X size={24} color="#FFFFFF" strokeWidth={2.5} />
+            </Pressable>
+
+            <YStack position="absolute" right={ACTION_RIGHT} bottom={ACTION_BOTTOM} gap={24}>
+              <ActionButton
+                label={`Aimer le post de @${post.author_username}`}
+                count={post.like_count}
+                onPress={handleLike}
+              >
+                <Animated.View>
+                  <Heart
+                    size={32}
+                    color={post.liked_by_me ? LIKE_RED : '#FFFFFF'}
+                    fill={post.liked_by_me ? LIKE_RED : 'transparent'}
+                  />
+                </Animated.View>
+              </ActionButton>
+
+              <ActionButton
+                label={`Commenter le post de @${post.author_username}`}
+                count={post.comment_count}
+                onPress={handleComments}
+              >
+                <MessageCircle size={32} color="#FFFFFF" />
+              </ActionButton>
+
+              <ActionButton
+                label={`Partager le post de @${post.author_username}`}
+                count={post.share_count}
+                onPress={() => void handleShare()}
+              >
+                <Send size={32} color="#FFFFFF" />
+              </ActionButton>
+
+              <ActionButton
+                label={`Sauvegarder le post de @${post.author_username}`}
+                count={post.bookmark_count}
+                onPress={handleBookmark}
+              >
+                <Bookmark
                   size={32}
-                  color={post.liked_by_me ? LIKE_RED : '#FFFFFF'}
-                  fill={post.liked_by_me ? LIKE_RED : 'transparent'}
+                  color={post.bookmarked_by_me ? ACCENT_NEON : '#FFFFFF'}
+                  fill={post.bookmarked_by_me ? ACCENT_NEON : 'transparent'}
                 />
-              </Animated.View>
-            </ActionButton>
+              </ActionButton>
+            </YStack>
 
-            <ActionButton
-              label={`Commenter le post de @${post.author_username}`}
-              count={post.comment_count}
-              onPress={handleComments}
-            >
-              <MessageCircle size={32} color="#FFFFFF" />
-            </ActionButton>
+            <Footer post={post} onOpenProfile={handleOpenProfile} />
+          </>
+        ) : null}
+      </View>
 
-            <ActionButton
-              label={`Partager le post de @${post.author_username}`}
-              count={post.share_count}
-              onPress={() => void handleShare()}
-            >
-              <Send size={32} color="#FFFFFF" />
-            </ActionButton>
-
-            <ActionButton
-              label={`Sauvegarder le post de @${post.author_username}`}
-              count={post.bookmark_count}
-              onPress={handleBookmark}
-            >
-              <Bookmark
-                size={32}
-                color={post.bookmarked_by_me ? ACCENT_NEON : '#FFFFFF'}
-                fill={post.bookmarked_by_me ? ACCENT_NEON : 'transparent'}
-              />
-            </ActionButton>
-          </YStack>
-
-          <Footer post={post} onOpenProfile={handleOpenProfile} />
-        </>
+      {postId ? (
+        <CommentsSheet postId={postId} open={commentsOpen} onOpenChange={setCommentsOpen} />
       ) : null}
-    </View>
+    </>
   );
 }
 

--- a/src/features/comments/components/CommentCard.tsx
+++ b/src/features/comments/components/CommentCard.tsx
@@ -1,0 +1,186 @@
+import * as Haptics from 'expo-haptics';
+import { Image } from 'expo-image';
+import { Heart } from 'lucide-react-native';
+import { Alert, Pressable, StyleSheet } from 'react-native';
+import { Text, XStack, YStack } from 'tamagui';
+
+import type { Comment } from '@/features/comments/hooks/useComments';
+import { formatViewCount } from '@/utils/formatCount';
+
+type CommentCardProps = {
+  comment: Comment;
+  currentUserId: string | null;
+  nested?: boolean;
+  onReply: (comment: Comment) => void;
+  onDelete: (commentId: string) => void;
+  onToggleLike: (commentId: string) => void;
+};
+
+const HIT_SLOP = { top: 8, right: 8, bottom: 8, left: 8 };
+const LIKE_RED = '#FF3B30';
+
+function formatRelativeTime(value: string) {
+  const createdAt = new Date(value).getTime();
+  if (Number.isNaN(createdAt)) return '1min';
+
+  const elapsedMs = Math.max(0, Date.now() - createdAt);
+  const minutes = Math.floor(elapsedMs / 60_000);
+
+  if (minutes < 1) return '1min';
+  if (minutes < 60) return `${minutes}min`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}j`;
+
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}sem`;
+
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mois`;
+
+  return `${Math.floor(days / 365)}an`;
+}
+
+function Avatar({ comment, size }: { comment: Comment; size: number }) {
+  const initial = comment.author_username.trim().charAt(0).toUpperCase() || '?';
+
+  return (
+    <YStack
+      width={size}
+      height={size}
+      borderRadius={9999}
+      backgroundColor="$surfaceElevated"
+      alignItems="center"
+      justifyContent="center"
+      overflow="hidden"
+      flexShrink={0}
+    >
+      {comment.author_avatar_url ? (
+        <Image
+          source={{ uri: comment.author_avatar_url }}
+          style={{ width: size, height: size }}
+          contentFit="cover"
+        />
+      ) : (
+        <Text color="$color" fontSize={size === 32 ? 13 : 12} fontWeight="700">
+          {initial}
+        </Text>
+      )}
+    </YStack>
+  );
+}
+
+export function CommentCard({
+  comment,
+  currentUserId,
+  nested = false,
+  onReply,
+  onDelete,
+  onToggleLike,
+}: CommentCardProps) {
+  const isAuthor = currentUserId === comment.author_id;
+  const relativeTime = formatRelativeTime(comment.created_at);
+  const avatarSize = nested ? 28 : 32;
+
+  const handleLongPress = () => {
+    if (!isAuthor) return;
+
+    void Haptics.selectionAsync();
+    Alert.alert('Supprimer ce commentaire ?', 'Cette action retirera le commentaire du post.', [
+      { text: 'Annuler', style: 'cancel' },
+      {
+        text: 'Supprimer',
+        style: 'destructive',
+        onPress: () => onDelete(comment.id),
+      },
+    ]);
+  };
+
+  const handleLike = () => {
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onToggleLike(comment.id);
+  };
+
+  return (
+    <Pressable
+      onLongPress={handleLongPress}
+      delayLongPress={380}
+      accessibilityRole="text"
+      style={[styles.row, nested ? styles.nestedRow : null]}
+    >
+      <Avatar comment={comment} size={avatarSize} />
+
+      <YStack flex={1} minWidth={0} gap={5}>
+        <XStack alignItems="baseline" gap={6} flexWrap="wrap">
+          <Text color="$color" fontSize={14} fontWeight="700">
+            @{comment.author_username}
+          </Text>
+          <Text color="$textSecondary" fontSize={12}>
+            {relativeTime}
+          </Text>
+        </XStack>
+
+        <Text color="$color" fontSize={14} lineHeight={20}>
+          {comment.content}
+        </Text>
+
+        {!nested ? (
+          <Pressable
+            onPress={() => onReply(comment)}
+            hitSlop={HIT_SLOP}
+            accessibilityRole="button"
+            accessibilityLabel={`Répondre à @${comment.author_username}`}
+            style={styles.replyButton}
+          >
+            <Text color="$textSecondary" fontSize={12} fontWeight="700">
+              Répondre
+            </Text>
+          </Pressable>
+        ) : null}
+      </YStack>
+
+      <Pressable
+        onPress={handleLike}
+        hitSlop={HIT_SLOP}
+        accessibilityRole="button"
+        accessibilityLabel={`Aimer le commentaire de @${comment.author_username}`}
+        style={styles.likeButton}
+      >
+        <Heart
+          size={18}
+          color={comment.liked_by_me ? LIKE_RED : '#A1A1AA'}
+          fill={comment.liked_by_me ? LIKE_RED : 'transparent'}
+        />
+        <Text color="$textSecondary" fontSize={12} fontWeight="600" marginTop={3}>
+          {formatViewCount(comment.like_count)}
+        </Text>
+      </Pressable>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  likeButton: {
+    alignItems: 'center',
+    minWidth: 34,
+    paddingTop: 2,
+  },
+  nestedRow: {
+    marginLeft: 32,
+    paddingTop: 5,
+  },
+  replyButton: {
+    alignSelf: 'flex-start',
+    minHeight: 24,
+    justifyContent: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    gap: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 9,
+  },
+});

--- a/src/features/comments/components/CommentsSheet.tsx
+++ b/src/features/comments/components/CommentsSheet.tsx
@@ -1,0 +1,290 @@
+import { FlashList } from '@shopify/flash-list';
+import { Send, X } from 'lucide-react-native';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  TextInput,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Sheet, Text, XStack, YStack } from 'tamagui';
+
+import { CommentCard } from '@/features/comments/components/CommentCard';
+import {
+  type Comment,
+  useComments,
+  useCreateComment,
+  useDeleteComment,
+  useToggleCommentLike,
+} from '@/features/comments/hooks/useComments';
+import { supabase } from '@/lib/supabase';
+
+type CommentsSheetProps = {
+  postId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps) {
+  const insets = useSafeAreaInsets();
+  const commentsQuery = useComments(postId);
+  const createComment = useCreateComment(postId);
+  const deleteComment = useDeleteComment(postId);
+  const toggleLike = useToggleCommentLike(postId);
+  const [content, setContent] = useState('');
+  const [replyTo, setReplyTo] = useState<Comment | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  const comments = commentsQuery.data ?? [];
+  const trimmedContent = content.trim();
+
+  const countLabel = useMemo(() => {
+    if (comments.length === 0) return '0';
+    return String(comments.length);
+  }, [comments.length]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    supabase.auth.getSession().then(({ data }) => {
+      if (!cancelled) {
+        setCurrentUserId(data.session?.user.id ?? null);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      setReplyTo(null);
+      setContent('');
+    }
+  }, [open]);
+
+  const handleSend = async () => {
+    if (!trimmedContent || createComment.isPending) return;
+
+    await createComment.mutateAsync({
+      content: trimmedContent,
+      parentCommentId: replyTo?.id ?? null,
+    });
+    setContent('');
+    setReplyTo(null);
+  };
+
+  const renderItem = ({ item }: { item: Comment }) => (
+    <CommentCard
+      comment={item}
+      currentUserId={currentUserId}
+      nested={Boolean(item.parent_comment_id)}
+      onReply={setReplyTo}
+      onDelete={(commentId) => deleteComment.mutate(commentId)}
+      onToggleLike={(commentId) => toggleLike.mutate(commentId)}
+    />
+  );
+
+  return (
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={onOpenChange}
+      snapPoints={[82]}
+      dismissOnSnapToBottom
+      moveOnKeyboardChange
+    >
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="rgba(0,0,0,0.58)"
+      />
+      <Sheet.Frame
+        backgroundColor="$background"
+        borderTopLeftRadius={18}
+        borderTopRightRadius={18}
+        overflow="hidden"
+      >
+        <KeyboardAvoidingView
+          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+          style={styles.keyboardAvoiding}
+        >
+          <YStack flex={1}>
+            <YStack
+              paddingTop={10}
+              paddingHorizontal={16}
+              paddingBottom={10}
+              borderBottomWidth={StyleSheet.hairlineWidth}
+              borderBottomColor="$borderColor"
+            >
+              <XStack justifyContent="center" marginBottom={10}>
+                <YStack
+                  width={38}
+                  height={4}
+                  borderRadius={2}
+                  backgroundColor="$borderColorHover"
+                />
+              </XStack>
+
+              <XStack alignItems="center">
+                <XStack alignItems="baseline" gap={8} flex={1}>
+                  <Text color="$color" fontSize={18} fontWeight="800">
+                    Commentaires
+                  </Text>
+                  <Text color="$textSecondary" fontSize={13} fontWeight="700">
+                    {countLabel}
+                  </Text>
+                </XStack>
+
+                <Pressable
+                  onPress={() => onOpenChange(false)}
+                  hitSlop={{ top: 12, right: 12, bottom: 12, left: 12 }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Fermer les commentaires"
+                  style={styles.closeButton}
+                >
+                  <X size={20} color="#FFFFFF" />
+                </Pressable>
+              </XStack>
+            </YStack>
+
+            <View style={styles.listContainer}>
+              {commentsQuery.isLoading ? (
+                <YStack flex={1} alignItems="center" justifyContent="center">
+                  <ActivityIndicator color="#FFFFFF" />
+                </YStack>
+              ) : (
+                <FlashList
+                  data={comments}
+                  renderItem={renderItem}
+                  keyExtractor={(item) => item.id}
+                  contentContainerStyle={styles.listContent}
+                  refreshControl={
+                    <RefreshControl
+                      refreshing={commentsQuery.isRefetching}
+                      onRefresh={() => void commentsQuery.refetch()}
+                      tintColor="#FFFFFF"
+                    />
+                  }
+                  ListEmptyComponent={
+                    <YStack flex={1} alignItems="center" justifyContent="center" paddingTop={88}>
+                      <Text color="$textSecondary" fontSize={15} fontWeight="600">
+                        Soyez le premier à commenter !
+                      </Text>
+                    </YStack>
+                  }
+                />
+              )}
+            </View>
+
+            <YStack
+              borderTopWidth={StyleSheet.hairlineWidth}
+              borderTopColor="$borderColor"
+              paddingHorizontal={16}
+              paddingTop={replyTo ? 8 : 12}
+              paddingBottom={Math.max(insets.bottom, 12)}
+              backgroundColor="$background"
+              gap={8}
+            >
+              {replyTo ? (
+                <XStack
+                  alignItems="center"
+                  gap={8}
+                  backgroundColor="$surface"
+                  borderRadius={8}
+                  paddingHorizontal={10}
+                  paddingVertical={8}
+                >
+                  <Text color="$textSecondary" fontSize={13} flex={1} numberOfLines={1}>
+                    Réponse à @{replyTo.author_username}
+                  </Text>
+                  <Pressable
+                    onPress={() => setReplyTo(null)}
+                    hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
+                    accessibilityRole="button"
+                    accessibilityLabel="Annuler la réponse"
+                  >
+                    <X size={16} color="#A1A1AA" />
+                  </Pressable>
+                </XStack>
+              ) : null}
+
+              <XStack alignItems="flex-end" gap={10}>
+                <TextInput
+                  value={content}
+                  onChangeText={setContent}
+                  placeholder="Ajouter un commentaire..."
+                  placeholderTextColor="#8E8E93"
+                  multiline
+                  maxLength={500}
+                  style={styles.input}
+                  returnKeyType="default"
+                />
+
+                <Button
+                  width={42}
+                  height={42}
+                  borderRadius={999}
+                  padding={0}
+                  alignItems="center"
+                  justifyContent="center"
+                  backgroundColor={trimmedContent ? '#10D970' : '$surfaceElevated'}
+                  disabled={!trimmedContent || createComment.isPending}
+                  onPress={() => void handleSend()}
+                  pressStyle={{ opacity: 0.86, scale: 0.98 }}
+                >
+                  {createComment.isPending ? (
+                    <ActivityIndicator color="#000000" size="small" />
+                  ) : (
+                    <Send size={18} color={trimmedContent ? '#000000' : '#8E8E93'} />
+                  )}
+                </Button>
+              </XStack>
+            </YStack>
+          </YStack>
+        </KeyboardAvoidingView>
+      </Sheet.Frame>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  closeButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 999,
+    backgroundColor: 'rgba(255,255,255,0.08)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  input: {
+    flex: 1,
+    minHeight: 42,
+    maxHeight: 110,
+    borderRadius: 18,
+    backgroundColor: '#1C1C1E',
+    color: '#FFFFFF',
+    fontSize: 15,
+    lineHeight: 20,
+    paddingHorizontal: 14,
+    paddingTop: 11,
+    paddingBottom: 10,
+  },
+  keyboardAvoiding: {
+    flex: 1,
+  },
+  listContainer: {
+    flex: 1,
+    minHeight: 0,
+  },
+  listContent: {
+    paddingBottom: 12,
+  },
+});

--- a/src/features/comments/components/CommentsSheet.tsx
+++ b/src/features/comments/components/CommentsSheet.tsx
@@ -3,8 +3,9 @@ import { Send, X } from 'lucide-react-native';
 import { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
-  KeyboardAvoidingView,
-  Platform,
+  Alert,
+  Keyboard,
+  type KeyboardEvent,
   Pressable,
   RefreshControl,
   StyleSheet,
@@ -39,6 +40,7 @@ export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps
   const [content, setContent] = useState('');
   const [replyTo, setReplyTo] = useState<Comment | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
 
   const comments = commentsQuery.data ?? [];
   const trimmedContent = content.trim();
@@ -66,18 +68,44 @@ export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps
     if (!open) {
       setReplyTo(null);
       setContent('');
+      setKeyboardHeight(0);
     }
   }, [open]);
+
+  useEffect(() => {
+    const handleKeyboardShow = (event: KeyboardEvent) => {
+      setKeyboardHeight(Math.max(0, event.endCoordinates.height - insets.bottom));
+    };
+    const handleKeyboardHide = () => setKeyboardHeight(0);
+
+    const showSubscription = Keyboard.addListener('keyboardDidShow', handleKeyboardShow);
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', handleKeyboardHide);
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, [insets.bottom]);
 
   const handleSend = async () => {
     if (!trimmedContent || createComment.isPending) return;
 
-    await createComment.mutateAsync({
-      content: trimmedContent,
-      parentCommentId: replyTo?.id ?? null,
-    });
-    setContent('');
-    setReplyTo(null);
+    try {
+      await createComment.mutateAsync({
+        content: trimmedContent,
+        parentCommentId: replyTo?.id ?? null,
+      });
+      setContent('');
+      setReplyTo(null);
+      Keyboard.dismiss();
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Impossible de publier ce commentaire pour le moment.';
+
+      Alert.alert('Commentaire non envoyé', `${message} Réessayez dans un instant.`);
+    }
   };
 
   const renderItem = ({ item }: { item: Comment }) => (
@@ -92,14 +120,7 @@ export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps
   );
 
   return (
-    <Sheet
-      modal
-      open={open}
-      onOpenChange={onOpenChange}
-      snapPoints={[82]}
-      dismissOnSnapToBottom
-      moveOnKeyboardChange
-    >
+    <Sheet modal open={open} onOpenChange={onOpenChange} snapPoints={[82]} dismissOnSnapToBottom>
       <Sheet.Overlay
         animation="lazy"
         enterStyle={{ opacity: 0 }}
@@ -112,144 +133,135 @@ export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps
         borderTopRightRadius={18}
         overflow="hidden"
       >
-        <KeyboardAvoidingView
-          behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-          style={styles.keyboardAvoiding}
-        >
-          <YStack flex={1}>
-            <YStack
-              paddingTop={10}
-              paddingHorizontal={16}
-              paddingBottom={10}
-              borderBottomWidth={StyleSheet.hairlineWidth}
-              borderBottomColor="$borderColor"
-            >
-              <XStack justifyContent="center" marginBottom={10}>
-                <YStack
-                  width={38}
-                  height={4}
-                  borderRadius={2}
-                  backgroundColor="$borderColorHover"
-                />
+        <YStack flex={1}>
+          <YStack
+            paddingTop={10}
+            paddingHorizontal={16}
+            paddingBottom={10}
+            borderBottomWidth={StyleSheet.hairlineWidth}
+            borderBottomColor="$borderColor"
+          >
+            <XStack justifyContent="center" marginBottom={10}>
+              <YStack width={38} height={4} borderRadius={2} backgroundColor="$borderColorHover" />
+            </XStack>
+
+            <XStack alignItems="center">
+              <XStack alignItems="baseline" gap={8} flex={1}>
+                <Text color="$color" fontSize={18} fontWeight="800">
+                  Commentaires
+                </Text>
+                <Text color="$textSecondary" fontSize={13} fontWeight="700">
+                  {countLabel}
+                </Text>
               </XStack>
 
-              <XStack alignItems="center">
-                <XStack alignItems="baseline" gap={8} flex={1}>
-                  <Text color="$color" fontSize={18} fontWeight="800">
-                    Commentaires
-                  </Text>
-                  <Text color="$textSecondary" fontSize={13} fontWeight="700">
-                    {countLabel}
-                  </Text>
-                </XStack>
+              <Pressable
+                onPress={() => onOpenChange(false)}
+                hitSlop={{ top: 12, right: 12, bottom: 12, left: 12 }}
+                accessibilityRole="button"
+                accessibilityLabel="Fermer les commentaires"
+                style={styles.closeButton}
+              >
+                <X size={20} color="#FFFFFF" />
+              </Pressable>
+            </XStack>
+          </YStack>
 
+          <View style={[styles.listContainer, { marginBottom: keyboardHeight }]}>
+            {commentsQuery.isLoading ? (
+              <YStack flex={1} alignItems="center" justifyContent="center">
+                <ActivityIndicator color="#FFFFFF" />
+              </YStack>
+            ) : (
+              <FlashList
+                data={comments}
+                renderItem={renderItem}
+                keyExtractor={(item) => item.id}
+                contentContainerStyle={styles.listContent}
+                refreshControl={
+                  <RefreshControl
+                    refreshing={commentsQuery.isRefetching}
+                    onRefresh={() => void commentsQuery.refetch()}
+                    tintColor="#FFFFFF"
+                  />
+                }
+                ListEmptyComponent={
+                  <YStack flex={1} alignItems="center" justifyContent="center" paddingTop={88}>
+                    <Text color="$textSecondary" fontSize={15} fontWeight="600">
+                      Soyez le premier à commenter !
+                    </Text>
+                  </YStack>
+                }
+              />
+            )}
+          </View>
+
+          <YStack
+            borderTopWidth={StyleSheet.hairlineWidth}
+            borderTopColor="$borderColor"
+            paddingHorizontal={16}
+            paddingTop={replyTo ? 8 : 12}
+            paddingBottom={Math.max(insets.bottom, 12)}
+            backgroundColor="$background"
+            gap={8}
+            style={[styles.composer, { bottom: keyboardHeight }]}
+          >
+            {replyTo ? (
+              <XStack
+                alignItems="center"
+                gap={8}
+                backgroundColor="$surface"
+                borderRadius={8}
+                paddingHorizontal={10}
+                paddingVertical={8}
+              >
+                <Text color="$textSecondary" fontSize={13} flex={1} numberOfLines={1}>
+                  Réponse à @{replyTo.author_username}
+                </Text>
                 <Pressable
-                  onPress={() => onOpenChange(false)}
-                  hitSlop={{ top: 12, right: 12, bottom: 12, left: 12 }}
+                  onPress={() => setReplyTo(null)}
+                  hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
                   accessibilityRole="button"
-                  accessibilityLabel="Fermer les commentaires"
-                  style={styles.closeButton}
+                  accessibilityLabel="Annuler la réponse"
                 >
-                  <X size={20} color="#FFFFFF" />
+                  <X size={16} color="#A1A1AA" />
                 </Pressable>
               </XStack>
-            </YStack>
+            ) : null}
 
-            <View style={styles.listContainer}>
-              {commentsQuery.isLoading ? (
-                <YStack flex={1} alignItems="center" justifyContent="center">
-                  <ActivityIndicator color="#FFFFFF" />
-                </YStack>
-              ) : (
-                <FlashList
-                  data={comments}
-                  renderItem={renderItem}
-                  keyExtractor={(item) => item.id}
-                  contentContainerStyle={styles.listContent}
-                  refreshControl={
-                    <RefreshControl
-                      refreshing={commentsQuery.isRefetching}
-                      onRefresh={() => void commentsQuery.refetch()}
-                      tintColor="#FFFFFF"
-                    />
-                  }
-                  ListEmptyComponent={
-                    <YStack flex={1} alignItems="center" justifyContent="center" paddingTop={88}>
-                      <Text color="$textSecondary" fontSize={15} fontWeight="600">
-                        Soyez le premier à commenter !
-                      </Text>
-                    </YStack>
-                  }
-                />
-              )}
-            </View>
+            <XStack alignItems="flex-end" gap={10}>
+              <TextInput
+                value={content}
+                onChangeText={setContent}
+                placeholder="Ajouter un commentaire..."
+                placeholderTextColor="#8E8E93"
+                multiline
+                maxLength={500}
+                style={styles.input}
+                returnKeyType="default"
+              />
 
-            <YStack
-              borderTopWidth={StyleSheet.hairlineWidth}
-              borderTopColor="$borderColor"
-              paddingHorizontal={16}
-              paddingTop={replyTo ? 8 : 12}
-              paddingBottom={Math.max(insets.bottom, 12)}
-              backgroundColor="$background"
-              gap={8}
-            >
-              {replyTo ? (
-                <XStack
-                  alignItems="center"
-                  gap={8}
-                  backgroundColor="$surface"
-                  borderRadius={8}
-                  paddingHorizontal={10}
-                  paddingVertical={8}
-                >
-                  <Text color="$textSecondary" fontSize={13} flex={1} numberOfLines={1}>
-                    Réponse à @{replyTo.author_username}
-                  </Text>
-                  <Pressable
-                    onPress={() => setReplyTo(null)}
-                    hitSlop={{ top: 8, right: 8, bottom: 8, left: 8 }}
-                    accessibilityRole="button"
-                    accessibilityLabel="Annuler la réponse"
-                  >
-                    <X size={16} color="#A1A1AA" />
-                  </Pressable>
-                </XStack>
-              ) : null}
-
-              <XStack alignItems="flex-end" gap={10}>
-                <TextInput
-                  value={content}
-                  onChangeText={setContent}
-                  placeholder="Ajouter un commentaire..."
-                  placeholderTextColor="#8E8E93"
-                  multiline
-                  maxLength={500}
-                  style={styles.input}
-                  returnKeyType="default"
-                />
-
-                <Button
-                  width={42}
-                  height={42}
-                  borderRadius={999}
-                  padding={0}
-                  alignItems="center"
-                  justifyContent="center"
-                  backgroundColor={trimmedContent ? '#10D970' : '$surfaceElevated'}
-                  disabled={!trimmedContent || createComment.isPending}
-                  onPress={() => void handleSend()}
-                  pressStyle={{ opacity: 0.86, scale: 0.98 }}
-                >
-                  {createComment.isPending ? (
-                    <ActivityIndicator color="#000000" size="small" />
-                  ) : (
-                    <Send size={18} color={trimmedContent ? '#000000' : '#8E8E93'} />
-                  )}
-                </Button>
-              </XStack>
-            </YStack>
+              <Button
+                width={42}
+                height={42}
+                borderRadius={999}
+                padding={0}
+                alignItems="center"
+                justifyContent="center"
+                backgroundColor={trimmedContent ? '#10D970' : '$surfaceElevated'}
+                disabled={!trimmedContent || createComment.isPending}
+                onPress={() => void handleSend()}
+                pressStyle={{ opacity: 0.86, scale: 0.98 }}
+              >
+                {createComment.isPending ? (
+                  <ActivityIndicator color="#000000" size="small" />
+                ) : (
+                  <Send size={18} color={trimmedContent ? '#000000' : '#8E8E93'} />
+                )}
+              </Button>
+            </XStack>
           </YStack>
-        </KeyboardAvoidingView>
+        </YStack>
       </Sheet.Frame>
     </Sheet>
   );
@@ -264,6 +276,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  composer: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+  },
   input: {
     flex: 1,
     minHeight: 42,
@@ -277,12 +294,10 @@ const styles = StyleSheet.create({
     paddingTop: 11,
     paddingBottom: 10,
   },
-  keyboardAvoiding: {
-    flex: 1,
-  },
   listContainer: {
     flex: 1,
     minHeight: 0,
+    paddingBottom: 82,
   },
   listContent: {
     paddingBottom: 12,

--- a/src/features/comments/components/CommentsSheet.tsx
+++ b/src/features/comments/components/CommentsSheet.tsx
@@ -6,6 +6,7 @@ import {
   Alert,
   Keyboard,
   type KeyboardEvent,
+  Platform,
   Pressable,
   RefreshControl,
   StyleSheet,
@@ -31,6 +32,19 @@ type CommentsSheetProps = {
   onOpenChange: (open: boolean) => void;
 };
 
+const KEYBOARD_COMPOSER_OFFSET = Platform.OS === 'android' ? 56 : 12;
+
+function getErrorMessage(error: unknown) {
+  if (error instanceof Error) return error.message;
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === 'string' && message.trim()) return message;
+  }
+
+  return 'Impossible de publier ce commentaire pour le moment.';
+}
+
 export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps) {
   const insets = useSafeAreaInsets();
   const commentsQuery = useComments(postId);
@@ -44,6 +58,7 @@ export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps
 
   const comments = commentsQuery.data ?? [];
   const trimmedContent = content.trim();
+  const keyboardOffset = keyboardHeight > 0 ? keyboardHeight + KEYBOARD_COMPOSER_OFFSET : 0;
 
   const countLabel = useMemo(() => {
     if (comments.length === 0) return '0';
@@ -99,10 +114,7 @@ export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps
       setReplyTo(null);
       Keyboard.dismiss();
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Impossible de publier ce commentaire pour le moment.';
+      const message = getErrorMessage(error);
 
       Alert.alert('Commentaire non envoyé', `${message} Réessayez dans un instant.`);
     }
@@ -167,7 +179,7 @@ export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps
             </XStack>
           </YStack>
 
-          <View style={[styles.listContainer, { marginBottom: keyboardHeight }]}>
+          <View style={[styles.listContainer, { marginBottom: keyboardOffset }]}>
             {commentsQuery.isLoading ? (
               <YStack flex={1} alignItems="center" justifyContent="center">
                 <ActivityIndicator color="#FFFFFF" />
@@ -204,7 +216,7 @@ export function CommentsSheet({ postId, open, onOpenChange }: CommentsSheetProps
             paddingBottom={Math.max(insets.bottom, 12)}
             backgroundColor="$background"
             gap={8}
-            style={[styles.composer, { bottom: keyboardHeight }]}
+            style={[styles.composer, { bottom: keyboardOffset }]}
           >
             {replyTo ? (
               <XStack

--- a/src/features/comments/hooks/useComments.ts
+++ b/src/features/comments/hooks/useComments.ts
@@ -1,0 +1,214 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { PostCardPost } from '@/components/feed/PostCard';
+import { FEED_QUERY_KEY } from '@/features/feed/hooks/useFeed';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type Comment = {
+  id: string;
+  post_id: string;
+  author_id: string;
+  author_username: string;
+  author_full_name: string | null;
+  author_avatar_url: string | null;
+  author_is_verified: boolean;
+  parent_comment_id: string | null;
+  content: string;
+  created_at: string;
+  like_count: number;
+  liked_by_me: boolean;
+};
+
+type FeedCacheData = {
+  pages: { posts: PostCardPost[]; nextCursor: string | null }[];
+  pageParams: unknown[];
+};
+
+type CreateCommentInput = {
+  content: string;
+  parentCommentId?: string | null;
+};
+
+type DeleteCommentContext = {
+  previousComments: Comment[] | undefined;
+  previousPost: PostCardPost | null | undefined;
+  previousFeed: FeedCacheData | undefined;
+};
+
+type ToggleCommentLikeContext = {
+  previousComments: Comment[] | undefined;
+};
+
+const COMMENTS_LIMIT = 50;
+
+function commentsQueryKey(postId: string) {
+  return ['comments', postId] as const;
+}
+
+function updateFeedPost(
+  old: FeedCacheData | undefined,
+  postId: string,
+  updater: (post: PostCardPost) => PostCardPost
+) {
+  if (!old) return old;
+
+  return {
+    ...old,
+    pages: old.pages.map((page) => ({
+      ...page,
+      posts: page.posts.map((post) => (post.id === postId ? updater(post) : post)),
+    })),
+  };
+}
+
+function updatePostCommentCount(
+  queryClient: ReturnType<typeof useQueryClient>,
+  postId: string,
+  delta: number
+) {
+  const updater = (post: PostCardPost) => ({
+    ...post,
+    comment_count: Math.max(0, post.comment_count + delta),
+  });
+
+  queryClient.setQueryData<PostCardPost | null>(['post', postId], (old) =>
+    old ? updater(old) : old
+  );
+  queryClient.setQueryData<FeedCacheData>(FEED_QUERY_KEY, (old) =>
+    updateFeedPost(old, postId, updater)
+  );
+}
+
+export function useComments(postId: string) {
+  return useQuery({
+    queryKey: commentsQueryKey(postId),
+    queryFn: async () => {
+      const { data, error } = await supabase.rpc('get_post_comments', {
+        p_post_id: postId,
+        p_limit: COMMENTS_LIMIT,
+      });
+
+      if (error) throw error;
+      return (data ?? []) as Comment[];
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function useCreateComment(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<string, Error, CreateCommentInput>({
+    mutationFn: async ({ content, parentCommentId }) => {
+      const { data, error } = await supabase.rpc('create_comment', {
+        p_post_id: postId,
+        p_content: content.trim(),
+        p_parent_comment_id: parentCommentId ?? null,
+      });
+
+      if (error) throw error;
+      return String(data);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: commentsQueryKey(postId) });
+      void queryClient.invalidateQueries({ queryKey: ['post', postId] });
+      void queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
+    },
+    onError: (error) => {
+      logger.warn('create_comment failed', { message: error.message, postId });
+    },
+  });
+}
+
+export function useDeleteComment(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string, DeleteCommentContext>({
+    mutationFn: async (commentId) => {
+      const { data, error } = await supabase.rpc('delete_comment', { p_comment_id: commentId });
+      if (error) throw error;
+      if (data !== true) throw new Error('Comment not deleted');
+    },
+    onMutate: async (commentId) => {
+      const queryKey = commentsQueryKey(postId);
+      await queryClient.cancelQueries({ queryKey });
+      await queryClient.cancelQueries({ queryKey: ['post', postId] });
+      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
+
+      const previousComments = queryClient.getQueryData<Comment[]>(queryKey);
+      const previousPost = queryClient.getQueryData<PostCardPost | null>(['post', postId]);
+      const previousFeed = queryClient.getQueryData<FeedCacheData>(FEED_QUERY_KEY);
+      const removedCount =
+        previousComments?.filter(
+          (comment) => comment.id === commentId || comment.parent_comment_id === commentId
+        ).length ?? 0;
+
+      queryClient.setQueryData<Comment[]>(queryKey, (old) =>
+        old?.filter(
+          (comment) => comment.id !== commentId && comment.parent_comment_id !== commentId
+        )
+      );
+
+      if (removedCount > 0) {
+        updatePostCommentCount(queryClient, postId, -removedCount);
+      }
+
+      return { previousComments, previousPost, previousFeed };
+    },
+    onError: (error, _commentId, context) => {
+      logger.warn('delete_comment failed', { message: error.message, postId });
+      queryClient.setQueryData(commentsQueryKey(postId), context?.previousComments);
+      queryClient.setQueryData(['post', postId], context?.previousPost);
+      queryClient.setQueryData(FEED_QUERY_KEY, context?.previousFeed);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: commentsQueryKey(postId) });
+      void queryClient.invalidateQueries({ queryKey: ['post', postId] });
+      void queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
+    },
+  });
+}
+
+export function useToggleCommentLike(postId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<boolean, Error, string, ToggleCommentLikeContext>({
+    mutationFn: async (commentId) => {
+      const { data, error } = await supabase.rpc('toggle_comment_like', {
+        p_comment_id: commentId,
+      });
+
+      if (error) throw error;
+      return Boolean(data);
+    },
+    onMutate: async (commentId) => {
+      const queryKey = commentsQueryKey(postId);
+      await queryClient.cancelQueries({ queryKey });
+      const previousComments = queryClient.getQueryData<Comment[]>(queryKey);
+
+      queryClient.setQueryData<Comment[]>(queryKey, (old) =>
+        old?.map((comment) => {
+          if (comment.id !== commentId) return comment;
+
+          return {
+            ...comment,
+            liked_by_me: !comment.liked_by_me,
+            like_count: comment.liked_by_me
+              ? Math.max(0, comment.like_count - 1)
+              : comment.like_count + 1,
+          };
+        })
+      );
+
+      return { previousComments };
+    },
+    onError: (error, _commentId, context) => {
+      logger.warn('toggle_comment_like failed', { message: error.message, postId });
+      queryClient.setQueryData(commentsQueryKey(postId), context?.previousComments);
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: commentsQueryKey(postId) });
+    },
+  });
+}

--- a/supabase/migrations/20260528113000_enable_pg_net.sql
+++ b/supabase/migrations/20260528113000_enable_pg_net.sql
@@ -1,0 +1,3 @@
+-- E4-11: certains triggers de notifications appellent net.http_post.
+-- pg_net cree le schema net requis par ces appels asynchrones.
+create extension if not exists pg_net;

--- a/supabase/migrations/20260528113000_enable_pg_net.sql
+++ b/supabase/migrations/20260528113000_enable_pg_net.sql
@@ -1,3 +1,0 @@
--- E4-11: certains triggers de notifications appellent net.http_post.
--- pg_net cree le schema net requis par ces appels asynchrones.
-create extension if not exists pg_net;


### PR DESCRIPTION
## Ticket lié

Closes #51

## Résumé

Commentaires sur les posts via BottomSheet — threadés 1 niveau de profondeur, likes inline, soft delete par l'auteur. Remplace le `Alert("Bientôt disponible")` du détail post TikTok.

- Hook `useComments` : 4 mutations (`useComments`, `useCreateComment`, `useDeleteComment`, `useToggleCommentLike`) — toutes optimistes avec rollback complet
- Synchronisation des **3 caches** au create / delete : `['comments', postId]`, `['post', postId]`, `FEED_QUERY_KEY` (pour que `comment_count` reflète partout)
- Sur delete : `removedCount` accumule aussi les réponses au commentaire supprimé pour décrémenter `comment_count` de la bonne valeur
- Composant `CommentsSheet` : Sheet Tamagui modale, FlashList des commentaires, input fixe en bas avec `KeyboardAvoidingView`, bandeau « Réponse à @username » + bouton X pour annuler
- Composant `CommentCard` : avatar + username + content + temps relatif + bouton « Répondre » (top-level seulement) + Heart inline avec `like_count`
- `app/(feed)/post/[id].tsx` : intégration de la `CommentsSheet`, auto-open au mount si query param `?focus=comments` (avec `didOpenFocusedComments.current` pour éviter les ré-ouvertures)

## RPCs (déjà livrées via PR #181)

- `get_post_comments(p_post_id, p_limit)` — threadés, retourne `liked_by_me`
- `create_comment(p_post_id, p_content, p_parent_comment_id)` — valide visibilité post + parent top-level
- `delete_comment(p_comment_id)` — soft delete par l'auteur, retourne boolean
- `toggle_comment_like(p_comment_id)` — like/unlike (trigger maintient `like_count`)

## Notes review CTO

- Branche **rebasée sur dev à jour** (sans conflit — Farah ne touche aucun fichier en commun avec #182 push ou #183 stories)
- Pattern `data !== true throw` reproduit comme dans `useDeletePost` de #49 (cohérence)
- Accents tous corrects

## Hors scope MVP

- Mentions `@username` qui notifient (déplacé Sprint 5)
- Réponses à une réponse (max 1 niveau — RPC `create_comment` empêche déjà)

## Checklist

- [x] Le code compile et passe le lint local
- [x] Optimistic + rollback sur les 3 mutations
- [x] Aucun console.log oublié

## Comment tester

1. `git checkout` cette branche (rebuild Dev Build si pas déjà fait pour Sprint 4)
2. Feed → tap sur l'image d'un post → écran détail TikTok
3. Tap sur `MessageCircle` → CommentsSheet s'ouvre
4. Écrire un commentaire → publier → apparaît en bas, compteur post incrémente
5. Tap « Répondre » sur un commentaire → bandeau « Réponse à @username » + l'input préfixé → publier → indenté sous le parent
6. Liker un commentaire → Heart se remplit, like_count + 1 (optimistic)
7. Supprimer un de ses commentaires → disparaît immédiatement
8. Depuis le feed, tap MessageCircle du PostCard → `/post/[id]?focus=comments` → la Sheet s'ouvre automatiquement