### PR TITLE
fix(rls): récursion infinie sur conversation_participants SELECT (bug critique)

### DIFF
--- a/docs/audits/RLS_AUDIT_PREBETA_RESULTS.md
+++ b/docs/audits/RLS_AUDIT_PREBETA_RESULTS.md
@@ -18,51 +18,63 @@ de contournements ci-dessous. Le résultat attendu est toujours **bloqué**
 3. Cocher la case ci-dessous correspondante
 4. Si un test échoue (`ok=f`), créer un ticket bug et corriger AVANT la bêta
 
-## Matrice de résultats — DEV
+## Matrice de résultats — DEV (exécuté 2026-06-05)
 
 | #    | Test                                                                 | Table             | Op     | Attendu | Observé | OK  |
 | ---- | -------------------------------------------------------------------- | ----------------- | ------ | ------- | ------- | --- |
-| 3.1  | Alice lit le post privé de Bob                                       | posts             | SELECT | 0 ligne | \_\_\_  | ☐   |
-| 3.2  | Alice insère un post au nom de Bob                                   | posts             | INSERT | bloqué  | \_\_\_  | ☐   |
-| 3.3  | Alice modifie le post de Bob                                         | posts             | UPDATE | 0 ligne | \_\_\_  | ☐   |
-| 3.4  | Alice supprime le post de Bob                                        | posts             | DELETE | 0 ligne | \_\_\_  | ☐   |
-| 3.5  | Alice lit les messages d'une conv où elle n'est pas participante     | messages          | SELECT | 0 ligne | \_\_\_  | ☐   |
-| 3.6  | Alice insère un message dans une conv où elle n'est pas participante | messages          | INSERT | bloqué  | \_\_\_  | ☐   |
-| 3.7  | Alice insère un message avec `sender_id = Bob` (usurpation)          | messages          | INSERT | bloqué  | \_\_\_  | ☐   |
-| 3.8  | Alice modifie un message envoyé par Bob                              | messages          | UPDATE | 0 ligne | \_\_\_  | ☐   |
-| 3.9  | Alice lit la deletion_request de Bob                                 | deletion_requests | SELECT | 0 ligne | \_\_\_  | ☐   |
-| 3.10 | Alice appelle `_anonymize_user_profile(Bob)` (escalade privilèges)   | (RPC)             | EXEC   | bloqué  | \_\_\_  | ☐   |
-| 3.11 | Alice lit les notifications de Bob                                   | notifications     | SELECT | 0 ligne | \_\_\_  | ☐   |
-| 3.12 | Alice lit la table blocks de Bob                                     | blocks            | SELECT | 0 ligne | \_\_\_  | ☐   |
+| 3.1  | Alice lit le post privé de Bob                                       | posts             | SELECT | 0 ligne | 0 ligne | ✅  |
+| 3.2  | Alice insère un post au nom de Bob                                   | posts             | INSERT | bloqué  | BLOCKED | ✅  |
+| 3.3  | Alice modifie le post de Bob                                         | posts             | UPDATE | 0 ligne | 0 rows  | ✅  |
+| 3.4  | Alice supprime le post de Bob                                        | posts             | DELETE | 0 ligne | 0 rows  | ✅  |
+| 3.5  | Alice lit les messages d'une conv où elle n'est pas participante     | messages          | SELECT | 0 ligne | 0 ligne | ✅  |
+| 3.6  | Alice insère un message dans une conv où elle n'est pas participante | messages          | INSERT | bloqué  | BLOCKED | ✅  |
+| 3.7  | Alice insère un message avec `sender_id = Bob` (usurpation)          | messages          | INSERT | bloqué  | BLOCKED | ✅  |
+| 3.8  | Alice modifie un message envoyé par Bob                              | messages          | UPDATE | 0 ligne | 0 rows  | ✅  |
+| 3.9  | Alice lit la deletion_request de Bob                                 | deletion_requests | SELECT | 0 ligne | 0 ligne | ✅  |
+| 3.10 | Alice appelle `_anonymize_user_profile(Bob)` (escalade privilèges)   | (RPC)             | EXEC   | bloqué  | BLOCKED | ✅  |
+| 3.11 | Alice lit les notifications de Bob                                   | notifications     | SELECT | 0 ligne | 0 ligne | ✅  |
+| 3.12 | Alice lit la table blocks de Bob                                     | blocks            | SELECT | 0 ligne | 0 ligne | ✅  |
 
-## Matrice de résultats — STAGING
+## Matrice de résultats — STAGING (exécuté 2026-06-05)
 
-Reproduire l'audit sur STAGING après DEV.
+| #    | Test            | Table             | Op     | Attendu | Observé | OK  |
+| ---- | --------------- | ----------------- | ------ | ------- | ------- | --- |
+| 3.1  | Identique à DEV | posts             | SELECT | 0 ligne | 0 ligne | ✅  |
+| 3.2  | Identique à DEV | posts             | INSERT | bloqué  | BLOCKED | ✅  |
+| 3.3  | Identique à DEV | posts             | UPDATE | 0 ligne | 0 rows  | ✅  |
+| 3.4  | Identique à DEV | posts             | DELETE | 0 ligne | 0 rows  | ✅  |
+| 3.5  | Identique à DEV | messages          | SELECT | 0 ligne | 0 ligne | ✅  |
+| 3.6  | Identique à DEV | messages          | INSERT | bloqué  | BLOCKED | ✅  |
+| 3.7  | Identique à DEV | messages          | INSERT | bloqué  | BLOCKED | ✅  |
+| 3.8  | Identique à DEV | messages          | UPDATE | 0 ligne | 0 rows  | ✅  |
+| 3.9  | Identique à DEV | deletion_requests | SELECT | 0 ligne | 0 ligne | ✅  |
+| 3.10 | Identique à DEV | (RPC)             | EXEC   | bloqué  | BLOCKED | ✅  |
+| 3.11 | Identique à DEV | notifications     | SELECT | 0 ligne | 0 ligne | ✅  |
+| 3.12 | Identique à DEV | blocks            | SELECT | 0 ligne | 0 ligne | ✅  |
 
-| #    | Test | Table             | Op     | Attendu | Observé | OK  |
-| ---- | ---- | ----------------- | ------ | ------- | ------- | --- |
-| 3.1  | …    | posts             | SELECT | 0 ligne | \_\_\_  | ☐   |
-| 3.2  | …    | posts             | INSERT | bloqué  | \_\_\_  | ☐   |
-| 3.3  | …    | posts             | UPDATE | 0 ligne | \_\_\_  | ☐   |
-| 3.4  | …    | posts             | DELETE | 0 ligne | \_\_\_  | ☐   |
-| 3.5  | …    | messages          | SELECT | 0 ligne | \_\_\_  | ☐   |
-| 3.6  | …    | messages          | INSERT | bloqué  | \_\_\_  | ☐   |
-| 3.7  | …    | messages          | INSERT | bloqué  | \_\_\_  | ☐   |
-| 3.8  | …    | messages          | UPDATE | 0 ligne | \_\_\_  | ☐   |
-| 3.9  | …    | deletion_requests | SELECT | 0 ligne | \_\_\_  | ☐   |
-| 3.10 | …    | (RPC)             | EXEC   | bloqué  | \_\_\_  | ☐   |
-| 3.11 | …    | notifications     | SELECT | 0 ligne | \_\_\_  | ☐   |
-| 3.12 | …    | blocks            | SELECT | 0 ligne | \_\_\_  | ☐   |
+## 🚨 Bug critique découvert et corrigé pendant l'audit
+
+**Récursion infinie sur `conversation_participants` SELECT policy** — la policy créée dans PR #192 (20260602120000_messaging_schema.sql) contenait un `EXISTS (SELECT FROM conversation_participants WHERE ...)` qui se référençait elle-même. Toute lecture sur cette table déclenchait l'erreur Postgres :
+
+> `infinite recursion detected in policy for relation "conversation_participants"` (SQLSTATE 42P17)
+
+**Impact évité** : les écrans messagerie (PR #196 conversation, PR #203 liste conversations, PR #201 Realtime) auraient tous crashé en bêta dès qu'un user authentifié ouvrait un fil de discussion. Le bug n'était pas visible en dev local parce que les fixtures de test direct via SQL bypassaient la RLS.
+
+**Fix appliqué** : migration `20260605120100_fix_conversation_participants_rls_recursion.sql` qui :
+
+1. Crée une fonction `fn_is_conversation_participant(uuid)` `SECURITY DEFINER STABLE` qui lit la table sans déclencher la RLS
+2. Remplace le subquery récursif de la policy par un appel à cette fonction
+
+Audit re-exécuté après fix : **12/12 OK**.
 
 ## Conclusion
 
-À remplir après exécution :
-
-- Date : **\_\_\_\_**
-- Nombre de tests : 12 par environnement
-- Nombre de succès : **_ / 12 (DEV) — _** / 12 (STAGING)
-- Failles identifiées : aucune ou voir tickets ouverts
-- Validation bêta : ☐ Go ☐ No-go
+- **Date** : 2026-06-05
+- **Nombre de tests** : 12 par environnement
+- **Nombre de succès** : **12 / 12 (DEV)** — **12 / 12 (STAGING)**
+- **Failles identifiées** :
+  - 1 bug critique de **récursion infinie sur `conversation_participants`** SELECT policy — corrigé via migration `20260605120100_fix_conversation_participants_rls_recursion.sql` (fonction helper SECURITY DEFINER `fn_is_conversation_participant`)
+- **Validation bêta** : ✅ **Go** — la sécurité RLS de l'application est validée pour l'ouverture de la bêta du 12 juin
 
 ## Limites de cet audit
 

--- a/supabase/migrations/20260605120100_fix_conversation_participants_rls_recursion.sql
+++ b/supabase/migrations/20260605120100_fix_conversation_participants_rls_recursion.sql
@@ -1,0 +1,81 @@
+-- Fix : récursion infinie sur conversation_participants SELECT policy
+--
+-- Bug critique découvert le 2026-06-05 pendant l'exécution de l'audit RLS
+-- pré-bêta (rls_audit_prebeta.sql / ticket T-04).
+--
+-- La policy SELECT initiale créée dans PR #192 (20260602120000_messaging_schema.sql) :
+--
+--   create policy "conversation_participants select if same conv"
+--     on public.conversation_participants for select
+--     to authenticated
+--     using (exists (
+--       select 1 from public.conversation_participants me
+--       where me.conversation_id = conversation_participants.conversation_id
+--         and me.user_id = (select auth.uid())
+--     ));
+--
+-- ... contient une référence à conversation_participants dans son USING. Quand
+-- la RLS évalue cette policy pour une row, le sous-SELECT déclenche à son tour
+-- l'évaluation de la même policy → récursion infinie → ERROR 42P17
+-- « infinite recursion detected in policy for relation "conversation_participants" ».
+--
+-- Impact : tout client authentifié qui tentait de lire une conversation,
+-- récupérer la liste des conversations, ou ouvrir un écran messagerie tombait
+-- en erreur. La PR #196 (écran conversation) et #203 (liste conversations)
+-- auraient été inutilisables en bêta.
+--
+-- Fix (pattern recommandé Supabase pour les policies self-referencing) :
+--   - Créer une fonction SECURITY DEFINER STABLE `fn_is_conversation_participant`
+--     qui lit conversation_participants en bypassant la RLS (SECURITY DEFINER)
+--   - Remplacer le subquery récursif par un appel à cette fonction
+--
+-- La fonction étant SECURITY DEFINER, son SELECT interne ne déclenche pas la
+-- policy SELECT de la table → récursion cassée.
+--
+-- Appliqué DEV + STAGING le 2026-06-05 et audit RLS re-exécuté : 12/12 tests OK.
+
+-- ============================================================================
+-- 1. Fonction helper SECURITY DEFINER
+-- ============================================================================
+create or replace function public.fn_is_conversation_participant(p_conversation_id uuid)
+returns boolean
+language sql
+security definer
+stable
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.conversation_participants
+    where conversation_id = p_conversation_id
+      and user_id = auth.uid()
+  );
+$$;
+
+-- Hygiène : fonction appelable depuis les policies (rôles de session) mais pas
+-- directement via PostgREST par les clients (pas besoin, c'est un helper interne).
+revoke all on function public.fn_is_conversation_participant(uuid) from public, anon;
+grant execute on function public.fn_is_conversation_participant(uuid) to authenticated;
+
+-- ============================================================================
+-- 2. Remplacement de la policy récursive
+-- ============================================================================
+drop policy if exists "conversation_participants select if same conv"
+  on public.conversation_participants;
+
+create policy "conversation_participants select if same conv"
+  on public.conversation_participants for select
+  to authenticated
+  using (public.fn_is_conversation_participant(conversation_id));
+
+-- ============================================================================
+-- Vérification post-application (à exécuter manuellement)
+-- ============================================================================
+-- 1. select * from public.fn_is_conversation_participant(uuid_d_une_conv_existante);
+--    → retourne true si je suis participant, false sinon (sans erreur)
+--
+-- 2. En tant qu'un user authentifié :
+--    select * from public.conversation_participants where conversation_id = '...';
+--    → retourne les participants si je suis dans la conv, 0 sinon, jamais d'erreur 42P17
+--
+-- 3. Réexécuter rls_audit_prebeta.sql → 12/12 tests passent


### PR DESCRIPTION
## Contexte

🚨 **Bug critique découvert par le CTO** le 2026-06-05 pendant l'exécution de l'audit RLS pré-bêta (T-04, PR #195).

## Le bug

La policy SELECT créée dans PR #192 contenait un subquery récursif :

```sql
create policy "conversation_participants select if same conv"
  on public.conversation_participants for select
  to authenticated
  using (exists (
    select 1 from public.conversation_participants me
    where me.conversation_id = conversation_participants.conversation_id
      and me.user_id = (select auth.uid())
  ));
```

→ Quand la RLS évaluait la policy pour une row, le `EXISTS` déclenchait à son tour l'évaluation de la même policy → **récursion infinie** → erreur Postgres `42P17 — infinite recursion detected`.

## Impact évité

**Tous les écrans messagerie auraient crashé en bêta** :
- PR #196 (écran conversation)
- PR #203 (liste conversations)
- PR #201 (Realtime)

Le bug n'était pas visible en dev local parce que les fixtures de test direct via SQL bypassent la RLS (rule postgres ne déclenche pas les policies pour le rôle owner).

## Fix

Pattern recommandé Supabase pour les policies self-referencing :

1. **Fonction helper** `fn_is_conversation_participant(uuid)` `SECURITY DEFINER STABLE` qui lit la table en bypassant la RLS (la SECURITY DEFINER s'exécute avec les droits du créateur de la fonction, sans déclencher les policies)
2. **Remplacement** du subquery récursif par un appel à cette fonction

## État d'application

- ✅ Migration appliquée sur **DEV** le 2026-06-05
- ✅ Migration appliquée sur **STAGING** le 2026-06-05
- ✅ Audit RLS re-exécuté : **12/12 OK** sur les 2 environnements
- ✅ Rapport `docs/audits/RLS_AUDIT_PREBETA_RESULTS.md` mis à jour avec validation **Go bêta**

## Test plan

- [x] DEV : `select * from public.fn_is_conversation_participant('uuid_conv');` retourne true/false sans erreur
- [x] DEV : audit RLS 12/12 OK
- [x] STAGING : audit RLS 12/12 OK
- [ ] Sur Dev Build : ouvrir une conversation → liste des participants chargée sans erreur (avant le fix : crash silencieux ou page blanche)
- [ ] Sur Dev Build : envoyer un message → bulle apparaît, pas d'erreur 42P17 dans la console

## Note sur la détection

Le bug n'aurait jamais été trouvé sans l'audit RLS scripté. C'est exactement ce pour quoi le ticket T-04 existait. Si on n'avait pas lancé l'audit avant la bêta, on aurait livré une app messagerie complètement cassée à 100 testeurs.

À ré-exécuter l'audit à chaque ajout de table sensible ou de policy RLS.