### PR TITLE
docs(beta): release notes v0.1.0 + guide bêta-testeur (T-07)

### DIFF
--- a/docs/beta-guide.md
+++ b/docs/beta-guide.md
@@ -1,0 +1,125 @@
+# Guide du bêta-testeur DOUMASSI
+
+Bienvenue parmi les premiers utilisateurs de DOUMASSI 🎉
+
+Ce guide vous explique comment installer la bêta, ce que vous pouvez tester, et comment nous remonter vos retours.
+
+## 1. Installation
+
+### iOS (TestFlight)
+
+1. Vous avez reçu un email d'invitation de **TestFlight** (Apple). Acceptez l'invitation.
+2. Installez TestFlight depuis l'App Store si vous ne l'avez pas déjà.
+3. Ouvrez TestFlight → onglet « Apps » → tapez sur **DOUMASSI** → « Installer ».
+4. L'app apparaît sur votre écran d'accueil iOS comme n'importe quelle autre.
+
+### Android (Play Internal)
+
+1. Vous avez reçu un email d'invitation au **circuit interne** Play Store.
+2. Cliquez sur le lien dans l'email pour accepter (vous devez être connecté à votre compte Google sur l'appareil).
+3. Ouvrez Play Store → recherchez **DOUMASSI** → installez.
+4. Vérifiez bien que la version est marquée « Bêta interne » dans la fiche du store.
+
+## 2. Premier lancement
+
+1. Au démarrage, vous arrivez sur l'écran d'accueil avec le logo DOUMASSI.
+2. Tapez sur **Créer un compte** (ou **Se connecter** si vous en avez déjà un).
+3. Suivez le parcours d'inscription : email + mot de passe, puis acceptez les CGU et la politique de confidentialité.
+4. Étape 1 d'onboarding : ajoutez une photo de profil, votre prénom + nom, une bio courte.
+5. Étape 2 : choisissez votre nom d'utilisateur (`@username`) et votre date de naissance.
+6. Vous arrivez sur le fil d'actualité 🎉
+
+## 3. Ce qu'on vous demande de tester en priorité
+
+### Parcours « réseau social » classique
+
+- [ ] Créer un post avec du texte
+- [ ] Créer un post avec 1 à 4 images
+- [ ] Aimer / commenter / sauvegarder un post
+- [ ] Suivre un autre utilisateur
+- [ ] Voir vos abonnés et abonnements
+- [ ] Visiter votre profil et celui d'un autre utilisateur
+
+### Parcours stories
+
+- [ ] Créer une story photo (tap)
+- [ ] Créer une story vidéo (long-press, max 15 s)
+- [ ] Voir les stories des autres (tap droite/gauche pour naviguer)
+- [ ] Sur votre propre story : tapez « Vu par » en bas pour voir qui l'a vue
+
+### Parcours messagerie (nouveau)
+
+- [ ] Ouvrir l'onglet **Messages**
+- [ ] Démarrer une nouvelle conversation depuis le profil d'un autre utilisateur (bouton + en haut)
+- [ ] Envoyer plusieurs messages texte
+- [ ] **Long-press sur l'un de vos messages** : essayez de le modifier puis de le supprimer
+- [ ] Recevoir un message en temps réel (demandez à un autre testeur de vous écrire)
+
+### Parcours RGPD (important pour nous)
+
+- [ ] Paramètres → Compte → **Exporter mes données** → un fichier JSON doit se télécharger via le partage natif
+- [ ] Paramètres → Compte → **Supprimer mon compte** → confirmez en tapant SUPPRIMER → vous êtes déconnecté
+- [ ] Reconnectez-vous avec le même compte → l'écran vous propose d'**annuler la suppression**, faites-le, vérifiez que votre compte est restauré
+
+### Parcours notifications
+
+- [ ] Vérifier qu'une notification push arrive lorsqu'un autre utilisateur vous suit, like, commente, ou vous envoie un message
+- [ ] Taper sur la notification → l'app s'ouvre directement sur la bonne destination (profil, post, conversation)
+
+## 4. Ce qu'on **ne vous demande pas** de tester
+
+Les fonctions suivantes apparaissent en placeholder « Bientôt » dans l'app, c'est normal :
+
+- 🛒 Marketplace
+- 🤖 Studio AI
+- 💳 Wallet (portefeuille)
+- 📞 Appels audio / vidéo
+- 💬 Conversations de groupe
+- 📷 Envoi d'images / messages vocaux dans les messages
+
+Ces fonctionnalités arriveront dans les prochaines versions, on travaille dessus.
+
+## 5. Comment remonter vos retours
+
+### Pour un bug
+
+1. Sur Slack : canal `#beta-feedback` sur `doumassiworkspace.slack.com`
+   - Décrivez **ce que vous avez fait** (clic par clic)
+   - Décrivez **ce que vous attendiez**
+   - Décrivez **ce qui s'est passé à la place**
+   - Joignez une **capture d'écran** ou une **vidéo**
+   - Précisez votre **OS** (Android 14, iOS 17, etc.) et le **modèle d'appareil**
+2. Ou GitHub : https://github.com/Waoow-tech/DOUMASSI-Application/issues/new avec le préfixe `[BUG]`
+
+### Pour une suggestion / idée
+
+- Slack : `#beta-feedback` également, en préfixant par 💡
+
+### Pour une question
+
+- Slack : `#beta-questions` ou par email à `beta@doumassi.com`
+
+## 6. Vie privée & sécurité
+
+Pendant la bêta, vos données sont stockées sur nos serveurs Supabase (UE).
+
+- Vous pouvez à tout moment **exporter** vos données (Paramètres → Compte → Exporter mes données)
+- Vous pouvez à tout moment **supprimer** votre compte (Paramètres → Compte → Supprimer mon compte) avec un délai de récupération de 30 jours
+- Vos données ne sont **jamais** vendues ni partagées avec des tiers à des fins publicitaires
+- Pour toute question RGPD : `privacy@doumassi.com`
+
+## 7. Qu'arrive-t-il après la bêta ?
+
+À la fin de la bêta fermée, nous prévoyons :
+
+1. Une mise à jour majeure incluant la marketplace et le studio AI
+2. Un passage en bêta ouverte (TestFlight public + Play Store ouvert)
+3. Une sortie publique sur les stores
+
+Vos retours pendant cette phase fermée sont donc particulièrement précieux — ils orientent directement les prochaines versions.
+
+---
+
+**Merci de votre temps et de votre confiance ❤️**
+
+_L'équipe DOUMASSI_

--- a/docs/release-notes/v0.1.0-beta.md
+++ b/docs/release-notes/v0.1.0-beta.md
@@ -1,0 +1,124 @@
+# DOUMASSI v0.1.0-beta — Bêta fermée
+
+**Date de release** : 12 juin 2026
+**Cible** : TestFlight (iOS) + Play Internal (Android)
+**Volume** : ~50 bêta-testeurs sur invitation
+
+## Périmètre fonctionnel — ce que vous pouvez tester
+
+### 🔐 Authentification & onboarding
+
+- Inscription par email + mot de passe
+- Connexion par email + mot de passe **ou** par numéro de téléphone
+- Connexion par compte Google (OAuth)
+- Réinitialisation de mot de passe par email
+- Parcours d'onboarding en 2 étapes : photo de profil + bio, puis username + date de naissance
+- Acceptation des CGU et de la politique de confidentialité conditionnée à l'inscription
+
+### 👤 Profil & social
+
+- Profil personnel avec photo de couverture, avatar, bio, compteurs publics/abonnés/abonnements
+- Édition complète du profil (avec cooldown de 30 jours sur le changement de nom d'utilisateur)
+- Profil d'un autre utilisateur avec bouton « Suivre / Ne plus suivre »
+- Profil privé (le contenu n'est visible que par les abonnés acceptés)
+- Demande de suivi sur profil privé (Confirmer / Refuser depuis les notifications)
+- Bloquer / Débloquer un utilisateur (masquage bilatéral du contenu)
+- Liste des utilisateurs bloqués (gestion depuis les paramètres)
+- Recherche d'utilisateurs avec tolérance aux fautes (debounce 300 ms, `pg_trgm`)
+- Liste des abonnés / abonnements avec recherche locale
+
+### 📰 Fil d'actualité & posts
+
+- Fil principal avec 5 onglets (Social actif, Business / IA / Wallet / Soon en placeholder)
+- Pagination infinie + pull-to-refresh
+- Création d'un post texte ou avec jusqu'à 4 images
+- Vue détail d'un post en plein écran (type TikTok)
+- Like / unlike avec mise à jour optimiste
+- Commentaires threadés avec réponses + likes sur commentaires
+- Bookmark / unbookmark (liste des posts sauvegardés accessible depuis l'onglet correspondant)
+- Suppression de ses propres posts (soft-delete avec animation)
+- Masquage local d'un post (préférence personnelle stockée en `AsyncStorage`)
+- Partage d'un post via lien universel `https://doumassi.app/post/{id}`
+
+### 📸 Stories
+
+- Création d'une story photo (capture caméra) ou vidéo (long-press 15 s max)
+- Visionneuse plein écran avec barres de progression, navigation gauche/droite, auto-advance
+- Footer « 👁 Vu par » sur ses propres stories qui ouvre la liste des viewers avec avatars + horodatage
+- Expiration automatique au bout de 24 h (purge serveur par `pg_cron`)
+
+### 💬 Messagerie (nouveau en bêta)
+
+- Liste des conversations triée par dernier message, avec badge de messages non-lus
+- Ouverture d'une conversation 1-to-1 (DM)
+- Envoi de messages texte avec mise à jour optimiste (la bulle apparaît instantanément)
+- Édition et suppression d'un message qu'on a envoyé (long-press → modifier / supprimer)
+- Marquage lu automatique à l'ouverture d'une conversation
+- Mise à jour en temps réel des nouveaux messages (Supabase Realtime)
+
+### 🔔 Notifications
+
+- Notifications in-app (5 onglets : Toutes / Non lus / Social / Paiement / IA)
+- Notifications push (Expo Push, taps qui routent vers l'élément concerné)
+- Badge sur l'onglet « Cloche » qui se met à jour en quasi-temps réel
+
+### 🔒 Confidentialité & RGPD
+
+- **Exporter mes données** : JSON consolidé téléchargeable depuis Paramètres → Compte (article 20 RGPD — droit à la portabilité)
+- **Supprimer mon compte** : suppression avec grace period de 30 jours pendant lesquels le compte peut être restauré en se reconnectant
+- Conformité RGPD complète sur la collecte, la conservation et la suppression des données personnelles
+
+## Hors scope bêta — pour information
+
+Les fonctionnalités suivantes apparaissent dans l'interface sous forme de placeholders « Bientôt » et ne sont **pas testables** pendant cette bêta :
+
+- 🛒 Marketplace (vente entre particuliers, annonces, recommandations)
+- 🤖 Studio AI (chat IA, génération d'image, mode Reflection, mode Learning)
+- 💳 Wallet (portefeuille numérique, paiements peer-to-peer)
+- 📞 Appels audio / vidéo (Daily.co prévu Sprint 6)
+- 💬 Conversations de groupe dans la messagerie (le schéma DB les supporte mais l'UI n'est pas exposée)
+- 📷 Envoi de pièces jointes (image / voix / vidéo) dans les messages
+- 💬 Répondre à un message spécifique (le schéma le supporte, l'UI viendra Sprint 6)
+- 🌐 Recherche web Tavily, web search dans le chat IA, mode vocal Whisper
+
+## Bugs connus
+
+- Les builds Android sur certains Samsung Galaxy (One UI 5.x) peuvent afficher une zone de notch trop étroite — workaround : rotation puis retour
+- L'envoi d'images compresse en JPEG qualité 0,8 par défaut ; si l'image source est très petite, le fichier final peut être plus volumineux que l'original
+- Sur iOS, l'animation de fermeture du sheet « Vu par » peut hicquer si on swipe trop vite (cosmétique, sans impact fonctionnel)
+- Une notification push reçue alors que l'utilisateur est déjà sur l'écran de conversation correspondant ne sera pas dédupliquée — vous verrez la notification ET le nouveau message à l'écran
+
+## Comment remonter un bug
+
+1. Ouvrir une issue sur le repo : https://github.com/Waoow-tech/DOUMASSI-Application/issues/new
+2. Préfixer le titre par `[BUG]`
+3. Joindre :
+   - Le numéro de version (visible dans Paramètres → À propos)
+   - Un descriptif du parcours qui mène au bug
+   - Une capture d'écran si possible
+   - L'OS et le modèle de l'appareil (ex. Android 14, Samsung Galaxy S22)
+4. Slack : `#beta-feedback` sur `doumassiworkspace.slack.com` pour les retours informels
+
+## Architecture technique
+
+Pour les curieux, voici la stack en place :
+
+- **Mobile** : React Native 0.83.6 + Expo SDK 55, TypeScript strict
+- **UI Kit** : Tamagui 1.135.5
+- **State serveur** : TanStack Query v5 (optimistic updates, pagination cursor-based, mutations)
+- **State client global** : Zustand 5
+- **Formulaires** : React Hook Form + Zod
+- **Listes virtualisées** : FlashList (Shopify)
+- **Back-end** : Supabase (Postgres + RLS + Storage + Realtime + Edge Functions + pg_cron + pg_net)
+- **Monitoring** : Sentry (crashes) + PostHog (analytics + coûts API)
+- **CI/CD** : GitHub Actions + EAS Build
+
+## Crédits
+
+- **Direction produit** : Biram DOUMASSI
+- **Direction technique** : Abdourahamane BAH
+- **Développement** : Hamlaoui Mohamed Ilias (stagiaire L3), DISSOU M'hamed-Farah (stagiaire L3), et l'équipe technique COSMOS
+
+---
+
+_Pour toute question, contact : contact@doumassi.com_


### PR DESCRIPTION
## Contexte

Documentation prête pour l'ouverture de la bêta fermée du 12 juin (TestFlight + Play Internal, ~50 testeurs).

Closes #113.

## Contenu

| Fichier | Rôle |
|---|---|
| `docs/release-notes/v0.1.0-beta.md` | Changelog complet : périmètre testé, hors scope, bugs connus, stack |
| `docs/beta-guide.md` | Guide pour les bêta-testeurs : install, parcours à tester, comment remonter |

## Ce qui était déjà fait (PRs antérieures)

- **CGU/CGV** : `src/features/legal/content/cgv-fr.ts` (en place depuis Sprint 2)
- **Politique de confidentialité** : `src/features/legal/content/privacy-fr.ts` + `privacy-en.ts` (PR #156 par Farah, E-PRIVACY)
- **Écrans d'affichage** : `app/(auth)/terms.tsx` et `app/(auth)/privacy.tsx` déjà accessibles depuis Settings → Légal

## Test plan

- [ ] Lecture des release notes : tout le périmètre Phase 1 + Phase 2 RGPD + Phase 3 messagerie est mentionné
- [ ] Lecture du guide bêta : un nouveau testeur peut installer, créer un compte, et identifier les 5 parcours à tester
- [ ] Vérifier la cohérence avec les Email d'invitation TestFlight (à finaliser au moment de l'envoi)

## Hors scope de cette PR

- ⚠️ **Publication dans Notion** : à faire manuellement par le CTO (les liens vers les documents Notion sont mentionnés génériquement dans le guide)
- Lien depuis l'écran « À propos » vers les release notes in-app : cosmétique, peut être ajouté Sprint 6 si demande
- Génération automatique du changelog depuis les commits : pas critique en bêta, à mettre en place pour les versions publiques