### PR TITLE
feat(deep-links): client universal links / app links (E4-16)

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,8 @@
       "backgroundColor": "#000000"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "associatedDomains": ["applinks:doumassi.app"]
     },
     "android": {
       "adaptiveIcon": {
@@ -31,7 +32,31 @@
         "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK",
         "android.permission.POST_NOTIFICATIONS"
       ],
-      "package": "com.doumassi.app"
+      "package": "com.doumassi.app",
+      "intentFilters": [
+        {
+          "action": "VIEW",
+          "autoVerify": true,
+          "data": [
+            {
+              "scheme": "https",
+              "host": "doumassi.app",
+              "pathPrefix": "/post"
+            },
+            {
+              "scheme": "https",
+              "host": "doumassi.app",
+              "pathPrefix": "/profile"
+            },
+            {
+              "scheme": "https",
+              "host": "doumassi.app",
+              "pathPrefix": "/story"
+            }
+          ],
+          "category": ["BROWSABLE", "DEFAULT"]
+        }
+      ]
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/app/(feed)/post/[id].tsx
+++ b/app/(feed)/post/[id].tsx
@@ -349,8 +349,8 @@ export default function PostDetailRoute() {
     try {
       const result = await Share.share({
         message: post.content.trim()
-          ? `${post.content}\n\ndoumassi://post/${post.id}`
-          : `doumassi://post/${post.id}`,
+          ? `${post.content}\n\nhttps://doumassi.app/post/${post.id}`
+          : `https://doumassi.app/post/${post.id}`,
       });
 
       if (result.action === Share.sharedAction) {

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -332,7 +332,7 @@ export const PostCard = memo(function PostCard({
     }
 
     try {
-      const result = await Share.share({ message: `doumassi://post/${post.id}` });
+      const result = await Share.share({ message: `https://doumassi.app/post/${post.id}` });
       if (result.action === Share.sharedAction) {
         await supabase.rpc('increment_share_count', { p_post_id: post.id });
       }

--- a/src/components/feed/PostMenuSheet.tsx
+++ b/src/components/feed/PostMenuSheet.tsx
@@ -41,7 +41,7 @@ export function PostMenuSheet({
   };
 
   const handleCopyLink = async () => {
-    await Clipboard.setStringAsync(`doumassi://post/${postId}`);
+    await Clipboard.setStringAsync(`https://doumassi.app/post/${postId}`);
     close();
     onCopyLink?.();
     Alert.alert('Lien copié', 'Le lien du post est prêt à être partagé.');

--- a/src/features/feed/screens/FeedScreen.tsx
+++ b/src/features/feed/screens/FeedScreen.tsx
@@ -286,7 +286,7 @@ export function FeedScreen() {
     if (!selectedPost) return;
 
     try {
-      const result = await Share.share({ message: `doumassi://post/${selectedPost.id}` });
+      const result = await Share.share({ message: `https://doumassi.app/post/${selectedPost.id}` });
       if (result.action === Share.sharedAction) {
         await supabase.rpc('increment_share_count', { p_post_id: selectedPost.id });
       }


### PR DESCRIPTION
Closes #56

## Résumé

Partie client de #56 — **repris par le CTO** pour libérer @dev01-waoow sur sa préparation de soutenance.

## Contenu

### `app.json` — config native

- `expo.ios.associatedDomains = ['applinks:doumassi.app']`
- `expo.android.intentFilters` : `scheme=https`, `host=doumassi.app`, 3 pathPrefix (`/post`, `/profile`, `/story`), `autoVerify=true`

### 4 fichiers UI — remplacement `doumassi://post/<id>` → `https://doumassi.app/post/<id>`

- `PostMenuSheet.handleCopyLink` — bouton « Copier le lien »
- `PostCard.handleShare` — fallback Share dans le feed
- `FeedScreen.handleMenuShare` — Share via le menu kebab
- `app/(feed)/post/[id].tsx handleShare` — Share depuis le détail TikTok

(Les autres `doumassi://` du codebase — `reset-password`, `auth/callback` — sont des OAuth redirects internes, pas concernés.)

## :warning: Rebuild Dev Build EAS obligatoire après merge

Les `intentFilters` Android et `associatedDomains` iOS sont du code natif → nouveau build EAS requis. À grouper avec un autre rebuild en cours si possible.

## État côté serveur

- ✅ `https://doumassi.app/.well-known/assetlinks.json` validé par Google (cf PR #186)
- :clock3: `apple-app-site-association` : `TEAMID_PLACEHOLDER` à substituer Sprint 5-6 (Apple Developer Program payant requis)

## Test plan

- [ ] Une fois rebuild EAS dispo : ouvrir Chrome / WhatsApp / SMS sur tél Android, taper un lien `https://doumassi.app/post/<uuid>` → l'app DOUMASSI s'ouvre direct sur l'écran détail
- [ ] Si l'app n'est pas installée : le navigateur ouvre la landing avec le bandeau « Pour voir ce post... »
- [ ] Partager un post via le bouton Send → vérifier que le lien partagé est bien `https://doumassi.app/post/...` (et plus `doumassi://...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)