### PR TITLE
fix(rls): DEFAULT auth.uid() consolidé sur 8 colonnes owner Sprint 0

### DIFF
--- a/supabase/migrations/20260602150000_owner_columns_default_auth_uid.sql
+++ b/supabase/migrations/20260602150000_owner_columns_default_auth_uid.sql
@@ -1,0 +1,40 @@
+-- Fix consolidé : DEFAULT auth.uid() manquant sur 8 colonnes owner
+--
+-- Audit complet réalisé par le CTO le 2026-06-02 18:00 après découverte du
+-- bug `stories.author_id` (qui avait son propre fix juste avant —
+-- 20260602140000_stories_author_id_default.sql). L'audit a croisé pour chaque
+-- table `public.*` les colonnes owner (author_id, user_id, sender_id, etc.)
+-- avec leurs policies RLS INSERT.
+--
+-- Pattern du bug :
+--   - Une policy INSERT a `with check (col = auth.uid())` pour empêcher
+--     l'usurpation côté client (sécurité OK)
+--   - Mais la colonne n'a pas `default auth.uid()` côté schéma
+--   - Le client (par discipline RGPD/sécurité) n'envoie pas la colonne
+--   - Postgres insère NULL → la policy évalue `NULL = auth.uid()` → NULL →
+--     INSERT rejeté avec « new row violates row-level security policy »
+--
+-- Le fix : on ajoute le DEFAULT auth.uid() sur les 8 colonnes identifiées.
+-- Les autres colonnes nullable (recipient_id, followed_id, created_by,
+-- conversation_participants.user_id, ai_rate_limits.user_id, etc.) sont
+-- volontairement NON modifiées — soit elles désignent un autre user (followed,
+-- recipient), soit elles sont uniquement remplies via RPC SECURITY DEFINER
+-- ou trigger côté serveur.
+--
+-- À appliquer DEV + STAGING via AI Supabase.
+
+alter table public.blocks            alter column blocker_id  set default auth.uid();
+alter table public.comment_likes     alter column user_id     set default auth.uid();
+alter table public.comments          alter column author_id   set default auth.uid();
+alter table public.follows           alter column follower_id set default auth.uid();
+alter table public.listing_bookmarks alter column user_id     set default auth.uid();
+alter table public.messages          alter column sender_id   set default auth.uid();
+alter table public.deletion_requests alter column user_id     set default auth.uid();
+alter table public.ai_conversations  alter column user_id     set default auth.uid();
+
+-- Vérification post-application :
+--   select table_name, column_name, column_default
+--   from information_schema.columns
+--   where table_schema = 'public' and column_default like '%auth.uid()%'
+--   order by table_name;
+-- Attendu : 12 lignes (4 déjà fixées au Sprint 3 + 8 ajoutées ici)


### PR DESCRIPTION
## Contexte

Audit complet du CTO le 2026-06-02 18:00 après découverte du bug `stories.author_id` (fix précédent PR #198). 8 tables ont été identifiées avec le même pattern de bug latent.

## Pattern du bug

1. Policy RLS INSERT en place : `with check (col = auth.uid())` ✅ sécurité OK
2. Mais la colonne n'a pas `default auth.uid()` côté schéma
3. Le client (par discipline RGPD/sécurité) omet la colonne dans son INSERT
4. Postgres insère `NULL` → la policy évalue `NULL = auth.uid()` → `NULL` → INSERT rejeté avec « new row violates row-level security policy »

Déjà fixé en Sprint 3 sur `posts`, `likes`, `bookmarks` (PR `20260520120000`) puis sur `stories` (PR #198).

## Tables corrigées (8)

| Table | Colonne |
|---|---|
| `blocks` | `blocker_id` |
| `comment_likes` | `user_id` |
| `comments` | `author_id` |
| `follows` | `follower_id` |
| `listing_bookmarks` | `user_id` |
| `messages` | `sender_id` |
| `deletion_requests` | `user_id` |
| `ai_conversations` | `user_id` |

## Tables NON modifiées (volontairement)

| Table | Colonne | Raison |
|---|---|---|
| `follows` | `followed_id` | Désigne l'autre user, pas moi |
| `notifications` | `recipient_id` | Désigne le destinataire |
| `conversations` | `created_by` | Renseigné par RPC explicitement |
| `conversation_participants` | `user_id` | Alimenté par RPC create_dm/group |
| `ai_rate_limits` | `user_id` | Alimenté server-side uniquement |
| `user_interest_embeddings` | `user_id` | Alimenté par cron embedding |

## À appliquer

```sql
alter table public.blocks            alter column blocker_id  set default auth.uid();
alter table public.comment_likes     alter column user_id     set default auth.uid();
alter table public.comments          alter column author_id   set default auth.uid();
alter table public.follows           alter column follower_id set default auth.uid();
alter table public.listing_bookmarks alter column user_id     set default auth.uid();
alter table public.messages          alter column sender_id   set default auth.uid();
alter table public.deletion_requests alter column user_id     set default auth.uid();
alter table public.ai_conversations  alter column user_id     set default auth.uid();
```

## Vérification post-application

```sql
select table_name, column_name, column_default
from information_schema.columns
where table_schema = 'public' and column_default like '%auth.uid()%'
order by table_name;
```

Attendu : **12 lignes** (4 déjà fixées au Sprint 3 + 8 ajoutées ici).

## Test plan

- [ ] Appliquer la migration sur **DEV** via AI Supabase
- [ ] Sur Dev Build : créer un commentaire (test `comments.author_id`)
- [ ] Tester un bloc utilisateur (test `blocks.blocker_id`)
- [ ] Tester un suivi (test `follows.follower_id`)
- [ ] Tester un envoi de message (test `messages.sender_id`)
- [ ] Appliquer sur **STAGING** une fois DEV validé