### PR TITLE
chore(landing): SHA-256 Android dans assetlinks.json (#56)

### DIFF
--- a/doumassi-landing/.well-known/assetlinks.json
+++ b/doumassi-landing/.well-known/assetlinks.json
@@ -4,7 +4,9 @@
     "target": {
       "namespace": "android_app",
       "package_name": "com.doumassi.app",
-      "sha256_cert_fingerprints": ["SHA256_FINGERPRINT_PLACEHOLDER"]
+      "sha256_cert_fingerprints": [
+        "F1:B0:DE:D0:E3:31:39:55:FF:75:0B:6E:27:3E:DD:1F:76:F2:A2:5A:9C:04:75:3A:26:41:78:BB:7A:D5:C7:E5"
+      ]
     }
   }
 ]


### PR DESCRIPTION
Substitue `SHA256_FINGERPRINT_PLACEHOLDER` par le vrai fingerprint Android (récupéré via expo.dev Credentials).

Une fois mergée, Vercel redéploie automatiquement et les app links Android fonctionneront pour de vrai.

Placeholder iOS (`TEAMID_PLACEHOLDER` dans apple-app-site-association) reste en l'état — pas de credentials iOS provisionnées encore, Sprint 5-6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)