### PR TITLE
chore(storage): supprimer 7 policies Sprint 0 redondantes (posts + stories)

### DIFF
--- a/supabase/migrations/20260529120000_cleanup_storage_policies_sprint0_doublons.sql
+++ b/supabase/migrations/20260529120000_cleanup_storage_policies_sprint0_doublons.sql
@@ -1,0 +1,46 @@
+-- Cleanup — suppression des doublons Sprint 0 sur storage.objects
+--
+-- Contexte : en Sprint 0 (avant le repo), des policies ont été créées via la
+-- console Supabase pour les buckets `posts` et `stories`. En Sprint 3 et
+-- Sprint 4, on a re-déclaré ces policies dans des migrations versionnées avec
+-- des noms différents et un scoping plus strict (rôle `authenticated` au lieu
+-- de `public`, contrôle de dossier `(storage.foldername(name))[1] = auth.uid()`).
+--
+-- Les deux jeux de policies coexistent depuis. Comme RLS est PERMISSIVE
+-- (union des policies), les anciennes laxistes Sprint 0 prennent quand même
+-- effet et masquent en partie le durcissement opéré par les nouvelles. On
+-- supprime ici les anciennes pour ne garder que les versions Sprint 3/4 du
+-- repo.
+--
+-- Vérifié avant exécution :
+--   - Le code mobile upload via createUploadTask dans `${userId}/${uuid}.ext`
+--     (src/lib/storage.ts:349 pour posts, l.404 pour stories) → pattern
+--     compatible avec les policies Sprint 3/4 qui valident
+--     `(storage.foldername(name))[1] = auth.uid()::text`.
+--   - Audit DEV du 2026-05-29 : 4 doublons sur `posts`, 3 doublons sur
+--     `stories`. Les buckets `avatars`, `covers`, `listings_media`,
+--     `messaging_media`, `ai_attachments` n'ont pas de doublons — non touchés.
+--
+-- À appliquer DEV puis STAGING via AI Supabase. Idempotent
+-- (`drop policy if exists`) donc safe à re-rejouer.
+
+-- ----- posts (4 policies Sprint 0) -----
+drop policy if exists "posts_insert_own"   on storage.objects;
+drop policy if exists "posts_update_own"   on storage.objects;
+drop policy if exists "posts_delete_own"   on storage.objects;
+drop policy if exists "posts_read_object"  on storage.objects;
+
+-- ----- stories (3 policies Sprint 0) -----
+drop policy if exists "stories_insert_own"  on storage.objects;
+drop policy if exists "stories_delete_own"  on storage.objects;
+drop policy if exists "stories_read_object" on storage.objects;
+
+-- Post-condition attendue après application (à vérifier manuellement) :
+--   select policyname, cmd, roles from pg_policies
+--   where schemaname='storage' and tablename='objects'
+--     and (policyname ilike '%posts%' or policyname ilike '%stories%')
+--   order by policyname;
+--
+-- Doit retourner exactement 7 policies (4 posts + 3 stories), toutes sur le
+-- rôle `authenticated` (sauf les deux "public read" qui sont sur
+-- {anon, authenticated}).


### PR DESCRIPTION
## Contexte

Audit storage.objects sur DEV (2026-05-29) : 7 policies Sprint 0 (créées via console Supabase avant le repo) coexistent toujours avec leurs équivalents Sprint 3/4 versionnés en migration. Les anciennes sont sur le rôle `{public}` (anon + authenticated) et plus laxistes que les nouvelles, qui scopent à `{authenticated}` et vérifient `(storage.foldername(name))[1] = auth.uid()::text`.

RLS étant PERMISSIVE (union des policies), les anciennes restent actives → on perd le bénéfice du durcissement Sprint 3/4 tant que ce cleanup n'est pas fait.

## Doublons supprimés

| Bucket  | Policies Sprint 0 droppées                                                 |
|---------|----------------------------------------------------------------------------|
| posts   | `posts_insert_own`, `posts_update_own`, `posts_delete_own`, `posts_read_object` |
| stories | `stories_insert_own`, `stories_delete_own`, `stories_read_object`          |

**Non touchés** (pas de doublons identifiés à l'audit) : `avatars`, `covers`, `listings_media`, `messaging_media`, `ai_attachments`. Ils seront migrés au fil de l'eau quand chaque feature les consommera.

## Sécurité

- `drop policy if exists` → idempotente, safe à re-rejouer
- Code mobile actuel upload dans `${userId}/${uuid}.ext` ([src/lib/storage.ts:349](src/lib/storage.ts#L349) et [l.404](src/lib/storage.ts#L404)) → pattern compatible avec les policies Sprint 3/4 qui restent en place
- Aucun changement fonctionnel attendu côté app, seulement une suppression de bruit + un vrai durcissement effectif

## Test plan

- [ ] Appliquer la migration sur **DEV** via AI Supabase
- [ ] Re-lancer l'audit `select … from pg_policies where schemaname='storage'` → vérifier qu'il reste exactement 4 policies posts + 3 stories (Sprint 3/4 uniquement)
- [ ] Tester un upload de post (compte authentifié) → doit fonctionner
- [ ] Tester un upload de story → doit fonctionner
- [ ] Appliquer ensuite sur **STAGING**