### PR TITLE
docs(beta): limites connues guide + 8 tickets post-bêta

### DIFF
--- a/docs/beta-guide.md
+++ b/docs/beta-guide.md
@@ -71,13 +71,23 @@ Ce guide vous explique comment installer la bêta, ce que vous pouvez tester, et
 Les fonctions suivantes apparaissent en placeholder « Bientôt » dans l'app, c'est normal :
 
 - 🛒 Marketplace
-- 🤖 Studio AI
+- 🤖 Doumassi AI
 - 💳 Wallet (portefeuille)
 - 📞 Appels audio / vidéo
 - 💬 Conversations de groupe
 - 📷 Envoi d'images / messages vocaux dans les messages
 
 Ces fonctionnalités arriveront dans les prochaines versions, on travaille dessus.
+
+## 4 bis. Limites connues de cette bêta
+
+Quelques fonctionnalités sont volontairement réduites pour cette première version. On les ajoutera dans les prochaines mises à jour :
+
+- **Partage interne d'un post ou d'un profil vers un ami DOUMASSI** : pour l'instant, le bouton « Partager » sur un post copie un lien `https://doumassi.app/post/...` que vous pouvez envoyer par SMS, WhatsApp, etc. L'envoi direct dans une conversation DOUMASSI arrive Sprint 6.
+- **Réponse à un message spécifique** : la réponse à un message précis dans une conversation arrive Sprint 6 (le schéma est déjà en place côté serveur).
+- **Mentions `@username` dans les posts et messages** : arrive Sprint 6.
+- **Hashtags `#tag`** : arrive Sprint 6.
+- **Modale de rappel d'annulation au login** si une suppression de compte est en cours : pour la bêta, vous accédez quand même au feed normalement et vous voyez le statut dans `Paramètres → Compte → Supprimer mon compte`. Une modale d'annulation directement au login viendra plus tard.
 
 ## 5. Comment remonter vos retours
 


### PR DESCRIPTION
## Contexte

Suite au bug bash CTO et à la préparation Sprint 6, on documente les limites connues dans le guide bêta + on crée 8 tickets pour le post-bêta.

## Contenu

### Doc

- `docs/beta-guide.md` : nouvelle section "4 bis. Limites connues de cette bêta" qui explique aux testeurs ce qui n'est pas encore en V1 (partage interne, réponses, mentions, hashtags, modale annulation login)
- Correction "🤖 Studio AI" → "🤖 Doumassi AI" (cohérence avec PR #207)

### 8 tickets créés sans milestone

| # | Titre | Epic | Prio |
|---|---|---|---|
| #208 | Partage interne posts/profils via DM (Bug 2 reporté) | E6 Messaging | P2 |
| #209 | UI réponses dans messages (`reply_to_id`) | E6 Messaging | P2 |
| #210 | Envoi image dans message | E6 Messaging | P2 |
| #211 | Envoi vocal dans message | E6 Messaging | P3 |
| #212 | UI groupes conversations | E6 Messaging | P3 |
| #213 | Mentions `@username` posts + messages | E4 Feed | P2 |
| #214 | Modale annulation suppression compte au login | E8 Transverses | P3 |
| #215 | Accessibilité polish post-bêta (WCAG AA + hints + Reader) | Stab | P3 |

## Stratégie

On laisse intacts :
- **Sprint 6 actuel** (22 tickets) — roadmap Studio AI T1 + Marketplace
- **Sprint 7 actuel** (13 tickets) — Polish + Studio AI T2/T3

Les 8 nouveaux tickets vont **sans milestone** et seront triés au vrai sprint planning Sprint 6, **après réception des premiers retours bêta**. Ça nous laisse la flexibilité de :
- Prioriser les retours testeurs (priorité 1)
- Décider en fonction du temps dispo si on attaque Studio AI/Marketplace ou si on consolide le réseau social

## Test plan

- [ ] Relire la section "4 bis. Limites connues" du guide bêta : ton OK, formulation positive ("arrive Sprint 6" plutôt que "non fait")
- [ ] Vérifier les 8 issues créées : description claire, critères d'acceptation détaillés, labels corrects