### PR TITLE
feat(stories): footer « Vu par » dans la visionneuse

### DIFF
--- a/src/features/stories/components/StoryViewersSheet.tsx
+++ b/src/features/stories/components/StoryViewersSheet.tsx
@@ -1,0 +1,128 @@
+// StoryViewersSheet — composant « Vu par » pour l'auteur d'une story.
+// BottomSheet Tamagui qui liste les viewers via la RPC get_story_viewers
+// (réservée à l'auteur — vérifié côté BDD, pas besoin de garde côté UI).
+
+import { FlashList } from '@shopify/flash-list';
+import { Image } from 'expo-image';
+import { Eye } from 'lucide-react-native';
+import { useCallback } from 'react';
+import { ActivityIndicator, StyleSheet } from 'react-native';
+import { Sheet, Text, XStack, YStack } from 'tamagui';
+
+import { type StoryViewer, useStoryViewers } from '@/features/stories/hooks/useStoriesFeed';
+
+function formatViewedAgo(value: string): string {
+  const viewedAt = new Date(value).getTime();
+  if (Number.isNaN(viewedAt)) return '';
+  const elapsedMs = Math.max(0, Date.now() - viewedAt);
+  const minutes = Math.floor(elapsedMs / 60_000);
+  if (minutes < 1) return "à l'instant";
+  if (minutes < 60) return `il y a ${minutes}min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `il y a ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `il y a ${days}j`;
+}
+
+function ViewerRow({ viewer }: { viewer: StoryViewer }) {
+  return (
+    <XStack alignItems="center" paddingHorizontal="$4" paddingVertical="$3" gap="$3">
+      {viewer.viewer_avatar_url ? (
+        <Image
+          source={{ uri: viewer.viewer_avatar_url }}
+          style={styles.avatar}
+          contentFit="cover"
+        />
+      ) : (
+        <YStack
+          style={styles.avatar}
+          backgroundColor="$surface"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Text color="$color" fontSize={14} fontWeight="700">
+            {viewer.viewer_username.charAt(0).toUpperCase()}
+          </Text>
+        </YStack>
+      )}
+      <YStack flex={1} gap={2}>
+        <Text color="$color" fontSize={15} fontWeight="600">
+          @{viewer.viewer_username}
+        </Text>
+        <Text color="$textSecondary" fontSize={12}>
+          {formatViewedAgo(viewer.viewed_at)}
+        </Text>
+      </YStack>
+    </XStack>
+  );
+}
+
+export type StoryViewersSheetProps = {
+  storyId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export function StoryViewersSheet({ storyId, open, onOpenChange }: StoryViewersSheetProps) {
+  const viewersQuery = useStoryViewers(storyId, open);
+  const viewers = viewersQuery.data ?? [];
+
+  const renderItem = useCallback(
+    ({ item }: { item: StoryViewer }) => <ViewerRow viewer={item} />,
+    []
+  );
+
+  return (
+    <Sheet modal open={open} onOpenChange={onOpenChange} snapPoints={[70]} dismissOnSnapToBottom>
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="rgba(0,0,0,0.5)"
+      />
+      <Sheet.Frame backgroundColor="$surface" borderTopLeftRadius={16} borderTopRightRadius={16}>
+        <XStack justifyContent="center" paddingTop="$3" paddingBottom="$2">
+          <YStack width={36} height={4} borderRadius={2} backgroundColor="$borderColorHover" />
+        </XStack>
+
+        <XStack alignItems="center" paddingHorizontal="$4" paddingVertical="$2" gap="$2">
+          <Eye size={18} color="#FFFFFF" />
+          <Text color="$color" fontSize={17} fontWeight="700">
+            {viewers.length} {viewers.length > 1 ? 'vues' : 'vue'}
+          </Text>
+        </XStack>
+
+        {viewersQuery.isLoading ? (
+          <YStack alignItems="center" paddingVertical="$6">
+            <ActivityIndicator color="#FFFFFF" />
+          </YStack>
+        ) : viewers.length === 0 ? (
+          <YStack alignItems="center" paddingVertical="$8" gap="$2">
+            <Text color="$textSecondary" fontSize={14}>
+              Personne n&apos;a encore vu cette story
+            </Text>
+          </YStack>
+        ) : (
+          <FlashList
+            data={viewers}
+            renderItem={renderItem}
+            keyExtractor={(item) => item.viewer_id}
+            contentContainerStyle={styles.listContent}
+          />
+        )}
+      </Sheet.Frame>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  avatar: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    overflow: 'hidden',
+  },
+  listContent: {
+    paddingBottom: 32,
+  },
+});

--- a/src/features/stories/hooks/useStoriesFeed.ts
+++ b/src/features/stories/hooks/useStoriesFeed.ts
@@ -92,3 +92,32 @@ export function useMarkStoryViewed() {
     // à true au prochain refetch naturel (next mount, focus, etc.).
   });
 }
+
+// ---------------------------------------------------------------------------
+// useStoryViewers — réservé à l'auteur d'une story (la RPC vérifie en interne)
+// ---------------------------------------------------------------------------
+
+export type StoryViewer = {
+  viewer_id: string;
+  viewer_username: string;
+  viewer_avatar_url: string | null;
+  viewed_at: string;
+};
+
+export function useStoryViewers(storyId: string | null, enabled = true) {
+  return useQuery({
+    queryKey: ['stories', 'viewers', storyId],
+    enabled: enabled && Boolean(storyId),
+    queryFn: async (): Promise<StoryViewer[]> => {
+      const { data, error } = await supabase.rpc('get_story_viewers', {
+        p_story_id: storyId,
+      });
+      if (error) {
+        logger.warn('get_story_viewers failed', { message: error.message, storyId });
+        throw error;
+      }
+      return (data ?? []) as StoryViewer[];
+    },
+    staleTime: 15_000,
+  });
+}

--- a/src/features/stories/screens/StoryViewerScreen.tsx
+++ b/src/features/stories/screens/StoryViewerScreen.tsx
@@ -17,7 +17,7 @@ import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useVideoPlayer, VideoView } from 'expo-video';
-import { X } from 'lucide-react-native';
+import { Eye, X } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -30,6 +30,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Text, XStack, YStack } from 'tamagui';
 
+import { StoryViewersSheet } from '@/features/stories/components/StoryViewersSheet';
 import {
   type StoryItem,
   type StoryUserGroup,
@@ -169,6 +170,15 @@ export function StoryViewerScreen() {
   const [userIndex, setUserIndex] = useState(0);
   const [storyIndex, setStoryIndex] = useState(0);
   const [isPaused, setIsPaused] = useState(false);
+  const [viewersOpen, setViewersOpen] = useState(false);
+
+  // Pause la story tant que la sheet « Vu par » est ouverte, reprend à la
+  // fermeture. Pattern Insta : on ne veut pas que la story avance pendant
+  // qu'on regarde la liste des viewers.
+  const handleViewersOpenChange = useCallback((open: boolean) => {
+    setViewersOpen(open);
+    setIsPaused(open);
+  }, []);
 
   const progress = useRef(new Animated.Value(0)).current;
   const animationRef = useRef<Animated.CompositeAnimation | null>(null);
@@ -364,6 +374,27 @@ export function StoryViewerScreen() {
           </Pressable>
         </XStack>
       </View>
+
+      {/* Footer « Vu par » — auteur seulement */}
+      {currentGroup.is_mine ? (
+        <Pressable
+          onPress={() => handleViewersOpenChange(true)}
+          accessibilityRole="button"
+          accessibilityLabel="Voir qui a vu cette story"
+          style={[styles.viewersButton, { bottom: insets.bottom + 24 }]}
+        >
+          <Eye size={18} color="#FFFFFF" />
+          <Text color="#FFFFFF" fontSize={13} fontWeight="700">
+            Vu par
+          </Text>
+        </Pressable>
+      ) : null}
+
+      <StoryViewersSheet
+        storyId={currentStory.id}
+        open={viewersOpen}
+        onOpenChange={handleViewersOpenChange}
+      />
     </View>
   );
 }
@@ -424,5 +455,16 @@ const styles = StyleSheet.create({
     backgroundColor: 'rgba(0,0,0,0.4)',
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  viewersButton: {
+    position: 'absolute',
+    alignSelf: 'center',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 999,
+    backgroundColor: 'rgba(0,0,0,0.55)',
   },
 });


### PR DESCRIPTION
## Summary

- Cable la RPC `get_story_viewers` (livrée PR #181, jusqu'ici non consommée)
- Quand je regarde **ma propre** story, un footer « 👁 Vu par » ouvre une BottomSheet listant les viewers (avatar, @username, temps relatif)
- Pause/resume auto de la story tant que la sheet est ouverte (pattern Insta)

## Changes

- `src/features/stories/hooks/useStoriesFeed.ts` — ajout du hook `useStoryViewers(storyId, enabled)` avec gating `enabled` (pas de round-trip tant que la sheet est fermée)
- `src/features/stories/components/StoryViewersSheet.tsx` (nouveau) — Sheet Tamagui modale, FlashList des viewers, loading + empty state
- `src/features/stories/screens/StoryViewerScreen.tsx` — state `viewersOpen`, footer conditionnel `is_mine`, handler unique `handleViewersOpenChange` qui synchronise pause/play

## Sécurité

La RPC `get_story_viewers` est `SECURITY DEFINER` et vérifie en interne que `auth.uid() = story.author_id`. Pas besoin de garde supplémentaire côté UI — le footer n'est juste pas affiché si `!is_mine` pour éviter une requête qui de toute façon échouerait côté BDD.

## Test plan

- [ ] Build dev sur Android, créer une story
- [ ] Demander à un compte qui me suit de la voir
- [ ] Rouvrir ma story → footer « 1 vue » apparaît → tap → sheet avec son avatar + « à l'instant »
- [ ] Vérifier que la story se met en pause à l'ouverture de la sheet et reprend à la fermeture
- [ ] Vérifier que le footer n'apparaît PAS sur les stories des autres