### PR TITLE
feat(messaging): écran conversation 1-to-1 + envoi texte (E6-03, E6-05)

### DIFF
--- a/app/messages/[id].tsx
+++ b/app/messages/[id].tsx
@@ -1,0 +1,16 @@
+// Route Expo Router — Écran de conversation (E6-03 + E6-05).
+// Modale fullscreen sans tabbar. Le composant vit dans
+// src/features/messaging/screens/.
+
+import { Stack } from 'expo-router';
+
+import { ConversationScreen } from '@/features/messaging/screens/ConversationScreen';
+
+export default function ConversationRoute() {
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false, presentation: 'card' }} />
+      <ConversationScreen />
+    </>
+  );
+}

--- a/src/features/messaging/components/MessageActionSheet.tsx
+++ b/src/features/messaging/components/MessageActionSheet.tsx
@@ -1,0 +1,199 @@
+// MessageActionSheet — E6-03.
+//
+// Sheet contextuel qui s'ouvre au long-press sur une bulle "à moi".
+// Propose : Modifier (texte seulement), Supprimer.
+// Édition : passe en mode `editing` qui remplace le sheet par un input
+// pré-rempli + bouton de validation.
+
+import { Edit3, Trash2 } from 'lucide-react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { Alert, Pressable, StyleSheet } from 'react-native';
+import { Button, Sheet, Spinner, Text, TextArea, XStack, YStack } from 'tamagui';
+
+import type { MessageRow } from '../hooks/useConversationMessages';
+
+export interface MessageActionSheetProps {
+  message: MessageRow | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onEdit: (messageId: string, newContent: string) => Promise<void>;
+  onDelete: (messageId: string) => Promise<void>;
+  editIsPending?: boolean;
+  deleteIsPending?: boolean;
+}
+
+const MAX_CONTENT_LENGTH = 4000;
+
+export function MessageActionSheet({
+  message,
+  open,
+  onOpenChange,
+  onEdit,
+  onDelete,
+  editIsPending = false,
+  deleteIsPending = false,
+}: MessageActionSheetProps) {
+  const [mode, setMode] = useState<'menu' | 'editing'>('menu');
+  const [editingContent, setEditingContent] = useState('');
+
+  // Reset à chaque ouverture
+  useEffect(() => {
+    if (open) {
+      setMode('menu');
+      setEditingContent(message?.content ?? '');
+    }
+  }, [open, message]);
+
+  const isText = message?.attachment_type === 'text';
+  const canEdit = isText && message?.content;
+
+  const handleStartEdit = useCallback(() => {
+    if (!message?.content) return;
+    setEditingContent(message.content);
+    setMode('editing');
+  }, [message]);
+
+  const handleSaveEdit = useCallback(async () => {
+    if (!message) return;
+    const trimmed = editingContent.trim();
+    if (trimmed.length === 0) {
+      Alert.alert('Contenu vide', 'Le message ne peut pas être vide.');
+      return;
+    }
+    try {
+      await onEdit(message.id, trimmed);
+      onOpenChange(false);
+    } catch (e) {
+      Alert.alert(
+        'Édition impossible',
+        e instanceof Error ? e.message : 'Réessayez dans un instant.'
+      );
+    }
+  }, [message, editingContent, onEdit, onOpenChange]);
+
+  const handleDelete = useCallback(() => {
+    if (!message) return;
+    Alert.alert(
+      'Supprimer ce message ?',
+      'Le contenu sera remplacé par « Message supprimé » pour tous les participants. Action irréversible.',
+      [
+        { text: 'Annuler', style: 'cancel' },
+        {
+          text: 'Supprimer',
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await onDelete(message.id);
+              onOpenChange(false);
+            } catch (e) {
+              Alert.alert(
+                'Suppression impossible',
+                e instanceof Error ? e.message : 'Réessayez dans un instant.'
+              );
+            }
+          },
+        },
+      ]
+    );
+  }, [message, onDelete, onOpenChange]);
+
+  return (
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={onOpenChange}
+      snapPoints={mode === 'editing' ? [60] : [30]}
+      dismissOnSnapToBottom
+    >
+      <Sheet.Overlay backgroundColor="rgba(0,0,0,0.6)" />
+      <Sheet.Frame
+        backgroundColor="$surface"
+        borderTopLeftRadius={16}
+        borderTopRightRadius={16}
+        padding="$4"
+        gap="$3"
+      >
+        <Sheet.Handle backgroundColor="$borderColor" />
+
+        {mode === 'menu' ? (
+          <YStack gap="$2">
+            {canEdit ? (
+              <Pressable onPress={handleStartEdit} style={styles.row}>
+                <Edit3 size={20} color="#FFFFFF" />
+                <Text color="$color" fontSize={16}>
+                  Modifier
+                </Text>
+              </Pressable>
+            ) : null}
+            <Pressable onPress={handleDelete} style={styles.row}>
+              {deleteIsPending ? <Spinner color="#FF3B30" /> : <Trash2 size={20} color="#FF3B30" />}
+              <Text color="$danger" fontSize={16} fontWeight="600">
+                Supprimer
+              </Text>
+            </Pressable>
+          </YStack>
+        ) : (
+          <YStack gap="$3">
+            <Text color="$textSecondary" fontSize={12} fontWeight="700" textTransform="uppercase">
+              Modifier le message
+            </Text>
+            <TextArea
+              value={editingContent}
+              onChangeText={(text) => setEditingContent(text.slice(0, MAX_CONTENT_LENGTH))}
+              placeholder="Tape ton message…"
+              placeholderTextColor="$placeholderColor"
+              backgroundColor="$background"
+              borderColor="$borderColor"
+              borderWidth={1}
+              borderRadius={12}
+              color="$color"
+              fontSize={15}
+              minHeight={90}
+              padding="$3"
+              multiline
+              autoFocus
+            />
+            <XStack gap="$3">
+              <Button
+                flex={1}
+                onPress={() => setMode('menu')}
+                backgroundColor="transparent"
+                borderColor="$borderColor"
+                borderWidth={1}
+                color="$color"
+                borderRadius={12}
+                height={44}
+                fontWeight="600"
+              >
+                Annuler
+              </Button>
+              <Button
+                flex={1}
+                onPress={() => void handleSaveEdit()}
+                disabled={editIsPending || editingContent.trim().length === 0}
+                backgroundColor="$accentNeon"
+                color="#000000"
+                borderRadius={12}
+                height={44}
+                fontWeight="800"
+                opacity={editIsPending || editingContent.trim().length === 0 ? 0.5 : 1}
+              >
+                {editIsPending ? <Spinner color="#000000" /> : 'Enregistrer'}
+              </Button>
+            </XStack>
+          </YStack>
+        )}
+      </Sheet.Frame>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 14,
+    paddingVertical: 14,
+    paddingHorizontal: 4,
+  },
+});

--- a/src/features/messaging/components/MessageBubble.tsx
+++ b/src/features/messaging/components/MessageBubble.tsx
@@ -1,0 +1,124 @@
+// MessageBubble — E6-03.
+//
+// Affichage d'un message dans la liste. Bulle à droite si c'est moi, à
+// gauche sinon. Gère trois états :
+//   - normal : contenu + horodatage relatif
+//   - edited : ajoute « modifié » à côté de l'horodatage
+//   - deleted : remplace le contenu par « 🚫 Message supprimé » en italique
+// Long-press sur ma propre bulle → ouvre la sheet d'actions (parent).
+
+import { memo, useCallback } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, XStack, YStack } from 'tamagui';
+
+import type { MessageRow } from '../hooks/useConversationMessages';
+
+const COLORS = {
+  myBubble: '#10D970', // accent neon
+  myText: '#000000',
+  otherBubble: '#1A1A1A',
+  otherText: '#FFFFFF',
+  metaText: '#A0A0A0',
+  deletedText: '#6B6B6B',
+};
+
+function formatTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  // Format HH:MM pour les messages du jour. Pour la bêta on garde simple.
+  return date.toLocaleTimeString('fr-FR', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export interface MessageBubbleProps {
+  message: MessageRow;
+  isMine: boolean;
+  onLongPress?: (message: MessageRow) => void;
+}
+
+function MessageBubbleComponent({ message, isMine, onLongPress }: MessageBubbleProps) {
+  const isDeleted = message.deleted_at !== null;
+  const isEdited = message.edited_at !== null;
+  const isOptimistic = message.id.startsWith('temp-');
+  const isFailed = message.id.startsWith('failed-');
+
+  const handleLongPress = useCallback(() => {
+    if (!isMine || isDeleted) return;
+    onLongPress?.(message);
+  }, [isMine, isDeleted, onLongPress, message]);
+
+  return (
+    <XStack
+      paddingHorizontal="$3"
+      paddingVertical={3}
+      justifyContent={isMine ? 'flex-end' : 'flex-start'}
+    >
+      <Pressable
+        onLongPress={handleLongPress}
+        delayLongPress={350}
+        style={[
+          styles.bubble,
+          {
+            backgroundColor: isMine ? COLORS.myBubble : COLORS.otherBubble,
+            borderBottomRightRadius: isMine ? 4 : 18,
+            borderBottomLeftRadius: isMine ? 18 : 4,
+            opacity: isOptimistic || isFailed ? 0.6 : 1,
+          },
+        ]}
+      >
+        <YStack gap={2}>
+          {isDeleted ? (
+            <Text
+              fontSize={14}
+              fontStyle="italic"
+              color={isMine ? COLORS.myText : COLORS.deletedText}
+            >
+              🚫 Message supprimé
+            </Text>
+          ) : (
+            <Text fontSize={15} lineHeight={20} color={isMine ? COLORS.myText : COLORS.otherText}>
+              {message.content ?? ''}
+            </Text>
+          )}
+
+          <XStack gap={4} alignItems="center" justifyContent="flex-end">
+            {isFailed ? (
+              <Text fontSize={11} color="#FF3B30" fontWeight="600">
+                Échec — taper pour réessayer
+              </Text>
+            ) : (
+              <>
+                {isEdited && !isDeleted ? (
+                  <Text
+                    fontSize={11}
+                    color={isMine ? 'rgba(0,0,0,0.55)' : COLORS.metaText}
+                    fontStyle="italic"
+                  >
+                    modifié
+                  </Text>
+                ) : null}
+                <Text fontSize={11} color={isMine ? 'rgba(0,0,0,0.55)' : COLORS.metaText}>
+                  {formatTime(message.created_at)}
+                </Text>
+              </>
+            )}
+          </XStack>
+        </YStack>
+      </Pressable>
+    </XStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  bubble: {
+    maxWidth: '78%',
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderTopLeftRadius: 18,
+    borderTopRightRadius: 18,
+  },
+});
+
+export const MessageBubble = memo(MessageBubbleComponent);

--- a/src/features/messaging/components/MessageInput.tsx
+++ b/src/features/messaging/components/MessageInput.tsx
@@ -1,0 +1,93 @@
+// MessageInput — E6-03 / E6-05.
+//
+// Composant sticky bottom : input multiline (max 6 lignes) + bouton Send.
+// Send désactivé si vide ou whitespace only.
+
+import { Send } from 'lucide-react-native';
+import { useCallback, useState } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { TextArea, XStack, YStack } from 'tamagui';
+
+export interface MessageInputProps {
+  onSend: (content: string) => void;
+  disabled?: boolean;
+  placeholder?: string;
+}
+
+const MAX_LINES = 6;
+const MAX_CONTENT_LENGTH = 4000;
+
+export function MessageInput({
+  onSend,
+  disabled = false,
+  placeholder = 'Écrire un message…',
+}: MessageInputProps) {
+  const [content, setContent] = useState('');
+
+  const trimmed = content.trim();
+  const canSend = trimmed.length > 0 && trimmed.length <= MAX_CONTENT_LENGTH;
+
+  const handleSend = useCallback(() => {
+    if (!canSend) return;
+    onSend(trimmed);
+    setContent('');
+  }, [canSend, onSend, trimmed]);
+
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderTopWidth={StyleSheet.hairlineWidth}
+      borderTopColor="$borderColor"
+      paddingHorizontal="$3"
+      paddingTop="$2"
+      paddingBottom="$2"
+    >
+      <XStack alignItems="flex-end" gap="$2">
+        <TextArea
+          flex={1}
+          value={content}
+          onChangeText={(text) => setContent(text.slice(0, MAX_CONTENT_LENGTH))}
+          placeholder={placeholder}
+          placeholderTextColor="$placeholderColor"
+          backgroundColor="$background"
+          borderColor="$borderColor"
+          borderWidth={1}
+          borderRadius={18}
+          color="$color"
+          fontSize={15}
+          paddingHorizontal={14}
+          paddingVertical={8}
+          minHeight={40}
+          maxHeight={20 * MAX_LINES}
+          editable={!disabled}
+          multiline
+        />
+        <Pressable
+          onPress={handleSend}
+          disabled={!canSend || disabled}
+          style={[
+            styles.sendButton,
+            { backgroundColor: canSend && !disabled ? '#10D970' : '#2A2A2A' },
+          ]}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Envoyer le message"
+          accessibilityState={{ disabled: !canSend || disabled }}
+        >
+          <Send size={20} color={canSend && !disabled ? '#000000' : '#6B6B6B'} />
+        </Pressable>
+      </XStack>
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  sendButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 1,
+  },
+});

--- a/src/features/messaging/hooks/useConversationHeader.ts
+++ b/src/features/messaging/hooks/useConversationHeader.ts
@@ -1,0 +1,103 @@
+// useConversationHeader — E6-03.
+//
+// Récupère les infos de l'header pour une conversation : l'autre user (DM)
+// ou le nom du groupe. Pour la bêta, on n'affiche que les DM 1-to-1, donc
+// l'header montre l'avatar + username de l'autre participant.
+
+import { useQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export interface ConversationHeader {
+  conversation_id: string;
+  is_group: boolean;
+  display_name: string;
+  display_avatar_url: string | null;
+  display_is_verified: boolean;
+  other_user_id: string | null;
+}
+
+export function useConversationHeader(conversationId: string | null) {
+  return useQuery({
+    queryKey: ['conversation', conversationId, 'header'],
+    enabled: Boolean(conversationId),
+    queryFn: async (): Promise<ConversationHeader | null> => {
+      if (!conversationId) return null;
+
+      // 1. Récupère la conversation pour savoir si c'est un groupe
+      const { data: conv, error: convError } = await supabase
+        .from('conversations')
+        .select('id, is_group, name')
+        .eq('id', conversationId)
+        .maybeSingle();
+      if (convError) {
+        logger.warn('useConversationHeader conv error', { message: convError.message });
+        throw convError;
+      }
+      if (!conv) return null;
+
+      // 2. Récupère ma session pour exclure moi-même
+      const { data: session, error: sessionError } = await supabase.auth.getSession();
+      if (sessionError || !session.session) throw sessionError ?? new Error('no session');
+      const meId = session.session.user.id;
+
+      if (conv.is_group) {
+        return {
+          conversation_id: conversationId,
+          is_group: true,
+          display_name: conv.name ?? '?',
+          display_avatar_url: null,
+          display_is_verified: false,
+          other_user_id: null,
+        };
+      }
+
+      // 3. DM : récupère l'autre participant + son profile
+      const { data: others, error: othersError } = await supabase
+        .from('conversation_participants')
+        .select('user_id, profiles!inner(username, avatar_url, is_verified)')
+        .eq('conversation_id', conversationId)
+        .neq('user_id', meId)
+        .limit(1);
+      if (othersError) {
+        logger.warn('useConversationHeader other error', { message: othersError.message });
+        throw othersError;
+      }
+
+      const other = (others ?? [])[0] as
+        | {
+            user_id: string;
+            profiles: {
+              username: string;
+              avatar_url: string | null;
+              is_verified: boolean;
+            };
+          }
+        | undefined;
+
+      if (!other) {
+        // Cas dégradé : conv DM sans autre participant (rare, peut arriver si
+        // l'autre user a supprimé son compte et a été retiré par cascade)
+        return {
+          conversation_id: conversationId,
+          is_group: false,
+          display_name: 'Compte supprimé',
+          display_avatar_url: null,
+          display_is_verified: false,
+          other_user_id: null,
+        };
+      }
+
+      return {
+        conversation_id: conversationId,
+        is_group: false,
+        display_name: other.profiles.username,
+        display_avatar_url: other.profiles.avatar_url,
+        display_is_verified: other.profiles.is_verified,
+        other_user_id: other.user_id,
+      };
+    },
+    staleTime: 60_000,
+  });
+}

--- a/src/features/messaging/hooks/useConversationMessages.ts
+++ b/src/features/messaging/hooks/useConversationMessages.ts
@@ -1,0 +1,82 @@
+// useConversationMessages — E6-03.
+//
+// Liste les messages d'une conversation avec pagination infinie vers le haut
+// (cursor sur created_at desc). 50 messages par page.
+//
+// RLS automatique : seuls les messages des conversations dont je suis
+// participant sont retournés (policy `messages select if participant`).
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type MessageAttachmentType = 'text' | 'image' | 'voice' | 'video';
+
+export interface MessageRow {
+  id: string;
+  conversation_id: string;
+  sender_id: string;
+  attachment_type: MessageAttachmentType;
+  content: string | null;
+  attachment_url: string | null;
+  reply_to_id: string | null;
+  created_at: string;
+  edited_at: string | null;
+  deleted_at: string | null;
+}
+
+export const PAGE_SIZE = 50;
+
+export function conversationMessagesQueryKey(conversationId: string) {
+  return ['conversation', conversationId, 'messages'] as const;
+}
+
+interface Page {
+  messages: MessageRow[];
+  nextCursor: string | null;
+}
+
+export function useConversationMessages(conversationId: string | null) {
+  return useInfiniteQuery({
+    queryKey: conversationId
+      ? conversationMessagesQueryKey(conversationId)
+      : ['conversation', 'none'],
+    enabled: Boolean(conversationId),
+    initialPageParam: null as string | null,
+    queryFn: async ({ pageParam }): Promise<Page> => {
+      if (!conversationId) return { messages: [], nextCursor: null };
+
+      let q = supabase
+        .from('messages')
+        .select(
+          'id, conversation_id, sender_id, attachment_type, content, attachment_url, reply_to_id, created_at, edited_at, deleted_at'
+        )
+        .eq('conversation_id', conversationId)
+        .order('created_at', { ascending: false })
+        .limit(PAGE_SIZE);
+
+      if (pageParam) {
+        q = q.lt('created_at', pageParam);
+      }
+
+      const { data, error } = await q;
+      if (error) {
+        logger.warn('useConversationMessages query failed', {
+          message: error.message,
+          conversationId,
+        });
+        throw error;
+      }
+
+      const messages = (data ?? []) as MessageRow[];
+      const last = messages[messages.length - 1];
+      const nextCursor: string | null =
+        messages.length === PAGE_SIZE && last ? last.created_at : null;
+
+      return { messages, nextCursor };
+    },
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    staleTime: 10_000,
+  });
+}

--- a/src/features/messaging/hooks/useMessageActions.ts
+++ b/src/features/messaging/hooks/useMessageActions.ts
@@ -1,0 +1,192 @@
+// useMessageActions — E6-03.
+//
+// Actions sur les messages : édition (UPDATE content + edited_at), soft-delete
+// (UPDATE deleted_at), et marquage lu de la conversation (UPDATE
+// conversation_participants.last_read_at).
+//
+// RLS :
+//   - messages update own : seul le sender peut UPDATE (couvre edit + delete)
+//   - conversation_participants update own last_read_at : seul moi peux UPDATE
+//
+// Optimistic updates côté cache pour fluidité immédiate.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+import { conversationMessagesQueryKey, type MessageRow } from './useConversationMessages';
+
+type MessagePage = {
+  messages: MessageRow[];
+  nextCursor: string | null;
+};
+
+// ---------------------------------------------------------------------------
+// useDeleteMessage — soft-delete d'un message qu'on a envoyé
+// ---------------------------------------------------------------------------
+export function useDeleteMessage(conversationId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (messageId: string) => {
+      const { error } = await supabase
+        .from('messages')
+        .update({ deleted_at: new Date().toISOString() })
+        .eq('id', messageId);
+      if (error) {
+        logger.warn('useDeleteMessage failed', { message: error.message, messageId });
+        throw error;
+      }
+    },
+
+    onMutate: async (messageId) => {
+      await queryClient.cancelQueries({
+        queryKey: conversationMessagesQueryKey(conversationId),
+      });
+      const previous = queryClient.getQueryData<{
+        pages: MessagePage[];
+        pageParams: unknown[];
+      }>(conversationMessagesQueryKey(conversationId));
+
+      queryClient.setQueryData<{
+        pages: MessagePage[];
+        pageParams: unknown[];
+      }>(conversationMessagesQueryKey(conversationId), (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            messages: page.messages.map((m) =>
+              m.id === messageId ? { ...m, deleted_at: new Date().toISOString() } : m
+            ),
+          })),
+        };
+      });
+
+      return { previous };
+    },
+
+    onError: (_err, _msgId, context) => {
+      const ctx = context as
+        | { previous?: { pages: MessagePage[]; pageParams: unknown[] } }
+        | undefined;
+      if (ctx?.previous) {
+        queryClient.setQueryData(conversationMessagesQueryKey(conversationId), ctx.previous);
+      }
+    },
+
+    onSettled: () => {
+      // Le trigger fn_recalc_conversation_last_message_on_delete a mis à jour
+      // conversations.last_message_preview si on a supprimé le dernier message.
+      // On invalide la liste pour le refléter.
+      void queryClient.invalidateQueries({ queryKey: ['conversations', 'my'] });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useEditMessage — édition du contenu (content + edited_at)
+// ---------------------------------------------------------------------------
+export interface EditMessagePayload {
+  messageId: string;
+  newContent: string;
+}
+
+const MAX_CONTENT_LENGTH = 4000;
+
+export function useEditMessage(conversationId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, EditMessagePayload>({
+    mutationFn: async ({ messageId, newContent }) => {
+      const trimmed = newContent.trim();
+      if (trimmed.length === 0) throw new Error('Contenu vide');
+      if (trimmed.length > MAX_CONTENT_LENGTH) {
+        throw new Error(`Message trop long (max ${MAX_CONTENT_LENGTH} caractères)`);
+      }
+
+      const { error } = await supabase
+        .from('messages')
+        .update({ content: trimmed, edited_at: new Date().toISOString() })
+        .eq('id', messageId);
+      if (error) {
+        logger.warn('useEditMessage failed', { message: error.message, messageId });
+        throw error;
+      }
+    },
+
+    onMutate: async ({ messageId, newContent }) => {
+      await queryClient.cancelQueries({
+        queryKey: conversationMessagesQueryKey(conversationId),
+      });
+      const previous = queryClient.getQueryData<{
+        pages: MessagePage[];
+        pageParams: unknown[];
+      }>(conversationMessagesQueryKey(conversationId));
+
+      queryClient.setQueryData<{
+        pages: MessagePage[];
+        pageParams: unknown[];
+      }>(conversationMessagesQueryKey(conversationId), (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            messages: page.messages.map((m) =>
+              m.id === messageId
+                ? { ...m, content: newContent.trim(), edited_at: new Date().toISOString() }
+                : m
+            ),
+          })),
+        };
+      });
+
+      return { previous };
+    },
+
+    onError: (_err, _payload, context) => {
+      const ctx = context as
+        | { previous?: { pages: MessagePage[]; pageParams: unknown[] } }
+        | undefined;
+      if (ctx?.previous) {
+        queryClient.setQueryData(conversationMessagesQueryKey(conversationId), ctx.previous);
+      }
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useMarkConversationRead — UPDATE last_read_at = now() pour moi
+// ---------------------------------------------------------------------------
+export function useMarkConversationRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation<void, Error, string>({
+    mutationFn: async (conversationId: string) => {
+      const { data: session } = await supabase.auth.getSession();
+      if (!session.session) return;
+
+      const { error } = await supabase
+        .from('conversation_participants')
+        .update({ last_read_at: new Date().toISOString() })
+        .eq('conversation_id', conversationId)
+        .eq('user_id', session.session.user.id);
+
+      if (error) {
+        logger.warn('useMarkConversationRead failed', {
+          message: error.message,
+          conversationId,
+        });
+        // On n'rethrow pas : un échec de mark-read ne doit pas bloquer la lecture
+      }
+    },
+
+    onSuccess: () => {
+      // Réduit le badge non-lu sur la liste des conv
+      void queryClient.invalidateQueries({ queryKey: ['conversations', 'my'] });
+    },
+  });
+}

--- a/src/features/messaging/hooks/useSendMessage.ts
+++ b/src/features/messaging/hooks/useSendMessage.ts
@@ -1,0 +1,185 @@
+// useSendMessage — E6-05.
+//
+// Mutation pour envoyer un message texte dans une conversation, avec
+// optimistic update. La bulle apparaît immédiatement (status pending), puis
+// est remplacée par la vraie au retour serveur (via Realtime ou refetch).
+// En cas d'échec, la bulle passe en status 'failed' et un retry est possible.
+//
+// Triggers DB côté Postgres :
+//   - trg_update_conversation_last_message : met à jour conversations.last_message_*
+//   - trg_notify_message : crée une notification pour l'autre participant
+// Aucune action manuelle requise.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+import { uuidv4 } from '@/lib/uuid';
+
+import { conversationMessagesQueryKey, type MessageRow } from './useConversationMessages';
+
+const MAX_CONTENT_LENGTH = 4000;
+
+export interface SendMessagePayload {
+  conversationId: string;
+  content: string;
+  /**
+   * ID temporaire généré côté client. Sert à matcher la bulle optimistic
+   * avec celle qui revient via Realtime.
+   */
+  clientTempId?: string;
+}
+
+interface OptimisticContext {
+  conversationId: string;
+  clientTempId: string;
+}
+
+type MessagePage = {
+  messages: MessageRow[];
+  nextCursor: string | null;
+};
+
+export function useSendMessage() {
+  const queryClient = useQueryClient();
+
+  return useMutation<MessageRow, Error, SendMessagePayload, OptimisticContext>({
+    mutationFn: async ({ conversationId, content }) => {
+      const trimmed = content.trim();
+      if (trimmed.length === 0) throw new Error('Message vide');
+      if (trimmed.length > MAX_CONTENT_LENGTH) {
+        throw new Error(`Message trop long (max ${MAX_CONTENT_LENGTH} caractères)`);
+      }
+
+      const { data: session, error: sessionError } = await supabase.auth.getSession();
+      if (sessionError || !session.session) {
+        throw new Error('Session expirée. Reconnectez-vous.');
+      }
+
+      const { data, error } = await supabase
+        .from('messages')
+        .insert({
+          conversation_id: conversationId,
+          sender_id: session.session.user.id,
+          attachment_type: 'text',
+          content: trimmed,
+        })
+        .select(
+          'id, conversation_id, sender_id, attachment_type, content, attachment_url, reply_to_id, created_at, edited_at, deleted_at'
+        )
+        .single();
+
+      if (error) {
+        logger.warn('useSendMessage insert failed', {
+          message: error.message,
+          conversationId,
+        });
+        throw error;
+      }
+      return data as MessageRow;
+    },
+
+    onMutate: async ({ conversationId, content, clientTempId }) => {
+      const tempId = clientTempId ?? `temp-${uuidv4()}`;
+
+      // Annule les fetchs en cours pour éviter qu'ils écrasent l'optimistic
+      await queryClient.cancelQueries({
+        queryKey: conversationMessagesQueryKey(conversationId),
+      });
+
+      // Ajoute la bulle optimistic en tête de la 1re page (la plus récente)
+      const { data: session } = await supabase.auth.getSession();
+      const meId = session.session?.user.id;
+
+      const optimisticMsg: MessageRow = {
+        id: tempId,
+        conversation_id: conversationId,
+        sender_id: meId ?? 'unknown',
+        attachment_type: 'text',
+        content: content.trim(),
+        attachment_url: null,
+        reply_to_id: null,
+        created_at: new Date().toISOString(),
+        edited_at: null,
+        deleted_at: null,
+      };
+
+      queryClient.setQueryData<{
+        pages: MessagePage[];
+        pageParams: unknown[];
+      }>(conversationMessagesQueryKey(conversationId), (old) => {
+        if (!old || old.pages.length === 0) {
+          return {
+            pages: [{ messages: [optimisticMsg], nextCursor: null as string | null }],
+            pageParams: [null],
+          };
+        }
+        const firstPage = old.pages[0] ?? { messages: [], nextCursor: null as string | null };
+        const rest = old.pages.slice(1);
+        return {
+          ...old,
+          pages: [
+            {
+              messages: [optimisticMsg, ...firstPage.messages],
+              nextCursor: firstPage.nextCursor,
+            },
+            ...rest,
+          ],
+        };
+      });
+
+      return { conversationId, clientTempId: tempId };
+    },
+
+    onError: (_err, vars, context) => {
+      // On marque la bulle temp en `failed` plutôt que de la retirer, pour
+      // permettre un retry depuis l'UI.
+      if (!context) return;
+      queryClient.setQueryData<{
+        pages: MessagePage[];
+        pageParams: unknown[];
+      }>(conversationMessagesQueryKey(vars.conversationId), (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            messages: page.messages.map((m) =>
+              m.id === context.clientTempId
+                ? {
+                    ...m,
+                    // Marqueur visuel pour l'UI : on encode l'erreur dans le content
+                    // (alternative : étendre MessageRow avec status, mais on garde
+                    // light pour la bêta)
+                    id: `failed-${context.clientTempId}`,
+                  }
+                : m
+            ),
+          })),
+        };
+      });
+    },
+
+    onSuccess: (serverMessage, vars, context) => {
+      if (!context) return;
+      // Remplace la bulle temp par la vraie (matching par id temp)
+      queryClient.setQueryData<{
+        pages: MessagePage[];
+        pageParams: unknown[];
+      }>(conversationMessagesQueryKey(vars.conversationId), (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          pages: old.pages.map((page) => ({
+            ...page,
+            messages: page.messages.map((m) => (m.id === context.clientTempId ? serverMessage : m)),
+          })),
+        };
+      });
+
+      // Invalide la liste des conversations pour mettre à jour last_message
+      // (le trigger DB l'a fait côté Postgres, mais le cache client ne le sait pas)
+      void queryClient.invalidateQueries({ queryKey: ['conversations', 'my'] });
+    },
+  });
+}

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -1,0 +1,265 @@
+// ConversationScreen — E6-03 + E6-05.
+//
+// Écran de conversation 1-to-1. Header avec avatar + username de l'autre.
+// FlashList inversée des messages, paginée vers le haut (cursor created_at).
+// Input texte en bas (KeyboardAvoidingView).
+// Marquage lu auto au mount + au focus.
+// Long-press sur mes bulles → sheet d'actions (Modifier / Supprimer).
+//
+// Hors scope bêta (cohérent avec spec recadrée le 02/06/2026) :
+//   - Boutons d'appel audio/vidéo Daily.co (Sprint 6+ tickets #85-88)
+//   - Pièces jointes image/voice/video
+//   - Réponses (reply_to_id)
+
+import { FlashList } from '@shopify/flash-list';
+import { Image } from 'expo-image';
+import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
+import { ArrowLeft, CheckCircle2 } from 'lucide-react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+import { MessageActionSheet } from '@/features/messaging/components/MessageActionSheet';
+import { MessageBubble } from '@/features/messaging/components/MessageBubble';
+import { MessageInput } from '@/features/messaging/components/MessageInput';
+import { useConversationHeader } from '@/features/messaging/hooks/useConversationHeader';
+import {
+  type MessageRow,
+  useConversationMessages,
+} from '@/features/messaging/hooks/useConversationMessages';
+import {
+  useDeleteMessage,
+  useEditMessage,
+  useMarkConversationRead,
+} from '@/features/messaging/hooks/useMessageActions';
+import { useSendMessage } from '@/features/messaging/hooks/useSendMessage';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export function ConversationScreen() {
+  const insets = useSafeAreaInsets();
+  const { id: conversationId } = useLocalSearchParams<{ id: string }>();
+  const convId = typeof conversationId === 'string' ? conversationId : null;
+
+  const headerQuery = useConversationHeader(convId);
+  const messagesQuery = useConversationMessages(convId);
+  const sendMessage = useSendMessage();
+  const markRead = useMarkConversationRead();
+  const editMessage = useEditMessage(convId ?? '');
+  const deleteMessage = useDeleteMessage(convId ?? '');
+
+  const [meId, setMeId] = useState<string | null>(null);
+  const [actionSheetOpen, setActionSheetOpen] = useState(false);
+  const [actionMessage, setActionMessage] = useState<MessageRow | null>(null);
+
+  // Récupère mon user_id au mount pour identifier les bulles "à moi"
+  useEffect(() => {
+    void (async () => {
+      const { data } = await supabase.auth.getSession();
+      setMeId(data.session?.user.id ?? null);
+    })();
+  }, []);
+
+  // Marquage lu au mount et à chaque focus de l'écran
+  useFocusEffect(
+    useCallback(() => {
+      if (convId) {
+        markRead.mutate(convId);
+      }
+    }, [convId, markRead])
+  );
+
+  // Aplatissement des pages en une seule liste (la plus récente en tête)
+  const messages = useMemo<MessageRow[]>(() => {
+    return messagesQuery.data?.pages.flatMap((p) => p.messages) ?? [];
+  }, [messagesQuery.data]);
+
+  const handleSend = useCallback(
+    (content: string) => {
+      if (!convId) return;
+      sendMessage.mutate(
+        { conversationId: convId, content },
+        {
+          onError: (err) => {
+            logger.warn('Send message failed', { message: err.message });
+          },
+        }
+      );
+    },
+    [convId, sendMessage]
+  );
+
+  const handleLongPressBubble = useCallback((message: MessageRow) => {
+    setActionMessage(message);
+    setActionSheetOpen(true);
+  }, []);
+
+  const handleEdit = useCallback(
+    async (messageId: string, newContent: string) => {
+      await editMessage.mutateAsync({ messageId, newContent });
+    },
+    [editMessage]
+  );
+
+  const handleDelete = useCallback(
+    async (messageId: string) => {
+      await deleteMessage.mutateAsync(messageId);
+    },
+    [deleteMessage]
+  );
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/(tabs)/messages');
+  }, []);
+
+  const handleLoadMore = useCallback(() => {
+    if (messagesQuery.hasNextPage && !messagesQuery.isFetchingNextPage) {
+      void messagesQuery.fetchNextPage();
+    }
+  }, [messagesQuery]);
+
+  const renderMessage = useCallback(
+    ({ item }: { item: MessageRow }) => (
+      <MessageBubble
+        message={item}
+        isMine={item.sender_id === meId}
+        onLongPress={handleLongPressBubble}
+      />
+    ),
+    [meId, handleLongPressBubble]
+  );
+
+  // Header
+  const header = headerQuery.data;
+  const initial =
+    header?.display_name && header.display_name.length > 0
+      ? header.display_name.charAt(0).toUpperCase()
+      : '?';
+
+  return (
+    <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+      {/* Header */}
+      <XStack
+        height={56}
+        paddingHorizontal="$3"
+        alignItems="center"
+        gap="$3"
+        borderBottomWidth={StyleSheet.hairlineWidth}
+        borderBottomColor="$borderColor"
+      >
+        <Pressable
+          onPress={handleBack}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          accessibilityRole="button"
+          accessibilityLabel="Retour"
+        >
+          <ArrowLeft size={24} color="#FFFFFF" />
+        </Pressable>
+
+        {header?.display_avatar_url ? (
+          <Image
+            source={{ uri: header.display_avatar_url }}
+            style={styles.avatar}
+            contentFit="cover"
+          />
+        ) : (
+          <YStack
+            style={styles.avatar}
+            backgroundColor="$surface"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Text color="$color" fontSize={14} fontWeight="700">
+              {initial}
+            </Text>
+          </YStack>
+        )}
+
+        <XStack flex={1} alignItems="center" gap={4}>
+          <Text color="$color" fontSize={16} fontWeight="700" numberOfLines={1}>
+            {header?.display_name ?? '...'}
+          </Text>
+          {header?.display_is_verified ? (
+            <CheckCircle2 size={14} color="#10D970" fill="#10D970" />
+          ) : null}
+        </XStack>
+        {/* Pas de bouton appel pour la bêta (Daily.co Sprint 6+) */}
+      </XStack>
+
+      {/* Liste messages */}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 20}
+        style={styles.flex}
+      >
+        <View flex={1} backgroundColor="$background">
+          {messagesQuery.isLoading ? (
+            <YStack flex={1} alignItems="center" justifyContent="center">
+              <ActivityIndicator color="#FFFFFF" />
+            </YStack>
+          ) : (
+            <FlashList
+              data={messages}
+              renderItem={renderMessage}
+              keyExtractor={(item) => item.id}
+              inverted
+              onEndReached={handleLoadMore}
+              onEndReachedThreshold={0.3}
+              contentContainerStyle={styles.listContent}
+              ListFooterComponent={
+                messagesQuery.isFetchingNextPage ? (
+                  <YStack paddingVertical="$3" alignItems="center">
+                    <ActivityIndicator color="#FFFFFF" />
+                  </YStack>
+                ) : null
+              }
+              ListEmptyComponent={
+                <YStack flex={1} alignItems="center" justifyContent="center" paddingVertical={80}>
+                  <Text color="$textSecondary" fontSize={14}>
+                    Aucun message. Démarre la conversation 👋
+                  </Text>
+                </YStack>
+              }
+            />
+          )}
+        </View>
+
+        <MessageInput onSend={handleSend} disabled={sendMessage.isPending} />
+        <View style={{ height: insets.bottom }} backgroundColor="$surface" />
+      </KeyboardAvoidingView>
+
+      {/* Sheet d'actions sur long-press */}
+      <MessageActionSheet
+        message={actionMessage}
+        open={actionSheetOpen}
+        onOpenChange={setActionSheetOpen}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        editIsPending={editMessage.isPending}
+        deleteIsPending={deleteMessage.isPending}
+      />
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  flex: { flex: 1 },
+  avatar: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    overflow: 'hidden',
+  },
+  listContent: {
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+});


### PR DESCRIPTION
## Contexte

Écran de conversation 1-to-1 type WhatsApp pour la bêta du 12 juin. Consomme le schéma livré dans PR #192. La spec a été recadrée ce matin pour clarifier le scope bêta vs Sprint 6+.

Closes #77, closes #79.

## Contenu

| Fichier | Rôle |
|---|---|
| `hooks/useConversationMessages.ts` | useInfiniteQuery sur messages, cursor `created_at` desc, 50/page |
| `hooks/useConversationHeader.ts` | Récupère l'autre participant + profile pour l'header |
| `hooks/useSendMessage.ts` | INSERT texte + optimistic update + retry sur échec |
| `hooks/useMessageActions.ts` | Edit + soft-delete + mark-read (optimistic + rollback) |
| `components/MessageBubble.tsx` | Bulle accent neon (moi) / surface (autre), gère deleted + edited + failed |
| `components/MessageInput.tsx` | Sticky bottom multiline + bouton Send |
| `components/MessageActionSheet.tsx` | Sheet long-press → Modifier / Supprimer |
| `screens/ConversationScreen.tsx` | Assemblage : header + FlashList inversée + input + mark-read auto |
| `app/messages/[id].tsx` | Route Expo |

## Décisions techniques

| Sujet | Choix |
|---|---|
| Pagination | Cursor sur `created_at` desc (50/page) — pas d'offset, pas de double-fetch si nouveau message arrive entre 2 pages |
| Optimistic | `setQueryData` direct + ID temp `temp-{uuid}` → `serverMessage` au retour. Échec → `failed-{uuid}` pour retry depuis l'UI |
| Mark read | `UPDATE conversation_participants` au mount + au `useFocusEffect` (réduit le badge non-lu de la liste #76) |
| Soft-delete | `UPDATE deleted_at`, bulle « 🚫 Message supprimé » côté UI + trigger DB recalcule le preview de la liste |
| Édition | `UPDATE content + edited_at`, marqueur « modifié » à côté de l'horodatage |
| RLS | Côté serveur uniquement (policies `messages select if participant` etc.). Aucun filtre côté client. |

## Hors scope bêta (cohérent avec spec recadrée)

- Boutons d'appel audio/vidéo Daily.co — tickets #85-88 (Sprint 6+)
- Pièces jointes image/voice/video — schéma supporte via `attachment_type`
- Réponses (`reply_to_id`) — supporté en DB mais pas d'UI bêta
- Reactions emoji
- **Realtime live** : ticket #78 dans une PR séparée. Pour l'instant on rafraîchit au focus + au mount. Quand #78 sera mergé, les nouveaux messages apparaîtront en temps réel sans modif d'autre code.

## Test plan

À tester sur le nouveau Dev Build (en cours EAS) :

- [ ] Depuis #76 (écran liste qu'on a confié à Farah, à attendre) → tap row → /messages/[id] s'ouvre
- [ ] L'header affiche bien l'avatar + username de l'autre user
- [ ] Tape un message + Send → bulle accent neon à droite, immédiatement
- [ ] Le badge de la conv dans la liste se met à jour avec ton message
- [ ] Long-press sur ta bulle → sheet apparaît avec Modifier + Supprimer
- [ ] Modifier → input pré-rempli, change le texte, Enregistrer → la bulle update avec « modifié » à côté de l'horodatage
- [ ] Supprimer → confirmation → la bulle devient « 🚫 Message supprimé »
- [ ] Long-press sur la bulle de l'autre user → sheet ne s'ouvre PAS (control isMine)
- [ ] Scroll vers le haut → pagination 50/page se déclenche
- [ ] Quitter et revenir → mark-read s'est fait (badge à 0 sur la conv dans la liste)
- [ ] Tester `senderId != auth.uid()` : impossible côté client car on récupère du `getSession()`. RLS bloquerait quand même côté serveur (test couvert par l'audit RLS #110).

## Dépend de

- PR #192 (schéma DB messagerie) ✅ mergée
- PR #76 (écran liste conv) — à mergeer pour avoir la navigation vers `/messages/[id]`. Mais cette PR ne dépend pas du code de #76, juste de la route.

## Suite

- #78 Realtime subscription (PR séparée, ajout du hook `useRealtimeConversation`)
- #114 Accessibilité (Voice Over sur les bulles)