### PR TITLE
chore(landing): mini-site statique doumassi.app (préreq E4-16)

### DIFF
--- a/doumassi-landing/.well-known/apple-app-site-association
+++ b/doumassi-landing/.well-known/apple-app-site-association
@@ -1,0 +1,11 @@
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAMID_PLACEHOLDER.com.doumassi.app",
+        "paths": ["/post/*", "/profile/*", "/story/*"]
+      }
+    ]
+  }
+}

--- a/doumassi-landing/.well-known/assetlinks.json
+++ b/doumassi-landing/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "com.doumassi.app",
+      "sha256_cert_fingerprints": ["SHA256_FINGERPRINT_PLACEHOLDER"]
+    }
+  }
+]

--- a/doumassi-landing/README.md
+++ b/doumassi-landing/README.md
@@ -1,0 +1,46 @@
+# DOUMASSI Landing
+
+Mini-site statique déployé sur Vercel à `https://doumassi.app/`. Sert :
+
+- La page d'accueil — placeholder boutons stores (à brancher quand l'app sera publiée)
+- Les fichiers `.well-known/` requis pour les **universal links** iOS et **app links** Android (#56)
+- Une route catch-all (`/post/:id`, `/profile/:id`, `/story/:id`) qui sert le même `index.html` avec un bandeau « ouvrez l'app » personnalisé selon le contenu
+
+## Déploiement
+
+Vercel auto-déploie sur chaque push vers `dev` ou `main`. Aucune build step (HTML statique).
+
+**Root directory** : `doumassi-landing/` (configurable dans Settings > General du projet Vercel).
+
+## :warning: Placeholders à compléter avant la mise en prod
+
+Les 2 fichiers `.well-known/` contiennent des placeholders à remplacer par les vraies valeurs avant que les universal links / app links ne fonctionnent réellement :
+
+### `apple-app-site-association`
+
+`TEAMID_PLACEHOLDER` → ton **Apple Developer Team ID** (10 caractères alphanumériques).
+Récupérer via :
+
+```bash
+eas credentials -p ios
+# ou Apple Developer → Account → Membership Details
+```
+
+### `assetlinks.json`
+
+`SHA256_FINGERPRINT_PLACEHOLDER` → le **SHA-256 fingerprint** du certificat de signature Android.
+Récupérer via :
+
+```bash
+eas credentials -p android
+# ou keytool -list -v -keystore <keystore-path> -alias <alias>
+```
+
+## Tests de validation
+
+Une fois déployé sur le domaine `doumassi.app` :
+
+- **iOS AASA** : https://branch.io/resources/aasa-validator/?domain=doumassi.app
+- **Android assetlinks** : https://developers.google.com/digital-asset-links/tools/generator
+
+Ces 2 validateurs téléchargent les fichiers `.well-known/` et confirment leur conformité.

--- a/doumassi-landing/index.html
+++ b/doumassi-landing/index.html
@@ -22,8 +22,7 @@
         height: 100%;
       }
       body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, system-ui, sans-serif;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, system-ui, sans-serif;
         background: #000;
         color: #fff;
         display: flex;

--- a/doumassi-landing/index.html
+++ b/doumassi-landing/index.html
@@ -1,0 +1,144 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <meta name="theme-color" content="#000000" />
+    <title>DOUMASSI</title>
+    <meta
+      name="description"
+      content="DOUMASSI — la super-app sociale, business, créative et financière."
+    />
+    <link rel="icon" type="image/png" href="/favicon.png" />
+
+    <style>
+      * {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+      html,
+      body {
+        height: 100%;
+      }
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, system-ui, sans-serif;
+        background: #000;
+        color: #fff;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 24px;
+        line-height: 1.5;
+        -webkit-font-smoothing: antialiased;
+      }
+      main {
+        max-width: 480px;
+        width: 100%;
+        text-align: center;
+      }
+      .logo {
+        font-size: 42px;
+        font-weight: 800;
+        letter-spacing: -0.02em;
+        margin-bottom: 16px;
+        color: #fff;
+      }
+      .logo span {
+        color: #10d970;
+      }
+      .tagline {
+        font-size: 18px;
+        color: rgba(255, 255, 255, 0.72);
+        margin-bottom: 40px;
+      }
+      .post-redirect {
+        background: rgba(16, 217, 112, 0.08);
+        border: 1px solid rgba(16, 217, 112, 0.32);
+        border-radius: 12px;
+        padding: 16px;
+        margin-bottom: 24px;
+        display: none;
+      }
+      .post-redirect.visible {
+        display: block;
+      }
+      .post-redirect strong {
+        color: #10d970;
+      }
+      .buttons {
+        display: flex;
+        gap: 12px;
+        justify-content: center;
+        flex-wrap: wrap;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        padding: 14px 24px;
+        border-radius: 10px;
+        background: #fff;
+        color: #000;
+        font-weight: 700;
+        font-size: 15px;
+        text-decoration: none;
+        cursor: pointer;
+        transition: opacity 0.15s ease;
+        border: none;
+      }
+      .btn:hover {
+        opacity: 0.85;
+      }
+      .btn-secondary {
+        background: transparent;
+        color: #fff;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+      }
+      .footer {
+        margin-top: 64px;
+        font-size: 13px;
+        color: rgba(255, 255, 255, 0.4);
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <div class="logo">DOU<span>MASSI</span></div>
+      <p class="tagline">La super-app sociale, créative et financière.</p>
+
+      <!-- Affiché dynamiquement si on arrive via un lien /post/[id] ou /profile/[id] -->
+      <div id="post-redirect" class="post-redirect">
+        <p>
+          Pour voir <strong id="post-redirect-label">ce contenu</strong>,
+          <strong>ouvrez l'app DOUMASSI</strong>.
+        </p>
+      </div>
+
+      <div class="buttons">
+        <a class="btn" href="#" id="store-ios">App Store</a>
+        <a class="btn btn-secondary" href="#" id="store-android">Google Play</a>
+      </div>
+
+      <p class="footer">© 2026 DOUMASSI</p>
+    </main>
+
+    <script>
+      // Si on arrive via /post/[id], /profile/[id] ou /story/[userId],
+      // on personnalise le bandeau. La route catch-all de vercel.json sert
+      // toujours ce même index.html.
+      (function () {
+        var path = window.location.pathname;
+        var labels = { post: 'ce post', profile: 'ce profil', story: 'cette story' };
+        var match = path.match(/^\/(post|profile|story)\/[^/]+/);
+        if (match) {
+          var label = labels[match[1]] || 'ce contenu';
+          var el = document.getElementById('post-redirect-label');
+          if (el) el.textContent = label;
+          document.getElementById('post-redirect').classList.add('visible');
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/doumassi-landing/vercel.json
+++ b/doumassi-landing/vercel.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "cleanUrls": false,
+  "trailingSlash": false,
+  "headers": [
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
+    {
+      "source": "/.well-known/assetlinks.json",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    }
+  ],
+  "rewrites": [
+    { "source": "/post/:id", "destination": "/" },
+    { "source": "/profile/:id", "destination": "/" },
+    { "source": "/story/:id", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
Préreqs côté CTO pour les universal links / app links (#56). HTML statique pur, déploiement Vercel.

## Contenu

- `doumassi-landing/index.html` : page d'accueil avec bandeau dynamique « ouvrez l'app » si l'user arrive via /post/:id ou similar
- `doumassi-landing/.well-known/apple-app-site-association` : universal links iOS
- `doumassi-landing/.well-known/assetlinks.json` : app links Android
- `doumassi-landing/vercel.json` : Content-Type JSON forcé sur les .well-known + rewrites des routes /post|/profile|/story vers index
- `doumassi-landing/README.md` : docs déploiement + placeholders à compléter

## Placeholders à compléter avant prod

- `TEAMID_PLACEHOLDER` → Apple Developer Team ID (récupérer via `eas credentials -p ios`)
- `SHA256_FINGERPRINT_PLACEHOLDER` → SHA-256 cert Android (récupérer via `eas credentials -p android`)

## Test plan

- [ ] Déployer sur Vercel (root directory = `doumassi-landing/`)
- [ ] Connecter domaine `doumassi.app` + DNS OVH
- [ ] Substituer les placeholders
- [ ] Valider via https://branch.io/resources/aasa-validator/

🤖 Generated with [Claude Code](https://claude.com/claude-code)