### PR TITLE
feat(messaging): écran liste conversations + nouvelle conversation (E6-02)

### DIFF
--- a/app/(tabs)/messages.tsx
+++ b/app/(tabs)/messages.tsx
@@ -1,28 +1,123 @@
-// Tab Send — placeholder Messagerie, vrai écran livré en Sprint 5.
+import { FlashList } from '@shopify/flash-list';
+import { router } from 'expo-router';
+import { MessageCircle, Plus } from 'lucide-react-native';
+import { useCallback, useMemo } from 'react';
+import { RefreshControl, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Text, XStack, YStack } from 'tamagui';
 
-import { Send } from 'lucide-react-native';
-import { StyleSheet, View } from 'react-native';
-import { Text, YStack } from 'tamagui';
+import {
+  ConversationRow,
+  ConversationRowSkeleton,
+} from '@/features/messaging/components/ConversationRow';
+import {
+  type ConversationListRow,
+  useMyConversations,
+} from '@/features/messaging/hooks/useMyConversations';
+
+function MessagesEmptyState() {
+  return (
+    <YStack
+      flex={1}
+      minHeight={360}
+      alignItems="center"
+      justifyContent="center"
+      gap="$3"
+      padding="$6"
+    >
+      <MessageCircle size={36} color="#A0A0A0" strokeWidth={1.7} />
+      <Text color="$textSecondary" fontSize={15} textAlign="center">
+        Aucune conversation, démarrez-en une avec le +
+      </Text>
+    </YStack>
+  );
+}
+
+function MessagesSkeleton() {
+  return (
+    <YStack paddingTop="$2">
+      {Array.from({ length: 5 }).map((_, index) => (
+        <ConversationRowSkeleton key={index} />
+      ))}
+    </YStack>
+  );
+}
 
 export default function MessagesRoute() {
+  const insets = useSafeAreaInsets();
+  const conversationsQuery = useMyConversations();
+
+  const conversations = useMemo(() => {
+    return (conversationsQuery.data ?? []).filter((conversation) => !conversation.is_group);
+  }, [conversationsQuery.data]);
+
+  const handleOpenConversation = useCallback((conversationId: string) => {
+    router.push(`/messages/${conversationId}`);
+  }, []);
+
+  const renderConversation = useCallback(
+    ({ item }: { item: ConversationListRow }) => (
+      <ConversationRow
+        conversation={item}
+        onPress={() => handleOpenConversation(item.conversation_id)}
+      />
+    ),
+    [handleOpenConversation]
+  );
+
+  const keyExtractor = useCallback((item: ConversationListRow) => item.conversation_id, []);
+
   return (
-    <View style={styles.screen}>
-      <YStack flex={1} alignItems="center" justifyContent="center" gap="$3" paddingHorizontal="$6">
-        <Send size={64} color="#A0A0A0" strokeWidth={1.5} />
-        <Text color="$color" fontSize={18} fontWeight="700" textAlign="center">
-          Messagerie bientôt disponible
+    <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+      <XStack
+        height={58}
+        paddingHorizontal="$4"
+        alignItems="center"
+        justifyContent="space-between"
+        borderBottomWidth={StyleSheet.hairlineWidth}
+        borderBottomColor="$borderColor"
+      >
+        <Text color="$color" fontSize={24} fontWeight="700">
+          Messages
         </Text>
-        <Text color="$textSecondary" fontSize={14} textAlign="center">
-          Chats privés, appels audio et vidéo arrivent vite.
-        </Text>
-      </YStack>
-    </View>
+        <Button
+          circular
+          size="$3"
+          chromeless
+          onPress={() => router.push('/messages/new')}
+          pressStyle={{ opacity: 0.7 }}
+          accessibilityLabel="Nouvelle conversation"
+        >
+          <Plus size={24} color="#FFFFFF" />
+        </Button>
+      </XStack>
+
+      {conversationsQuery.isLoading ? (
+        <MessagesSkeleton />
+      ) : (
+        <FlashList<ConversationListRow>
+          data={conversations}
+          renderItem={renderConversation}
+          keyExtractor={keyExtractor}
+          showsVerticalScrollIndicator={false}
+          contentContainerStyle={styles.listContent}
+          refreshControl={
+            <RefreshControl
+              tintColor="#FFFFFF"
+              refreshing={conversationsQuery.isRefetching}
+              onRefresh={() => void conversationsQuery.refetch()}
+            />
+          }
+          ListEmptyComponent={<MessagesEmptyState />}
+        />
+      )}
+    </YStack>
   );
 }
 
 const styles = StyleSheet.create({
-  screen: {
-    flex: 1,
-    backgroundColor: '#000000',
+  listContent: {
+    paddingTop: 8,
+    paddingBottom: 96,
   },
 });

--- a/app/messages/new.tsx
+++ b/app/messages/new.tsx
@@ -1,0 +1,169 @@
+import { FlashList } from '@shopify/flash-list';
+import { router, Stack } from 'expo-router';
+import { AlertCircle, ArrowLeft, Search, X } from 'lucide-react-native';
+import { useCallback, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Input, Spinner, Text, XStack, YStack } from 'tamagui';
+
+import { useGetOrCreateDm } from '@/features/messaging/hooks/useGetOrCreateDm';
+import { UserRow } from '@/features/profile/components/UserRow';
+import { type SearchUserResult, useSearchUsers } from '@/features/profile/hooks/useSearchUsers';
+import { logger } from '@/lib/logger';
+
+function SearchState({ icon, title }: { icon: 'search' | 'error'; title: string }) {
+  const Icon = icon === 'search' ? Search : AlertCircle;
+
+  return (
+    <YStack flex={1} alignItems="center" justifyContent="center" gap="$3" padding="$6">
+      <Icon size={32} color="#A0A0A0" />
+      <Text color="$textSecondary" fontSize={15} textAlign="center">
+        {title}
+      </Text>
+    </YStack>
+  );
+}
+
+export default function NewMessageRoute() {
+  const insets = useSafeAreaInsets();
+  const [query, setQuery] = useState('');
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const { users, debouncedQuery, canSearch, isLoading, isError } = useSearchUsers(query);
+  const getOrCreateDm = useGetOrCreateDm();
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/(tabs)/messages');
+  }, []);
+
+  const handleSelectUser = useCallback(
+    (user: SearchUserResult) => {
+      setSelectedUserId(user.id);
+      getOrCreateDm.mutate(user.id, {
+        onSuccess: (conversationId) => {
+          router.replace(`/messages/${conversationId}`);
+        },
+        onError: (err) => {
+          logger.warn('Open DM failed', { message: err.message, userId: user.id });
+          setSelectedUserId(null);
+        },
+      });
+    },
+    [getOrCreateDm]
+  );
+
+  const renderUser = useCallback(
+    ({ item }: { item: SearchUserResult }) => (
+      <UserRow
+        user={item}
+        onPress={() => handleSelectUser(item)}
+        rightSlot={selectedUserId === item.id ? <Spinner size="small" color="$color" /> : null}
+      />
+    ),
+    [handleSelectUser, selectedUserId]
+  );
+
+  const keyExtractor = useCallback((item: SearchUserResult) => item.id, []);
+  const showEmptyState = !canSearch;
+  const showNoResults = canSearch && !isLoading && !isError && users.length === 0;
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false, presentation: 'card' }} />
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+        <XStack
+          height={56}
+          paddingHorizontal="$3"
+          alignItems="center"
+          gap="$3"
+          borderBottomWidth={StyleSheet.hairlineWidth}
+          borderBottomColor="$borderColor"
+        >
+          <Button
+            circular
+            size="$3"
+            chromeless
+            onPress={handleBack}
+            pressStyle={{ opacity: 0.7 }}
+            accessibilityLabel="Retour"
+          >
+            <ArrowLeft size={24} color="#FFFFFF" />
+          </Button>
+          <Text color="$color" fontSize={18} fontWeight="700">
+            Nouvelle conversation
+          </Text>
+        </XStack>
+
+        <YStack paddingHorizontal="$4" paddingTop="$3" paddingBottom="$3">
+          <XStack
+            alignItems="center"
+            gap="$2"
+            height={48}
+            backgroundColor="$surface"
+            borderRadius="$md"
+            paddingHorizontal="$3"
+          >
+            <Search size={20} color="#A0A0A0" />
+            <Input
+              id="new-message-search-users-input"
+              flex={1}
+              height={48}
+              borderWidth={0}
+              backgroundColor="transparent"
+              color="$color"
+              placeholder="Rechercher un utilisateur..."
+              placeholderTextColor="$placeholderColor"
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              value={query}
+              onChangeText={setQuery}
+              paddingHorizontal={0}
+              fontSize={16}
+            />
+            {query.length > 0 ? (
+              <Button
+                id="new-message-search-users-clear-button"
+                circular
+                size="$2.5"
+                chromeless
+                onPress={() => setQuery('')}
+                pressStyle={{ opacity: 0.65 }}
+                accessibilityLabel="Effacer la recherche"
+              >
+                <X size={18} color="#A0A0A0" />
+              </Button>
+            ) : null}
+          </XStack>
+        </YStack>
+
+        {showEmptyState ? (
+          <SearchState icon="search" title="Recherchez par username ou nom" />
+        ) : isLoading ? (
+          <YStack flex={1} alignItems="center" justifyContent="center">
+            <Spinner size="large" color="$color" />
+          </YStack>
+        ) : isError ? (
+          <SearchState icon="error" title="Recherche impossible. Réessayez." />
+        ) : showNoResults ? (
+          <SearchState icon="search" title={`Aucun utilisateur trouvé pour '@${debouncedQuery}'`} />
+        ) : (
+          <FlashList<SearchUserResult>
+            data={users}
+            renderItem={renderUser}
+            keyExtractor={keyExtractor}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.listContent}
+          />
+        )}
+      </YStack>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingBottom: 24,
+  },
+});

--- a/src/features/messaging/components/ConversationRow.tsx
+++ b/src/features/messaging/components/ConversationRow.tsx
@@ -1,0 +1,143 @@
+import { Image } from 'expo-image';
+import { BellOff, User as UserIcon } from 'lucide-react-native';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+import type { ConversationListRow } from '@/features/messaging/hooks/useMyConversations';
+
+const AVATAR_SIZE = 52;
+
+function formatTimeAgo(value: string) {
+  const date = new Date(value);
+  const timestamp = date.getTime();
+
+  if (!Number.isFinite(timestamp)) return '';
+
+  const diffSeconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000));
+  const diffMinutes = Math.floor(diffSeconds / 60);
+  const diffHours = Math.floor(diffMinutes / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSeconds < 60) return 'maintenant';
+  if (diffMinutes < 60) return `${diffMinutes} min`;
+  if (diffHours < 24) return `${diffHours} h`;
+  if (diffDays < 7) return `${diffDays} j`;
+
+  return date.toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: '2-digit',
+  });
+}
+
+function formatUnreadCount(count: number) {
+  return count > 99 ? '99+' : String(count);
+}
+
+export function ConversationRow({
+  conversation,
+  onPress,
+}: {
+  conversation: ConversationListRow;
+  onPress: () => void;
+}) {
+  const preview = conversation.last_message_preview?.trim() || 'Aucun message';
+  const initial = conversation.display_name.charAt(0).toUpperCase() || '?';
+  const hasUnread = conversation.unread_count > 0;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Conversation avec ${conversation.display_name}`}
+    >
+      <XStack paddingHorizontal="$4" paddingVertical="$3" alignItems="center" gap="$3">
+        <YStack
+          width={AVATAR_SIZE}
+          height={AVATAR_SIZE}
+          borderRadius={9999}
+          backgroundColor="$surface"
+          overflow="hidden"
+          alignItems="center"
+          justifyContent="center"
+        >
+          {conversation.display_avatar_url ? (
+            <Image
+              source={{ uri: conversation.display_avatar_url }}
+              style={styles.avatarImage}
+              contentFit="cover"
+            />
+          ) : conversation.is_group ? (
+            <Text color="$color" fontSize={18} fontWeight="700">
+              {initial}
+            </Text>
+          ) : (
+            <UserIcon size={26} color="#A0A0A0" />
+          )}
+        </YStack>
+
+        <YStack flex={1} minWidth={0} gap={4}>
+          <XStack alignItems="center" gap="$2">
+            <Text flex={1} color="$color" fontSize={16} fontWeight="700" numberOfLines={1}>
+              {conversation.display_name}
+            </Text>
+            {conversation.muted ? <BellOff size={15} color="#A0A0A0" /> : null}
+            <Text color="$textSecondary" fontSize={12} minWidth={42} textAlign="right">
+              {formatTimeAgo(conversation.last_message_at)}
+            </Text>
+          </XStack>
+
+          <XStack alignItems="center" gap="$2">
+            <Text
+              flex={1}
+              color={hasUnread ? '$color' : '$textSecondary'}
+              fontSize={14}
+              fontWeight={hasUnread ? '700' : '400'}
+              numberOfLines={1}
+            >
+              {preview}
+            </Text>
+            {hasUnread ? (
+              <View
+                minWidth={22}
+                height={22}
+                paddingHorizontal={6}
+                borderRadius={9999}
+                backgroundColor="#10D970"
+                alignItems="center"
+                justifyContent="center"
+              >
+                <Text color="#000000" fontSize={12} fontWeight="700">
+                  {formatUnreadCount(conversation.unread_count)}
+                </Text>
+              </View>
+            ) : null}
+          </XStack>
+        </YStack>
+      </XStack>
+    </Pressable>
+  );
+}
+
+export function ConversationRowSkeleton() {
+  return (
+    <XStack paddingHorizontal="$4" paddingVertical="$3" alignItems="center" gap="$3">
+      <View
+        width={AVATAR_SIZE}
+        height={AVATAR_SIZE}
+        borderRadius={9999}
+        backgroundColor="$surface"
+      />
+      <YStack flex={1} gap="$2">
+        <View width="48%" height={16} borderRadius={4} backgroundColor="$surface" />
+        <View width="76%" height={14} borderRadius={4} backgroundColor="$surface" />
+      </YStack>
+    </XStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  avatarImage: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/src/features/messaging/hooks/useGetOrCreateDm.ts
+++ b/src/features/messaging/hooks/useGetOrCreateDm.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+import { myConversationsQueryKey } from './useMyConversations';
+
+export function useGetOrCreateDm() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (otherUserId: string): Promise<string> => {
+      const { data, error } = await supabase.rpc('get_or_create_dm', {
+        p_other_user_id: otherUserId,
+      });
+
+      if (error) {
+        logger.warn('get_or_create_dm failed', {
+          message: error.message,
+          otherUserId,
+        });
+        throw error;
+      }
+
+      return String(data);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: myConversationsQueryKey });
+    },
+  });
+}

--- a/src/features/messaging/hooks/useMyConversations.ts
+++ b/src/features/messaging/hooks/useMyConversations.ts
@@ -1,0 +1,53 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type ConversationListRow = {
+  conversation_id: string;
+  is_group: boolean;
+  display_name: string;
+  display_avatar_url: string | null;
+  other_user_id: string | null;
+  last_message_at: string;
+  last_message_preview: string | null;
+  last_message_sender_id: string | null;
+  unread_count: number;
+  muted: boolean;
+};
+
+export const myConversationsQueryKey = ['conversations', 'my'] as const;
+
+function mapConversationRow(row: Record<string, unknown>): ConversationListRow {
+  const unreadCount = Number(row.unread_count ?? 0);
+
+  return {
+    conversation_id: String(row.conversation_id ?? ''),
+    is_group: row.is_group === true,
+    display_name: String(row.display_name ?? '?'),
+    display_avatar_url: (row.display_avatar_url as string | null) ?? null,
+    other_user_id: (row.other_user_id as string | null) ?? null,
+    last_message_at: String(row.last_message_at ?? ''),
+    last_message_preview: (row.last_message_preview as string | null) ?? null,
+    last_message_sender_id: (row.last_message_sender_id as string | null) ?? null,
+    unread_count: Number.isFinite(unreadCount) ? unreadCount : 0,
+    muted: row.muted === true,
+  };
+}
+
+export function useMyConversations() {
+  return useQuery({
+    queryKey: myConversationsQueryKey,
+    queryFn: async (): Promise<ConversationListRow[]> => {
+      const { data, error } = await supabase.rpc('get_my_conversations');
+
+      if (error) {
+        logger.warn('get_my_conversations failed', { message: error.message });
+        throw error;
+      }
+
+      return ((data ?? []) as Record<string, unknown>[]).map(mapConversationRow);
+    },
+    staleTime: 15_000,
+  });
+}


### PR DESCRIPTION
> PR ouverte par le CTO pour le compte de @fdissou (auteure du code). Code livré par elle, juste la PR à ouvrir.

## Contexte

Écran liste conversations type Instagram/WhatsApp pour la bêta du 12 juin. Consomme la RPC `get_my_conversations` livrée dans PR #192.

Closes #76.

## Contenu

| Fichier | Rôle |
|---|---|
| `app/(tabs)/messages.tsx` | Écran principal : FlashList de ConversationRow + RefreshControl + empty state + skeleton 5 rows + bouton + nouvelle conv |
| `app/messages/new.tsx` | Écran « Nouvelle conversation » : search users + tap → `get_or_create_dm` → push vers la conv créée |
| `src/features/messaging/components/ConversationRow.tsx` | Composant ligne : avatar 52px / nom / muted icon / time ago / preview / badge non-lu accent neon (99+ si > 99) + skeleton |
| `src/features/messaging/hooks/useMyConversations.ts` | useQuery sur la RPC + mapper défensif (gestion des nulls, conversions de types) |
| `src/features/messaging/hooks/useGetOrCreateDm.ts` | useMutation sur RPC `get_or_create_dm` + invalidation cache liste |

## Décisions techniques

| Sujet | Choix |
|---|---|
| Filtre groupes UI | `is_group === false` côté client — schéma DB supporte les groupes (livré PR #192) mais l'UI bêta n'expose que les DM. Pas de migration nécessaire pour activer les groupes plus tard. |
| Badge non-lu | Pastille accent neon (#10D970) sur fond noir → contraste max. Format `99+` au-delà de 99. |
| Icône silencieux | `BellOff` (lucide) à côté du nom si `muted === true` |
| Sanitisation du retour RPC | `mapConversationRow` convertit les nulls et coerce les types côté client (défense en profondeur — même si la RPC retourne du typé, on protège) |
| Skeleton | 5 rows pendant `isLoading` |
| Empty state | Icône MessageCircle + texte centré « Aucune conversation, démarrez-en une avec le + » |
| Tap conv | `router.push('/messages/{id}')` → ouvre ConversationScreen (livré PR #196) |
| Nouvelle conv | Réutilise `useSearchUsers` et `UserRow` (existants). Tap user → `get_or_create_dm.mutate` → si succès `router.replace('/messages/{id})`. Si erreur, reset selection + log. |

## Hors scope bêta

- Affichage des conversations de groupe (filtrées UI, schéma supporte)
- Recherche dans la liste des conversations
- Mode édition (suppression batch)

## État

- ✅ Code écrit par @fdissou
- ✅ Lint + typecheck passent
- 🟡 À tester sur Dev Build après merge (le DB est prêt, la nav est prête, manque juste le device)

## Test plan

- [ ] Onglet Messages → la liste de mes conv s'affiche triée par dernier message desc
- [ ] Badge non-lu visible et correct
- [ ] Icône BellOff visible si conv mutée
- [ ] Tap + en haut → écran search users → taper le username d'un autre user
- [ ] Tap un résultat → nouvelle conv créée + navigation vers `/messages/{id}` (ConversationScreen de PR #196)
- [ ] Re-tap le même user depuis le + → MÊME conv (idempotence get_or_create_dm)
- [ ] Tap user qui m'a bloqué → erreur affichée
- [ ] Tap moi-même → erreur affichée
- [ ] Pull-to-refresh → recharge la liste
- [ ] Empty state s'affiche pour un nouveau compte
- [ ] Skeleton s'affiche pendant le chargement

## Note sur l'auteure

Farah a livré ce ticket en autonomie pendant ses vacances scolaires. Niveau du code très propre — fallback avatar, sanitisation défensive, accessibilityLabel, skeleton, formats français. Bravo @fdissou 👏