### PR TITLE
feat(notifications): client push Expo (E4-14 partie client)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -8,7 +8,9 @@ import { Platform, StyleSheet, View } from 'react-native';
 
 import GuardLoader from '@/components/GuardLoader';
 import { useAuthGuard } from '@/features/auth/hooks/useAuthGuard';
+import { usePushToken } from '@/features/auth/hooks/usePushToken';
 import { useNotificationsUnreadCount } from '@/features/notifications/hooks/useNotifications';
+import { usePushNotificationsHandler } from '@/features/notifications/hooks/usePushNotificationsHandler';
 
 const ACTIVE_COLOR = '#FFFFFF';
 const INACTIVE_COLOR = '#A0A0A0';
@@ -38,6 +40,13 @@ function TabIcon({ Icon, focused }: TabIconProps) {
 // niveau du parent qui short-circuit avec des Redirect).
 function AuthenticatedTabs() {
   const unreadCount = useNotificationsUnreadCount();
+  // E4-14 : enregistrement du push token + handler de tap. Montés ici
+  // (sous le guard auth) car on a besoin d'une session valide pour le
+  // PATCH profiles.push_token, et il est inutile d'écouter les taps
+  // avant que l'app soit dans son état authentifié.
+  usePushToken();
+  usePushNotificationsHandler();
+
   return (
     <Tabs
       screenOptions={{

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@
 
 import { Inter_400Regular, Inter_700Bold, useFonts } from '@expo-google-fonts/inter';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as Notifications from 'expo-notifications';
 import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
@@ -19,6 +20,19 @@ import config from '../tamagui.config';
 // Init Sentry au top du module (avant le premier render).
 // No-op si EXPO_PUBLIC_SENTRY_DSN n'est pas défini.
 initSentry();
+
+// Comportement des notifs reçues quand l'app est au foreground (E4-14).
+// shouldShowBanner+List : affiche la notif même si l'app est ouverte
+// (sinon les notifs reçues en foreground sont silencieuses, ce qui rend
+// le debug + l'UX bizarres pendant la démo).
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
 
 // Garde le splash natif visible pendant le chargement des fonts
 SplashScreen.preventAutoHideAsync().catch(() => {

--- a/src/features/auth/hooks/usePushToken.ts
+++ b/src/features/auth/hooks/usePushToken.ts
@@ -1,0 +1,104 @@
+// usePushToken — E4-14.
+// Enregistre le token Expo Push du device dans `profiles.push_token` au
+// premier mount sous le guard auth (= dans AuthenticatedTabs, voir
+// app/(tabs)/_layout.tsx).
+//
+// Pattern :
+//   1. Vérifie/demande la permission notif iOS+Android
+//   2. Si accordée : récupère le token via getExpoPushTokenAsync
+//   3. PATCH profiles.push_token (idempotent — pas de réécriture si même token)
+//
+// Côté serveur, l'Edge Function `send-push` envoie via Expo Push API et
+// reset `push_token = null` si Expo répond DeviceNotRegistered (cf #54
+// préreqs CTO, PR #182).
+
+import Constants from 'expo-constants';
+import * as Device from 'expo-device';
+import * as Notifications from 'expo-notifications';
+import { useEffect } from 'react';
+import { Platform } from 'react-native';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+const PROJECT_ID = Constants.expoConfig?.extra?.eas?.projectId as string | undefined;
+
+async function registerPushToken(userId: string): Promise<void> {
+  // Les push notifs ne fonctionnent pas en simulateur — skip silencieusement
+  // (pas de log d'erreur, c'est attendu en dev sur émulateur).
+  if (!Device.isDevice) return;
+
+  if (!PROJECT_ID) {
+    logger.warn('No EAS projectId in app.json — cannot register push token');
+    return;
+  }
+
+  // Android : canal de notif par défaut (sinon les notifs n'affichent rien)
+  if (Platform.OS === 'android') {
+    await Notifications.setNotificationChannelAsync('default', {
+      name: 'DOUMASSI',
+      importance: Notifications.AndroidImportance.DEFAULT,
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: '#10D970',
+    });
+  }
+
+  // Vérifier la permission existante avant de demander (évite de re-prompt
+  // chaque ouverture si l'user a déjà refusé une fois).
+  const { status: existingStatus } = await Notifications.getPermissionsAsync();
+  let status = existingStatus;
+  if (existingStatus !== 'granted') {
+    const response = await Notifications.requestPermissionsAsync();
+    status = response.status;
+  }
+
+  if (status !== 'granted') {
+    logger.info('push_permission_denied', { userId });
+    return;
+  }
+
+  // Récupérer le token. Expo génère un token stable par installation.
+  const tokenResponse = await Notifications.getExpoPushTokenAsync({ projectId: PROJECT_ID });
+  const token = tokenResponse.data;
+
+  // Idempotent : on lit d'abord pour éviter un UPDATE inutile si rien n'a changé.
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('push_token')
+    .eq('id', userId)
+    .single();
+
+  if (profile?.push_token === token) return;
+
+  const { error } = await supabase.from('profiles').update({ push_token: token }).eq('id', userId);
+  if (error) {
+    logger.error('register_push_token_failed', error);
+  }
+}
+
+/**
+ * Lance l'enregistrement du push token au mount. Récupère le userId
+ * via supabase.auth.getSession() — on n'est appelé que sous le guard
+ * auth, donc la session existe forcément.
+ */
+export function usePushToken(): void {
+  useEffect(() => {
+    let cancelled = false;
+
+    void supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        if (cancelled) return;
+        const userId = data.session?.user.id;
+        if (!userId) return;
+        return registerPushToken(userId);
+      })
+      .catch((err) => {
+        logger.error('register_push_token_unexpected', err);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+}

--- a/src/features/notifications/hooks/usePushNotificationsHandler.ts
+++ b/src/features/notifications/hooks/usePushNotificationsHandler.ts
@@ -1,0 +1,76 @@
+// usePushNotificationsHandler — E4-14.
+// Handler de tap d'une notification push : route vers l'écran concerné
+// selon `data.type` + `data.entity_id` poussés par l'Edge Function
+// `send-push` (cf supabase/functions/send-push/index.ts).
+//
+// Logique de routing alignée avec `handlePressNotif` côté NotificationsScreen
+// (in-app) pour rester cohérent : peu importe que l'user tape une notif
+// in-app ou une notif push, il atterrit au même endroit.
+
+import * as Notifications from 'expo-notifications';
+import { router } from 'expo-router';
+import { useEffect } from 'react';
+
+import { logger } from '@/lib/logger';
+
+interface PushPayload {
+  type?: string;
+  entity_type?: string | null;
+  entity_id?: string | null;
+  actor_id?: string | null;
+  notification_id?: string;
+}
+
+function routeFromPayload(payload: PushPayload): void {
+  const { type, entity_id, actor_id } = payload;
+  switch (type) {
+    case 'follow':
+    case 'follow_request':
+      if (actor_id) router.push(`/profile/${actor_id}`);
+      return;
+    case 'like':
+    case 'comment':
+    case 'mention':
+      if (entity_id) router.push(`/post/${entity_id}`);
+      return;
+    case 'system':
+    case 'payment':
+      // Pas d'écran dédié pour le MVP — on ouvre l'écran Notifications par défaut
+      router.push('/notifications');
+      return;
+    default:
+      router.push('/notifications');
+      return;
+  }
+}
+
+/**
+ * S'abonne aux taps de notifications push (foreground + background).
+ * À monter une seule fois dans `AuthenticatedTabs`.
+ *
+ * Cas particulier : si l'app est lancée FROIDE depuis une notif (cold start),
+ * `getLastNotificationResponseAsync` permet de récupérer la notif qui a
+ * lancé l'app — on la route au mount.
+ */
+export function usePushNotificationsHandler(): void {
+  useEffect(() => {
+    // Cold start : si l'app a été ouverte via un tap notif, on a la réponse ici.
+    void Notifications.getLastNotificationResponseAsync().then((response) => {
+      if (!response) return;
+      const payload = response.notification.request.content.data as PushPayload | undefined;
+      if (payload) routeFromPayload(payload);
+    });
+
+    // Foreground / background : tap sur une notif déjà reçue.
+    const subscription = Notifications.addNotificationResponseReceivedListener((response) => {
+      try {
+        const payload = response.notification.request.content.data as PushPayload | undefined;
+        if (payload) routeFromPayload(payload);
+      } catch (err) {
+        logger.warn('push_tap_routing_failed', { error: (err as Error).message });
+      }
+    });
+
+    return () => subscription.remove();
+  }, []);
+}


### PR DESCRIPTION
Closes #54

## Résumé

Partie client de #54 — **repris par le CTO** pour libérer @fdissou sur sa préparation de soutenance.

## Contenu

### 1. `app/_layout.tsx` — handler global foreground

`setNotificationHandler` configure l'affichage des notifs reçues quand l'app est ouverte. Sans ça, elles sont silencieuses en foreground → UX dégradée pendant la démo.

### 2. `src/features/auth/hooks/usePushToken.ts`

- Check permission → request si nécessaire → `getExpoPushTokenAsync` → PATCH `profiles.push_token`
- **Idempotent** : pas de réécriture si le token n'a pas changé
- Canal Android `default` créé (obligatoire pour que les notifs s'affichent)
- Skip silencieux en simulateur (`Device.isDevice === false`)
- Récupère le userId via `supabase.auth.getSession()` en interne (pas de prop drilling)

### 3. `src/features/notifications/hooks/usePushNotificationsHandler.ts`

- `addNotificationResponseReceivedListener` pour foreground / background
- `getLastNotificationResponseAsync` pour le **cold start** (app lancée depuis une notif fermée)
- Routing aligné sur `handlePressNotif` (NotificationsScreen) :
  - `follow` / `follow_request` → `/profile/<actor_id>`
  - `like` / `comment` / `mention` → `/post/<entity_id>`
  - `system` / `payment` → `/notifications` (placeholder MVP)

### 4. `app/(tabs)/_layout.tsx`

`AuthenticatedTabs` câble les 2 hooks **sous le guard auth** : session garantie, et inutile d'écouter avant l'état authentifié.

## Hors scope MVP (Sprint 5+)

- Écran préférences notifications (besoin d'une table `notification_preferences`)
- Notifications groupées (« @paul et 3 autres ont aimé... »)
- Custom titles selon le type

## :warning: Rebuild Dev Build EAS obligatoire

`expo-notifications` est un module natif. **Idéalement groupé avec #56** (deep links — PR #187) qui demande aussi un rebuild pour `intentFilters` / `associatedDomains`. Un seul build pour les 2.

## État côté serveur (déjà en place via PR #182)

- Edge Function `send-push` déployée dev + staging
- Trigger DB `notifications` INSERT → `send-push` via `pg_net`
- `pg_net` activé (PR #182)
- Le payload poussé par l'Edge Function correspond exactement à ce que le hook `usePushNotificationsHandler` attend (`type`, `entity_type`, `entity_id`, `actor_id`, `notification_id`)

## Test plan

- [ ] Rebuild Dev Build EAS (groupé avec #187 si possible)
- [ ] Installer le nouveau APK sur 2 devices (toi + un compte test)
- [ ] Compte A like un post du compte B → compte B reçoit une notif push « @A a aimé votre post »
- [ ] Tap sur la notif → ouvre directement l'écran détail du post liké
- [ ] Idem pour follow / follow_request / comment
- [ ] App fermée + tap sur une notif → cold start sur le bon écran

🤖 Generated with [Claude Code](https://claude.com/claude-code)