### PR TITLE
feat(rgpd): export des données personnelles JSON (E8-09)

### DIFF
--- a/app.json
+++ b/app.json
@@ -83,7 +83,8 @@
         {
           "color": "#10D970"
         }
-      ]
+      ],
+      "expo-sharing"
     ],
     "extra": {
       "router": {},

--- a/app/(feed)/settings.tsx
+++ b/app/(feed)/settings.tsx
@@ -8,6 +8,7 @@ import {
   Bell,
   ChevronLeft,
   ChevronRight,
+  Download,
   EyeOff,
   FileText,
   Info,
@@ -30,6 +31,7 @@ import { type ReactNode, useMemo, useState } from 'react';
 import { Alert, Linking, Platform } from 'react-native';
 import { Button, ScrollView, Sheet, Spinner, Switch, Text, XStack, YStack } from 'tamagui';
 
+import { useExportMyData } from '@/features/auth/hooks/useExportMyData';
 import { useLogout } from '@/features/auth/hooks/useLogout';
 import { useBlockedUsers } from '@/features/profile/hooks/useBlockedUsers';
 import {
@@ -299,7 +301,33 @@ export default function SettingsScreen() {
   const profileQuery = useCurrentProfile();
   const blockedUsersQuery = useBlockedUsers();
   const privacyToggle = usePrivacyToggle();
+  const exportMyData = useExportMyData();
   const copy = t.auth.settings;
+
+  const handleExportData = async () => {
+    try {
+      const result = await exportMyData.mutateAsync();
+      logger.info('Settings export OK', {
+        sizeBytes: result.sizeBytes,
+        truncated: result.truncated,
+      });
+      // Pas d'Alert de succès : le sheet de partage natif a déjà été présenté.
+      // Si l'export est tronqué (volume > 10 MB, rarissime en bêta), on alerte.
+      if (result.truncated) {
+        Alert.alert(
+          'Export partiel',
+          'Votre export contient un très grand volume de données. Les messages les plus anciens ont été tronqués. Contactez le support pour un export complet.'
+        );
+      }
+    } catch (err) {
+      Alert.alert(
+        'Export impossible',
+        err instanceof Error
+          ? err.message
+          : "L'export a échoué. Réessayez dans un instant ou contactez le support."
+      );
+    }
+  };
 
   // MOCK - sera cable au sprint Notifications.
   const [pushNotifications, setPushNotifications] = useState(true);
@@ -431,6 +459,14 @@ export default function SettingsScreen() {
               icon={KeyRound}
               label="Changer le mot de passe"
               onPress={() => router.push('/(feed)/settings/change-password')}
+            />
+            <SettingRow
+              icon={Download}
+              label="Exporter mes données"
+              trailing={exportMyData.isPending ? <Spinner color="$accentNeon" /> : null}
+              onPress={() => {
+                if (!exportMyData.isPending) void handleExportData();
+              }}
             />
             <SettingRow
               icon={Trash2}

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "expo-notifications": "~55.0.20",
     "expo-router": "~55.0.13",
     "expo-secure-store": "~55.0.13",
+    "expo-sharing": "~55.0.20",
     "expo-splash-screen": "~55.0.19",
     "expo-status-bar": "~55.0.5",
     "expo-updates": "~55.0.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       expo-secure-store:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.17)
+      expo-sharing:
+        specifier: ~55.0.20
+        version: 55.0.20(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       expo-splash-screen:
         specifier: ~55.0.19
         version: 55.0.19(expo@55.0.17)(typescript@5.9.3)
@@ -115,7 +118,7 @@ importers:
         version: 1.11.0(react-native-svg@15.15.3(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       posthog-react-native:
         specifier: 4.43.5
-        version: 4.43.5(908a5acd72f7b100093367d8f23ad8e6)
+        version: 4.43.5(66c24e189184897ced01d26f492b9bfe)
       posthog-react-native-session-replay:
         specifier: 1.5.5
         version: 1.5.5(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -136,7 +139,7 @@ importers:
         version: 2.30.1(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-localize:
         specifier: 3.7.0
-        version: 3.7.0(@expo/config-plugins@55.0.8)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+        version: 3.7.0(@expo/config-plugins@55.0.10)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-reanimated:
         specifier: 4.3.0
         version: 4.3.0(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
@@ -963,6 +966,9 @@ packages:
   '@expo/code-signing-certificates@0.0.6':
     resolution: {integrity: sha512-iNe0puxwBNEcuua9gmTGzq+SuMDa0iATai1FlFTMHJ/vUmKvN/V//drXoLJkVb5i5H3iE/n/qIJxyoBnXouD0w==}
 
+  '@expo/config-plugins@55.0.10':
+    resolution: {integrity: sha512-1txnRnMLIO5lM/Of/VyvDkCwZap0YFvCyfSTIlUQamhwhx6Rh7r8TXfcIstaDYUQ7X6GTMkNxLXWbcYS6ZAFDw==}
+
   '@expo/config-plugins@55.0.7':
     resolution: {integrity: sha512-XZUoDWrsHEkH3yasnDSJABM/UxP5a1ixzRwU/M+BToyn/f0nTrSJJe/Ay/FpxkI4JSNz2n0e06I23b2bleXKVA==}
 
@@ -1034,6 +1040,9 @@ packages:
 
   '@expo/json-file@10.0.13':
     resolution: {integrity: sha512-pX/XjQn7tgNw6zuuV2ikmegmwe/S7uiwhrs2wXrANMkq7ozrA+JcZwgW9Q/8WZgciBzfAhNp5hnackHcrmapQA==}
+
+  '@expo/json-file@10.0.16':
+    resolution: {integrity: sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw==}
 
   '@expo/json-file@8.3.3':
     resolution: {integrity: sha512-eZ5dld9AD0PrVRiIWpRkm5aIoWBw3kAyd8VkuWEy92sEthBKDDDHAnK2a0dw0Eil6j7rK7lS/Qaq/Zzngv2h5A==}
@@ -1171,6 +1180,9 @@ packages:
 
   '@expo/plist@0.5.2':
     resolution: {integrity: sha512-o4xdVdBpe4aTl3sPMZ2u3fJH4iG1I768EIRk1xRZP+GaFI93MaR3JvoFibYqxeTmLQ1p1kNEVqylfUjezxx45g==}
+
+  '@expo/plist@0.5.4':
+    resolution: {integrity: sha512-Jqppj0FULNq6Zp5JtQrFICl8TtpMjwwUbxEcEC2T3z7m+TOrTQEHZXz3D3Ay7vhbmvD+VMgfWJ4ARclJXeN8Eg==}
 
   '@expo/plugin-help@5.1.23':
     resolution: {integrity: sha512-s0uH6cPplLj73ZVie40EYUhl7X7q9kRR+8IfZWDod3wUtVGOFInxuCPX9Jpv1UwwBgbRu2cLisqr8m45LrFgxw==}
@@ -4100,6 +4112,13 @@ packages:
   expo-server@55.0.8:
     resolution: {integrity: sha512-AoV5TKuO4biSzrhe/OVLyInfTT0pV9/OOc/g/oVq5vmCjL8SaSYTkES8PLt+67Tm7VqX+Dn0+kSx1nQcjEKaPw==}
     engines: {node: '>=20.16.0'}
+
+  expo-sharing@55.0.20:
+    resolution: {integrity: sha512-KhDCsqPmDFFEWM+NlJe+nn0Z48hYeprNpwtNa5wQ4JgXxr2FL7i+AXjLh6v6kdHO2+r6+gkDft/u4fTDgYXdtA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-splash-screen@55.0.19:
     resolution: {integrity: sha512-l8BWI/inLJW46Ojz5NgwvaM8LftrdXeFfZBUXhAoZxg44Qo2xKY76s0S1h3WIxWXT4sRKwK8YQzGr4k+zHubxQ==}
@@ -7793,6 +7812,24 @@ snapshots:
     dependencies:
       node-forge: 1.4.0
 
+  '@expo/config-plugins@55.0.10':
+    dependencies:
+      '@expo/config-types': 55.0.5
+      '@expo/json-file': 10.0.16
+      '@expo/plist': 0.5.4
+      '@expo/sdk-runtime-versions': 1.0.0
+      chalk: 4.1.2
+      debug: 4.4.3(supports-color@8.1.1)
+      getenv: 2.0.0
+      glob: 13.0.6
+      resolve-from: 5.0.0
+      semver: 7.7.4
+      slugify: 1.6.9
+      xcode: 3.0.1
+      xml2js: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@expo/config-plugins@55.0.7':
     dependencies:
       '@expo/config-types': 55.0.5
@@ -8009,6 +8046,11 @@ snapshots:
       '@babel/code-frame': 7.29.0
       json5: 2.2.3
 
+  '@expo/json-file@10.0.16':
+    dependencies:
+      '@babel/code-frame': 7.10.4
+      json5: 2.2.3
+
   '@expo/json-file@8.3.3':
     dependencies:
       '@babel/code-frame': 7.10.4
@@ -8215,6 +8257,12 @@ snapshots:
       xmlbuilder: 14.0.0
 
   '@expo/plist@0.5.2':
+    dependencies:
+      '@xmldom/xmldom': 0.8.13
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
+
+  '@expo/plist@0.5.4':
     dependencies:
       '@xmldom/xmldom': 0.8.13
       base64-js: 1.5.1
@@ -12321,6 +12369,17 @@ snapshots:
 
   expo-server@55.0.8: {}
 
+  expo-sharing@55.0.20(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@expo/config-plugins': 55.0.10
+      '@expo/config-types': 55.0.5
+      '@expo/plist': 0.5.4
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      react: 19.2.0
+      react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-splash-screen@55.0.19(expo@55.0.17)(typescript@5.9.3):
     dependencies:
       '@expo/prebuild-config': 55.0.16(expo@55.0.17)(typescript@5.9.3)
@@ -14198,7 +14257,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
 
-  posthog-react-native@4.43.5(908a5acd72f7b100093367d8f23ad8e6):
+  posthog-react-native@4.43.5(66c24e189184897ced01d26f492b9bfe):
     dependencies:
       '@posthog/core': 1.27.5
       '@posthog/types': 1.372.1
@@ -14212,7 +14271,7 @@ snapshots:
       expo-localization: 55.0.13(expo@55.0.17)(react@19.2.0)
       posthog-react-native-session-replay: 1.5.5(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-device-info: 15.0.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))
-      react-native-localize: 3.7.0(@expo/config-plugins@55.0.8)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
+      react-native-localize: 3.7.0(@expo/config-plugins@55.0.10)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
       react-native-safe-area-context: 5.6.2(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)
 
   prelude-ls@1.2.1: {}
@@ -14333,12 +14392,12 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
 
-  react-native-localize@3.7.0(@expo/config-plugins@55.0.8)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
+  react-native-localize@3.7.0(@expo/config-plugins@55.0.10)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:
       react: 19.2.0
       react-native: 0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0)
     optionalDependencies:
-      '@expo/config-plugins': 55.0.8
+      '@expo/config-plugins': 55.0.10
 
   react-native-reanimated@4.3.0(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0):
     dependencies:

--- a/src/features/auth/hooks/useExportMyData.ts
+++ b/src/features/auth/hooks/useExportMyData.ts
@@ -1,0 +1,102 @@
+// Hook useExportMyData — E8-09.
+//
+// Appelle l'Edge Function `export-data` pour récupérer toutes les données
+// personnelles de l'user au format JSON, écrit le fichier dans le cache
+// local, puis ouvre le sheet de partage natif iOS/Android.
+//
+// L'user peut depuis ce sheet :
+//   - Enregistrer dans Fichiers / Drive / Dropbox
+//   - Envoyer par mail à lui-même
+//   - Partager avec une autorité de contrôle (CNIL) si litige
+
+import { useMutation } from '@tanstack/react-query';
+import * as FileSystem from 'expo-file-system/legacy';
+import * as Sharing from 'expo-sharing';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export interface ExportResult {
+  fileUri: string;
+  filename: string;
+  sizeBytes: number;
+  truncated: boolean;
+}
+
+/**
+ * Mutation : déclenche l'export complet des données personnelles de l'user.
+ *
+ * Flow :
+ *   1. Appel POST de l'Edge Function `export-data` (Authorization auto via le client Supabase)
+ *   2. Le retour est un JSON déjà parsé par supabase-js
+ *   3. On re-sérialise proprement (indent 2) et on écrit dans cacheDirectory
+ *   4. On ouvre le sheet de partage natif via expo-sharing
+ *
+ * Erreurs propagées telles quelles vers l'UI pour affichage à l'user.
+ */
+export function useExportMyData() {
+  return useMutation<ExportResult, Error, void>({
+    mutationFn: async () => {
+      // 1. Récupère la session pour le user_id (pour le nom de fichier)
+      const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+      if (sessionError || !sessionData.session) {
+        throw new Error('Session expirée. Reconnectez-vous puis réessayez.');
+      }
+      const userId = sessionData.session.user.id;
+
+      // 2. Appel Edge Function. supabase-js ajoute automatiquement le header
+      //    Authorization avec le JWT de la session courante.
+      const { data, error } = await supabase.functions.invoke('export-data', {
+        method: 'POST',
+        body: {},
+      });
+      if (error) {
+        logger.warn('export-data invoke failed', { message: error.message });
+        throw new Error("L'export a échoué. Réessayez dans un instant.");
+      }
+      if (!data || typeof data !== 'object') {
+        throw new Error('Réponse export-data invalide');
+      }
+
+      // 3. Sérialisation propre (indent 2 = lisible par un humain dans un éditeur)
+      const serialized = JSON.stringify(data, null, 2);
+      const sizeBytes = serialized.length;
+
+      // 4. Écriture dans le cache local
+      const dateStr = new Date().toISOString().split('T')[0];
+      const filename = `doumassi-export-${userId.slice(0, 8)}-${dateStr}.json`;
+      const fileUri = `${FileSystem.cacheDirectory}${filename}`;
+
+      await FileSystem.writeAsStringAsync(fileUri, serialized, {
+        encoding: FileSystem.EncodingType.UTF8,
+      });
+
+      // 5. Ouvre le sheet de partage natif (l'user choisit où sauver)
+      const isAvailable = await Sharing.isAvailableAsync();
+      if (isAvailable) {
+        await Sharing.shareAsync(fileUri, {
+          mimeType: 'application/json',
+          dialogTitle: 'Exporter mes données DOUMASSI',
+          UTI: 'public.json',
+        });
+      } else {
+        // Fallback (très rare — émulateur web par ex.) : l'user trouvera le
+        // fichier dans le cache. On le signale dans l'erreur retournée.
+        logger.warn('Sharing not available on this device', { fileUri });
+      }
+
+      logger.info('Data export completed', {
+        userId,
+        sizeBytes,
+        truncated: (data as { truncated?: boolean }).truncated === true,
+      });
+
+      return {
+        fileUri,
+        filename,
+        sizeBytes,
+        truncated: (data as { truncated?: boolean }).truncated === true,
+      };
+    },
+  });
+}

--- a/supabase/functions/export-data/index.ts
+++ b/supabase/functions/export-data/index.ts
@@ -1,0 +1,272 @@
+// Edge Function `export-data` — E8-09.
+//
+// Conformité RGPD article 20 (droit à la portabilité). L'user appelle cet
+// endpoint depuis Settings → Compte → « Exporter mes données » et reçoit en
+// retour un JSON consolidé avec toutes les données personnelles auxquelles
+// son JWT donne accès.
+//
+// Pattern :
+//   - Client scoppé sur le JWT de l'user (la RLS s'applique sur chaque
+//     SELECT, ce qui garantit qu'on n'exporte que les données de cet user)
+//   - Aucune escalade de privilèges, aucune utilisation de service_role
+//   - Réponse en téléchargement direct : Content-Disposition: attachment
+//   - Tronquage des messages les plus anciens si JSON > 10 MB (rare en bêta)
+//
+// Tables exportées (Phase 1 — bêta) :
+//   profiles, posts, comments, stories, follows, likes, bookmarks, blocks,
+//   conversations + conversation_participants + messages,
+//   deletion_requests, notifications
+//
+// Hors scope bêta : ai_conversations, listings (pas de données en prod).
+//
+// Secrets injectés automatiquement par Supabase Edge Functions :
+//   - SUPABASE_URL
+//   - SUPABASE_ANON_KEY
+
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+};
+
+// Limite avant tronquage (sérialisé). Au-delà, on coupe les messages les plus
+// anciens. En pratique en bêta on est très loin de 10 MB par user.
+const MAX_PAYLOAD_BYTES = 10 * 1024 * 1024;
+
+serve(async (req: Request): Promise<Response> => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return jsonError(405, 'method_not_allowed', 'Use POST or GET');
+  }
+
+  // 1. JWT requis
+  const authHeader = req.headers.get('Authorization');
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return jsonError(401, 'missing_auth', 'Authorization header required');
+  }
+  const userJwt = authHeader.replace('Bearer ', '');
+
+  // 2. Client scoppé sur le JWT user → RLS s'applique
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+  const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
+  const userClient = createClient(supabaseUrl, supabaseAnonKey, {
+    global: { headers: { Authorization: `Bearer ${userJwt}` } },
+  });
+
+  // 3. Récupère l'user_id depuis le JWT
+  const { data: userData, error: userError } = await userClient.auth.getUser();
+  if (userError || !userData.user) {
+    return jsonError(401, 'invalid_session', 'Session not valid');
+  }
+  const userId = userData.user.id;
+
+  // 4. Assemblage des sections en parallèle (RLS appliquée sur chacune)
+  // On utilise Promise.all pour minimiser la latence — chaque section est
+  // indépendante.
+  let truncated = false;
+
+  const [
+    profile,
+    posts,
+    comments,
+    stories,
+    follows,
+    likes,
+    bookmarks,
+    blocks,
+    conversationsData,
+    deletionRequests,
+    notifications,
+  ] = await Promise.all([
+    selectOne(userClient, 'profiles', 'id', userId),
+    selectMany(userClient, 'posts', 'author_id', userId),
+    selectMany(userClient, 'comments', 'author_id', userId),
+    selectMany(userClient, 'stories', 'author_id', userId),
+    selectFollows(userClient, userId),
+    selectMany(userClient, 'likes', 'user_id', userId),
+    selectMany(userClient, 'bookmarks', 'user_id', userId),
+    selectMany(userClient, 'blocks', 'blocker_id', userId),
+    selectConversations(userClient, userId),
+    selectMany(userClient, 'deletion_requests', 'user_id', userId),
+    selectMany(userClient, 'notifications', 'recipient_id', userId),
+  ]);
+
+  // 5. URLs Storage publiques (l'user peut télécharger depuis le navigateur)
+  // Note : on n'inclut pas les fichiers binaires dans le JSON pour rester sous
+  // 10 MB. Si la demande est forte en bêta, on pourra basculer sur un ZIP V2.
+  const storageUrls = buildStorageUrls(profile, posts);
+
+  // 6. Construction du payload final
+  const payload: Record<string, unknown> = {
+    exported_at: new Date().toISOString(),
+    user_id: userId,
+    profile,
+    posts,
+    comments,
+    stories,
+    follows,
+    likes,
+    bookmarks,
+    blocks,
+    conversations: conversationsData,
+    deletion_requests: deletionRequests,
+    notifications,
+    storage_urls: storageUrls,
+    truncated: false,
+  };
+
+  // 7. Tronquage si > 10 MB (extrême edge case)
+  let serialized = JSON.stringify(payload, null, 2);
+  if (serialized.length > MAX_PAYLOAD_BYTES) {
+    truncated = true;
+    // On tronque la conversation la plus volumineuse en gardant les 100
+    // messages les plus récents par conversation
+    if (Array.isArray(conversationsData)) {
+      for (const conv of conversationsData) {
+        if (
+          conv &&
+          typeof conv === 'object' &&
+          'messages' in conv &&
+          Array.isArray((conv as { messages: unknown[] }).messages)
+        ) {
+          const c = conv as { messages: unknown[] };
+          c.messages = c.messages.slice(0, 100);
+        }
+      }
+    }
+    payload.truncated = true;
+    serialized = JSON.stringify(payload, null, 2);
+  }
+
+  // 8. Téléchargement direct
+  const dateStr = new Date().toISOString().split('T')[0];
+  const filename = `doumassi-export-${userId.slice(0, 8)}-${dateStr}.json`;
+
+  return new Response(serialized, {
+    status: 200,
+    headers: {
+      ...CORS_HEADERS,
+      'Content-Type': 'application/json',
+      'Content-Disposition': `attachment; filename="${filename}"`,
+      'X-Truncated': truncated ? 'true' : 'false',
+    },
+  });
+});
+
+// ===== Helpers =====
+
+async function selectOne(
+  client: ReturnType<typeof createClient>,
+  table: string,
+  column: string,
+  value: string
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await client.from(table).select('*').eq(column, value).maybeSingle();
+  if (error) {
+    console.warn(`selectOne(${table}) error:`, error.message);
+    return null;
+  }
+  return data as Record<string, unknown> | null;
+}
+
+async function selectMany(
+  client: ReturnType<typeof createClient>,
+  table: string,
+  column: string,
+  value: string
+): Promise<unknown[]> {
+  const { data, error } = await client.from(table).select('*').eq(column, value);
+  if (error) {
+    console.warn(`selectMany(${table}) error:`, error.message);
+    return [];
+  }
+  return data ?? [];
+}
+
+// follows : 2 directions à exporter (je suis follower OU followed)
+async function selectFollows(
+  client: ReturnType<typeof createClient>,
+  userId: string
+): Promise<{ following: unknown[]; followers: unknown[] }> {
+  const [followingResult, followersResult] = await Promise.all([
+    client.from('follows').select('*').eq('follower_id', userId),
+    client.from('follows').select('*').eq('followed_id', userId),
+  ]);
+  return {
+    following: followingResult.data ?? [],
+    followers: followersResult.data ?? [],
+  };
+}
+
+// conversations : 1 ligne par conv dont je suis participant, avec participants
+// + mes messages dans cette conv (RLS me laisse aussi voir ceux des autres)
+async function selectConversations(
+  client: ReturnType<typeof createClient>,
+  userId: string
+): Promise<unknown[]> {
+  // 1. Liste mes conv_ids
+  const { data: myParticipations, error: pError } = await client
+    .from('conversation_participants')
+    .select('conversation_id')
+    .eq('user_id', userId);
+
+  if (pError || !myParticipations) {
+    console.warn('selectConversations participants error:', pError?.message);
+    return [];
+  }
+  const convIds = myParticipations.map((p) => p.conversation_id);
+  if (convIds.length === 0) return [];
+
+  // 2. Récupère les conversations + participants + messages en parallèle
+  const [convs, parts, msgs] = await Promise.all([
+    client.from('conversations').select('*').in('id', convIds),
+    client.from('conversation_participants').select('*').in('conversation_id', convIds),
+    client.from('messages').select('*').in('conversation_id', convIds),
+  ]);
+
+  const convsData = convs.data ?? [];
+  const partsData = parts.data ?? [];
+  const msgsData = msgs.data ?? [];
+
+  // 3. Assemblage : 1 entrée par conv avec participants[] et messages[]
+  return convsData.map((c) => ({
+    ...c,
+    participants: partsData.filter((p) => p.conversation_id === c.id),
+    messages: msgsData
+      .filter((m) => m.conversation_id === c.id)
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()),
+  }));
+}
+
+function buildStorageUrls(
+  profile: Record<string, unknown> | null,
+  posts: unknown[]
+): Record<string, unknown> {
+  const urls: Record<string, unknown> = {};
+  if (profile) {
+    if (profile.avatar_url) urls.avatar = profile.avatar_url;
+    if (profile.cover_url) urls.cover = profile.cover_url;
+  }
+  // Extraction des media_urls des posts (champ text[] dans la table)
+  const postMedia: string[] = [];
+  for (const p of posts) {
+    if (p && typeof p === 'object' && 'media_urls' in p) {
+      const m = (p as { media_urls: unknown }).media_urls;
+      if (Array.isArray(m)) postMedia.push(...m.filter((u) => typeof u === 'string'));
+    }
+  }
+  if (postMedia.length > 0) urls.post_media = postMedia;
+  return urls;
+}
+
+function jsonError(status: number, code: string, message: string): Response {
+  return new Response(JSON.stringify({ ok: false, code, message }), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
## Contexte

Conformité **RGPD article 20** (droit à la portabilité). L'user déclenche l'export depuis Settings → Compte → « Exporter mes données », reçoit un fichier JSON complet et l'enregistre via le sheet de partage natif iOS/Android (Files, Drive, Mail, etc.).

Closes #106.

## Contenu

| Fichier | Rôle |
|---|---|
| `supabase/functions/export-data/index.ts` | Edge Function : récupère les données de l'user authentifié (RLS), assemble en JSON, retourne en téléchargement direct |
| `src/features/auth/hooks/useExportMyData.ts` | Hook qui invoke l'Edge Function, écrit le JSON dans cacheDirectory et ouvre `Sharing.shareAsync` |
| `app/(feed)/settings.tsx` | Nouvelle ligne « Exporter mes données » entre « Changer le mot de passe » et « Supprimer mon compte » (icône Download, spinner pendant pending) |
| `package.json` / `pnpm-lock.yaml` / `app.json` | Ajout de `expo-sharing` (lib officielle Expo) |

## Tables exportées

11 tables couvertes par la Phase 1 (sélection parallèle pour minimiser la latence) :
- `profiles` (sa ligne)
- `posts`, `comments`, `stories` (en tant qu'auteur)
- `follows` (following + followers)
- `likes`, `bookmarks`, `blocks` (siennes)
- `conversations` + `conversation_participants` + `messages` (toutes ses convs avec ses messages et ceux des autres dans ces convs — RLS scopée)
- `deletion_requests` (siennes)
- `notifications` (les siennes)
- Section `storage_urls` : URLs publiques de l'avatar, cover, post media

Tronquage automatique si JSON > 10 MB (rare en bêta) : garde les 100 derniers messages par conv + set `truncated: true` dans la réponse.

## Hors scope bêta

- ~~`ai_conversations`~~ : Sprint 6+
- ~~`listings` Marketplace~~ : Sprint 6+
- ZIP avec fichiers binaires : peut être ajouté V2 si demande forte

## Décisions techniques

| Sujet | Choix |
|---|---|
| RLS vs service_role | RLS scopée sur le JWT user (aucune escalade). Plus sûr, simple, et la RLS existante couvre tout |
| Format | JSON pur (pas ZIP), `Content-Disposition: attachment`, indent 2 pour lisibilité |
| UX télécharger | `expo-sharing` sheet natif → user choisit la destination |
| Nom de fichier | `doumassi-export-{user_id_8_chars}-{YYYY-MM-DD}.json` (sans nom complet pour éviter les info perso dans le path) |
| Sécurité tronquage | Au-delà de 10 MB, on coupe les conversations (les plus volumineuses). Header `X-Truncated: true` posé. Banner d'alerte côté UI. |

## ⚠️ Important pour le test

`expo-sharing` est un **module natif** — il faut **rebuilder le Dev Build** pour tester :

```bash
pnpm build:dev:android
```

Puis installer le nouveau dev build sur le device. Sans ce rebuild, l'app crashe au tap sur le bouton d'export.

## À déployer après merge

```bash
pnpm dlx supabase functions deploy export-data --project-ref kbysmkhalnolbsojzahf
pnpm dlx supabase functions deploy export-data --project-ref sdapojfdwduhuyduymxk
```

## Test plan

- [ ] Build dev Android avec expo-sharing inclus
- [ ] Déployer la function sur DEV et STAGING
- [ ] Sur Dev Build : Settings → Compte → « Exporter mes données » → spinner visible
- [ ] Sheet de partage natif s'ouvre, choisir "Save to Files"
- [ ] Ouvrir le fichier JSON et vérifier qu'il contient les 11 sections + storage_urls
- [ ] Vérifier qu'on ne voit QUE ses propres données (test croisé : depuis le compte de test A, l'export ne doit pas contenir les posts du compte de test B)
- [ ] Tester sur un compte avec beaucoup de messages pour vérifier le tronquage (pas critique en bêta)

## Suite Phase 2

Reste **#110 Audit RLS** pour finir la Phase 2 bêta-readiness.