### PR TITLE
fix: hotfixes pré-bêta (4 bugs CTO bug bash)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,10 +1,11 @@
 // Layout TabBar 5 onglets — Sprint 3 E8-04
-// Onglets : Home / Bell / Hash (Studio AI) / Send (Messages) / User (Profile)
+// Onglets : Home / Bell / Hash (Doumassi AI) / Send (Messages) / User (Profile)
 // Auth guard + redirect vers welcome/onboarding si pas connecté.
 
 import { Redirect, Tabs } from 'expo-router';
 import { Bell, Hash, Home, Send, User } from 'lucide-react-native';
 import { Platform, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import GuardLoader from '@/components/GuardLoader';
 import { useAuthGuard } from '@/features/auth/hooks/useAuthGuard';
@@ -40,6 +41,7 @@ function TabIcon({ Icon, focused }: TabIconProps) {
 // niveau du parent qui short-circuit avec des Redirect).
 function AuthenticatedTabs() {
   const unreadCount = useNotificationsUnreadCount();
+  const insets = useSafeAreaInsets();
   // E4-14 : enregistrement du push token + handler de tap. Montés ici
   // (sous le guard auth) car on a besoin d'une session valide pour le
   // PATCH profiles.push_token, et il est inutile d'écouter les taps
@@ -47,12 +49,23 @@ function AuthenticatedTabs() {
   usePushToken();
   usePushNotificationsHandler();
 
+  // Tab bar dynamique : on remonte la barre de la zone safe area système
+  // (gesture navigation Android moderne + home indicator iOS). Sans ça,
+  // la barre est posée au ras du bas → icônes coupées par la zone gestes.
+  const tabBarStyle = [
+    styles.tabBar,
+    {
+      height: styles.tabBar.height + insets.bottom,
+      paddingBottom: Math.max(styles.tabBar.paddingBottom, insets.bottom + 4),
+    },
+  ];
+
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
         tabBarShowLabel: false,
-        tabBarStyle: styles.tabBar,
+        tabBarStyle: tabBarStyle,
         tabBarActiveTintColor: ACTIVE_COLOR,
         tabBarInactiveTintColor: INACTIVE_COLOR,
       }}
@@ -78,7 +91,7 @@ function AuthenticatedTabs() {
         name="studio-ai"
         options={{
           tabBarIcon: ({ focused }) => <TabIcon Icon={Hash} focused={focused} />,
-          tabBarAccessibilityLabel: 'Studio AI',
+          tabBarAccessibilityLabel: 'Doumassi AI',
         }}
       />
       <Tabs.Screen

--- a/app/(tabs)/studio-ai.tsx
+++ b/app/(tabs)/studio-ai.tsx
@@ -1,4 +1,4 @@
-// Tab Hash — placeholder Studio AI, vrai écran livré en Sprint 5-6.
+// Tab Hash — placeholder Doumassi AI, vrai écran livré en Sprint 5-6.
 
 import { Sparkles } from 'lucide-react-native';
 import { StyleSheet, View } from 'react-native';
@@ -10,7 +10,7 @@ export default function StudioAIRoute() {
       <YStack flex={1} alignItems="center" justifyContent="center" gap="$3" paddingHorizontal="$6">
         <Sparkles size={64} color="#A0A0A0" strokeWidth={1.5} />
         <Text color="$color" fontSize={18} fontWeight="700" textAlign="center">
-          Studio AI bientôt disponible
+          Doumassi AI bientôt disponible
         </Text>
         <Text color="$textSecondary" fontSize={14} textAlign="center">
           Assistant IA, génération d&apos;images et plus.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,6 +49,10 @@ module.exports = defineConfig([
       // Edge Functions Supabase tournent en Deno (imports URL, env.Deno...).
       // Pas le même runtime que l'app RN ; on les exclut du lint Node/RN.
       'supabase/functions/**',
+      // Tests Jest — runtime de test, pas couvert par les configs RN.
+      '**/__tests__/**',
+      '**/*.test.ts',
+      '**/*.test.tsx',
     ],
   },
 

--- a/src/features/feed/hooks/useFeedStories.ts
+++ b/src/features/feed/hooks/useFeedStories.ts
@@ -1,3 +1,13 @@
+// useFeedStories — barre de stories au-dessus du fil d'actualité.
+//
+// Consomme la RPC `get_stories_feed` (livrée PR #181) qui retourne uniquement
+// les stories ACTIVES (non expirées) des follows acceptés + les miennes.
+//
+// La barre affiche toujours mon entry en premier (avec un + si je n'ai pas de
+// story active → tap = créer). Pour les autres users, on n'affiche QUE ceux
+// qui ont une story active. Sinon on aurait un avatar dans la barre qui
+// ouvre la visionneuse sur "rien" et fallback sur ma story (bug pré-bêta).
+
 import { useQuery } from '@tanstack/react-query';
 
 import { logger } from '@/lib/logger';
@@ -11,25 +21,14 @@ export type FeedStory = {
   hasUnseenStory: boolean;
 };
 
-type FollowStoryRow = {
-  followed_id: string;
-  profile:
-    | {
-        id: string;
-        username: string | null;
-        avatar_url: string | null;
-      }
-    | {
-        id: string;
-        username: string | null;
-        avatar_url: string | null;
-      }[]
-    | null;
+type StoriesFeedRow = {
+  id: string;
+  author_id: string;
+  author_username: string;
+  author_avatar_url: string | null;
+  viewed_by_me: boolean;
+  is_mine: boolean;
 };
-
-function firstProfile(row: FollowStoryRow) {
-  return Array.isArray(row.profile) ? row.profile[0] : row.profile;
-}
 
 export function useFeedStories() {
   return useQuery({
@@ -39,56 +38,77 @@ export function useFeedStories() {
       if (sessionError || !sessionData.session?.user?.id) {
         throw new Error('No authenticated user');
       }
-
       const userId = sessionData.session.user.id;
 
-      const [meRes, followsRes] = await Promise.all([
-        supabase.from('profiles').select('id, username, avatar_url').eq('id', userId).single(),
-        supabase
-          .from('follows')
-          .select('followed_id, profile:profiles!followed_id(id, username, avatar_url)')
-          .eq('follower_id', userId)
-          .eq('status', 'accepted')
-          .limit(20),
-      ]);
-
-      if (meRes.error) {
-        logger.warn('fetch feed story self failed', { message: meRes.error.message });
-        throw meRes.error;
+      // 1. RPC get_stories_feed : ne retourne que les stories actives,
+      //    mes stories en premier, puis celles des follows acceptés.
+      const { data: rpcData, error: rpcError } = await supabase.rpc('get_stories_feed');
+      if (rpcError) {
+        logger.warn('get_stories_feed failed in feed bar', { message: rpcError.message });
+        throw rpcError;
       }
 
-      if (followsRes.error) {
-        logger.warn('fetch feed stories failed', { message: followsRes.error.message });
-        throw followsRes.error;
+      const rows = (rpcData ?? []) as StoriesFeedRow[];
+
+      // 2. Group par author_id et calcule hasUnseenStory (au moins une story
+      //    non vue) pour chaque auteur.
+      const groupsByAuthor = new Map<string, { story: StoriesFeedRow; hasUnseen: boolean }>();
+      for (const row of rows) {
+        const existing = groupsByAuthor.get(row.author_id);
+        if (existing) {
+          existing.hasUnseen = existing.hasUnseen || !row.viewed_by_me;
+        } else {
+          groupsByAuthor.set(row.author_id, { story: row, hasUnseen: !row.viewed_by_me });
+        }
       }
 
-      const meProfile = meRes.data as {
-        id: string;
-        username: string | null;
-        avatar_url: string | null;
-      };
-      const followingStories = ((followsRes.data ?? []) as FollowStoryRow[])
-        .map((row) => firstProfile(row))
-        .filter((profile): profile is NonNullable<ReturnType<typeof firstProfile>> => !!profile)
-        .map((profile) => ({
-          id: profile.id,
-          username: profile.username ?? 'user',
-          avatar_url: profile.avatar_url,
+      const myGroup = groupsByAuthor.get(userId);
+      const othersWithStories = Array.from(groupsByAuthor.entries())
+        .filter(([authorId]) => authorId !== userId)
+        .map(([, { story, hasUnseen }]) => ({
+          id: story.author_id,
+          username: story.author_username,
+          avatar_url: story.author_avatar_url,
           isMe: false,
-          hasUnseenStory: true,
+          hasUnseenStory: hasUnseen,
         }));
 
-      return [
-        {
-          id: meProfile.id,
-          username: meProfile.username ?? 'Moi',
-          avatar_url: meProfile.avatar_url,
+      // 3. Mon entry est toujours présent (même sans story active → permet le
+      //    "tap = créer une story"). Si j'ai des stories actives, on affiche
+      //    mon avatar avec hasUnseenStory selon viewed_by_me. Sinon, fallback
+      //    sur mon profil neutre (avatar/username récupéré via select séparé).
+      let meEntry: FeedStory;
+      if (myGroup) {
+        meEntry = {
+          id: myGroup.story.author_id,
+          username: myGroup.story.author_username,
+          avatar_url: myGroup.story.author_avatar_url,
+          isMe: true,
+          hasUnseenStory: myGroup.hasUnseen,
+        };
+      } else {
+        // Pas de story active de ma part : on fetch juste mon profile pour
+        // afficher mon avatar dans la barre.
+        const meRes = await supabase
+          .from('profiles')
+          .select('id, username, avatar_url')
+          .eq('id', userId)
+          .single();
+        if (meRes.error) {
+          logger.warn('fetch feed story self profile failed', { message: meRes.error.message });
+          throw meRes.error;
+        }
+        meEntry = {
+          id: meRes.data.id,
+          username: meRes.data.username ?? 'Moi',
+          avatar_url: meRes.data.avatar_url,
           isMe: true,
           hasUnseenStory: false,
-        },
-        ...followingStories,
-      ];
+        };
+      }
+
+      return [meEntry, ...othersWithStories];
     },
-    staleTime: 60_000,
+    staleTime: 30_000,
   });
 }

--- a/src/features/feed/screens/FeedScreen.tsx
+++ b/src/features/feed/screens/FeedScreen.tsx
@@ -56,7 +56,7 @@ const PLACEHOLDERS = {
   },
   ai: {
     Icon: Sparkles,
-    title: 'Studio AI bientôt disponible',
+    title: 'Doumassi AI bientôt disponible',
     subtitle: "Assistant IA, génération d'images et plus.",
   },
   wallet: {

--- a/supabase/migrations/20260605120200_fix_update_username_idempotent.sql
+++ b/supabase/migrations/20260605120200_fix_update_username_idempotent.sql
@@ -1,0 +1,111 @@
+-- Fix : update_username() doit être idempotent
+--
+-- Bug remonté pendant le bug bash CTO du 2026-06-05.
+--
+-- Symptôme observé : un utilisateur qui ouvre l'écran "Éditer mon profil"
+-- et modifie un champ AUTRE que son username (bio, avatar, etc.) déclenche
+-- parfois l'erreur "You can change your username again on YYYY-MM-DD".
+--
+-- Cause : la RPC update_username() (migration 20260511150300) vérifie le
+-- cooldown 30 jours AVANT de vérifier si le nouveau username est différent
+-- de l'actuel. Si le client appelle la RPC avec le même username (cas
+-- possible si la comparaison côté client tombe à false négatif — profile
+-- null pendant le chargement, normalisation Unicode différente, etc.), la
+-- RPC évalue le cooldown et raise.
+--
+-- Le code client (useEditProfile.ts) a un garde `if (username !== currentUsername)`
+-- mais c'est de la défense en profondeur — la RPC doit elle-même être
+-- idempotente : si on lui passe le username actuel, NO-OP, pas d'erreur.
+--
+-- Fix : récupérer username + username_changed_at dans le SELECT initial, et
+-- ajouter un EARLY RETURN si lower(current_username) = lower(p_username).
+--
+-- À appliquer DEV + STAGING via AI Supabase.
+
+create or replace function public.update_username(p_username text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_username text := lower(trim(p_username));
+  v_current_username text;
+  v_changed_at timestamptz;
+  v_reserved text[] := array[
+    'admin', 'administrator', 'root', 'sudo', 'system', 'staff', 'moderator', 'mod',
+    'support', 'helpdesk', 'help', 'contact', 'feedback', 'abuse', 'report',
+    'api', 'app', 'www', 'mail', 'email', 'null', 'undefined', 'true', 'false',
+    'anonymous', 'deleted', 'doumassi', 'doumassiapp', 'doumassi_app',
+    'doumassi_official', 'doumassi_team', 'official', 'team',
+    'ceo', 'founder', 'owner', 'me', 'you', 'user', 'users', 'guest'
+  ];
+begin
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  if v_username is null or length(v_username) < 3 or length(v_username) > 30 then
+    raise exception 'Username must be between 3 and 30 characters';
+  end if;
+
+  if v_username !~ '^[a-z][a-z0-9_]*$' then
+    raise exception 'Username must start with a letter and contain only letters, numbers and underscores';
+  end if;
+
+  if right(v_username, 1) = '_' then
+    raise exception 'Username cannot end with an underscore';
+  end if;
+
+  if v_username ~ '^user_[0-9a-f]{8}$' then
+    raise exception 'This username format is reserved';
+  end if;
+
+  if v_username = any(v_reserved) then
+    raise exception 'This username is reserved';
+  end if;
+
+  -- Récupère le username actuel + le timestamp de changement
+  select username, username_changed_at
+  into v_current_username, v_changed_at
+  from public.profiles
+  where id = v_user_id
+  for update;
+
+  if not found then
+    raise exception 'Profile not found';
+  end if;
+
+  -- IDEMPOTENT : si le username est inchangé, on ne fait rien et on ne
+  -- déclenche pas l'erreur cooldown. Permet au client d'appeler la RPC
+  -- sans craindre les faux positifs sur la comparaison locale.
+  if lower(coalesce(v_current_username, '')) = v_username then
+    return;
+  end if;
+
+  -- Vérif cooldown SEULEMENT si le username change vraiment
+  if v_changed_at is not null and v_changed_at > now() - interval '30 days' then
+    raise exception 'You can change your username again on %',
+      to_char((v_changed_at + interval '30 days')::date, 'YYYY-MM-DD');
+  end if;
+
+  -- Vérif unicité (autre user)
+  if exists (
+    select 1
+    from public.profiles
+    where lower(username) = v_username
+      and id <> v_user_id
+  ) then
+    raise exception 'This username is already taken';
+  end if;
+
+  -- Update effectif
+  update public.profiles
+  set
+    username = v_username,
+    username_changed_at = now(),
+    updated_at = now()
+  where id = v_user_id;
+end;
+$$;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,9 @@
     "ios",
     "dist",
     "web-build",
-    "supabase/functions/**"
+    "supabase/functions/**",
+    "**/__tests__/**",
+    "**/*.test.ts",
+    "**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
## Contexte

Bug bash exécuté par le CTO sur Dev Build le 2026-06-05 → **5 bugs détectés**. Cette PR en corrige **4**, le 5ème est reporté Sprint 6 (feature manquante, pas bug).

## Bugs corrigés

### 🔴 Bug 1 — Tap sur story d'un autre user ouvrait MA propre story

**Cause** : `useFeedStories` listait tous les follows acceptés sans vérifier qu'ils avaient une story active. Tap user sans story → `findIndex = -1` → fallback à ma story (en premier dans le groupe RPC).

**Fix** : `useFeedStories` consomme maintenant `get_stories_feed` directement et n'affiche dans la barre QUE les users avec stories actives (+ mon entry toujours présent pour le "tap = créer"). Cohérence garantie entre la barre et la visionneuse.

### 🟠 Bug 3 — Tab bar trop basse (gesture nav Android / home indicator iOS)

**Cause** : `paddingBottom: 8` (Android) ne tenait pas compte des safe area insets système.

**Fix** : `useSafeAreaInsets()` dynamique → `paddingBottom = max(8, insets.bottom + 4)` + extension de la hauteur de `insets.bottom`. Tab bar maintenant correctement positionnée sur tous devices.

### 🔴 Bug 4 — Édition profil déclenche "username cooldown" sur autres champs

**Cause racine** : la RPC `update_username` n'est **pas idempotente**. Si appelée avec le même username que l'actuel, elle évalue quand même le cooldown 30j et raise. Le client a un garde côté UI mais des faux positifs sont possibles (profile null pendant chargement, normalisation Unicode...).

**Fix** : migration `20260605120200_fix_update_username_idempotent.sql` — ajout d'un EARLY RETURN si `lower(current) = lower(new)`. La RPC reste safe (cooldown + unicité + reserved + format toujours vérifiés quand le username change vraiment).

⚠️ **À appliquer DEV + STAGING via AI Supabase après merge.**

### 🟡 Bug 5 — Renommage Studio AI → Doumassi AI

Décision produit du CTO. Remplacement des 4 chaînes user-facing : titre placeholder feed, texte placeholder onglet, commentaire header, `tabBarAccessibilityLabel`.

Le fichier `studio-ai.tsx` et l'identifiant interne ne sont pas renommés (éviter de casser les références routing). Seules les chaînes affichées.

## Bug 2 — Reporté Sprint 6 (pas un bug)

**« Impossible de partager un post ou profil à un user de l'app »** = feature manquante. Le partage natif (lien universal) marche déjà pour les posts via `Share.share()`. Le partage interne vers un user DOUMASSI nécessite un écran sélection user + envoi DM pré-rempli.

→ Ticket à créer Sprint 6 : **"Partage interne posts/profils via DM"** + ajout dans bugs connus du guide bêta.

## Hygiène lint/typecheck

Tests Jest (ajoutés PR #201 Realtime) maintenant exclus du typecheck et lint (`__tests__/`, `*.test.ts(x)`). Pas de blocage CI. `pnpm test` continue à les exécuter.

## Test plan

- [ ] Appliquer migration `20260605120200_fix_update_username_idempotent.sql` sur **DEV** via AI Supabase
- [ ] Sur Dev Build : modifier juste sa bio dans l'éditeur de profil → save → ✅ pas d'erreur cooldown
- [ ] Sur Dev Build : modifier vraiment son username (s'il a > 30j) → save → ✅ update OK
- [ ] Sur Dev Build : modifier son username avant 30j → save → ✅ erreur cooldown attendue
- [ ] Tap story d'un user sans story active dans la barre → ✅ l'user n'apparaît plus dans la barre (filtre activé)
- [ ] Tap story d'un user AVEC story active → ✅ ouvre sa story (pas la mienne)
- [ ] Vérifier que la tab bar est bien positionnée sur Android (zone gestures) et iOS (home indicator)
- [ ] Vérifier que l'onglet et le placeholder affichent bien "Doumassi AI"
- [ ] Appliquer migration sur **STAGING** une fois DEV validé