### PR TITLE
fix(stories): DEFAULT auth.uid() manquant sur stories.author_id

### DIFF
--- a/supabase/migrations/20260602140000_stories_author_id_default.sql
+++ b/supabase/migrations/20260602140000_stories_author_id_default.sql
@@ -1,0 +1,23 @@
+-- Fix : DEFAULT auth.uid() manquant sur stories.author_id
+--
+-- Même bug que sur posts.author_id (corrigé en Sprint 3 par
+-- 20260520120000_posts_author_id_default.sql). La table stories a été
+-- déployée au Sprint 0 sans DEFAULT sur author_id.
+--
+-- useCreateStory (E4-12) insère volontairement sans author_id (pattern
+-- RGPD : la base est seule source de vérité pour cette colonne, le client
+-- ne doit jamais pouvoir l'usurper). Sans le DEFAULT, la colonne tombe
+-- à NULL, et la policy RLS "stories users insert own" évalue
+-- `author_id = auth.uid()` comme NULL → INSERT rejeté avec
+-- « new row violates row-level security policy for table stories ».
+--
+-- Bug remonté par le CTO en test du Dev Build (2026-06-02 17:48).
+--
+-- À appliquer DEV + STAGING via AI Supabase.
+
+alter table public.stories alter column author_id set default auth.uid();
+
+-- Vérification post-application : la colonne doit avoir le default
+-- select column_default from information_schema.columns
+-- where table_schema = 'public' and table_name = 'stories' and column_name = 'author_id';
+-- attendu : "auth.uid()"


### PR DESCRIPTION
## Contexte

🚨 Bug remonté par le CTO en test du Dev Build (2026-06-02 17:48).

Création de story photo ou vidéo échoue avec :
> new row violates row-level security policy for table 'stories'

## Cause racine

Même bug qu'on avait sur `posts.author_id` au Sprint 3 (fixé via PR `20260520120000_posts_author_id_default.sql`) :

1. La table `stories` a été déployée au Sprint 0 sans `DEFAULT auth.uid()` sur la colonne `author_id`
2. Le hook `useCreateStory` (E4-12) insère volontairement **sans** `author_id` côté client — c'est un pattern RGPD/sécurité : la base est seule source de vérité pour cette colonne, le client ne doit jamais pouvoir l'usurper
3. Sans le DEFAULT, la colonne tombe à `NULL`
4. La policy RLS `stories users insert own` (`with check (author_id = auth.uid())`) évalue `NULL = auth.uid()` → NULL → INSERT rejeté

## Fix

Migration `20260602140000_stories_author_id_default.sql` :
```sql
alter table public.stories alter column author_id set default auth.uid();
```

Une ligne. Idempotente (rejouable sans casse).

## À appliquer

1. Coller le SQL dans AI Supabase sur **DEV** → vérifier la création de story
2. Pareil sur **STAGING**
3. Vérification :
```sql
select column_default from information_schema.columns
where table_schema = 'public' and table_name = 'stories' and column_name = 'author_id';
-- attendu : "auth.uid()"
```

## Test plan

- [ ] Appliquer migration sur DEV
- [ ] Sur le Dev Build : créer une story photo → publication OK
- [ ] Créer une story vidéo → publication OK
- [ ] Vérifier dans `select * from stories order by created_at desc limit 1` que `author_id` est bien rempli
- [ ] Appliquer sur STAGING quand DEV est validé

## Note pour le futur

Il faudrait auditer toutes les tables Sprint 0 pour repérer les autres colonnes owner sans DEFAULT (`comments.author_id`, `messages.sender_id`, `conversation_participants.user_id`, etc.). Probablement à ajouter à la checklist du Bug Bash #107.