### PR TITLE
feat(messaging): partage interne posts/profils via DM (E6-X)

### DIFF
--- a/app/(feed)/post/[id].tsx
+++ b/app/(feed)/post/[id].tsx
@@ -7,7 +7,6 @@ import { Bookmark, Heart, MessageCircle, Send, X } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   Animated,
   Pressable,
   Share,
@@ -21,6 +20,7 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Text, XStack, YStack } from 'tamagui';
 
 import type { PostCardPost } from '@/components/feed/PostCard';
+import { InternalShareOptionsSheet } from '@/components/share/InternalShareOptionsSheet';
 import { CommentsSheet } from '@/features/comments/components/CommentsSheet';
 import {
   useIncrementPostShare,
@@ -296,6 +296,7 @@ export default function PostDetailRoute() {
   const insets = useSafeAreaInsets();
   const [overlaysVisible, setOverlaysVisible] = useState(true);
   const [commentsOpen, setCommentsOpen] = useState(false);
+  const [shareSheetOpen, setShareSheetOpen] = useState(false);
 
   const postQuery = usePostDetail(postId);
   const likeMutation = useTogglePostLike(postId ?? '');
@@ -343,7 +344,7 @@ export default function PostDetailRoute() {
     setCommentsOpen(true);
   }, []);
 
-  const handleShare = useCallback(async () => {
+  const handleShareOutside = useCallback(async () => {
     if (!post) return;
 
     try {
@@ -357,9 +358,17 @@ export default function PostDetailRoute() {
         shareMutation.mutate();
       }
     } catch {
-      Alert.alert('Partage indisponible', 'Impossible d’ouvrir le partage pour le moment.');
+      // Annulation par l'utilisateur ou erreur native.
     }
   }, [post, shareMutation]);
+
+  const handleShareInside = useCallback(() => {
+    if (!post) return;
+    router.push({
+      pathname: '/messages/share',
+      params: { type: 'post', postId: post.id },
+    });
+  }, [post]);
 
   const handleOpenProfile = useCallback(() => {
     if (!post) return;
@@ -432,7 +441,7 @@ export default function PostDetailRoute() {
               <ActionButton
                 label={`Partager le post de @${post.author_username}`}
                 count={post.share_count}
-                onPress={() => void handleShare()}
+                onPress={() => setShareSheetOpen(true)}
               >
                 <Send size={32} color="#FFFFFF" />
               </ActionButton>
@@ -458,6 +467,12 @@ export default function PostDetailRoute() {
       {postId ? (
         <CommentsSheet postId={postId} open={commentsOpen} onOpenChange={setCommentsOpen} />
       ) : null}
+      <InternalShareOptionsSheet
+        open={shareSheetOpen}
+        onOpenChange={setShareSheetOpen}
+        onShareOutside={() => void handleShareOutside()}
+        onShareInside={handleShareInside}
+      />
     </>
   );
 }

--- a/app/(tabs)/profile/[id]/index.tsx
+++ b/app/(tabs)/profile/[id]/index.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Alert, Share, StyleSheet, useWindowDimensions } from 'react-native';
 import { Button, Sheet, Text, XStack, YStack } from 'tamagui';
 
+import { InternalShareOptionsSheet } from '@/components/share/InternalShareOptionsSheet';
 import { BlockConfirmModal } from '@/features/profile/components/BlockConfirmModal';
 import { FollowButton } from '@/features/profile/components/FollowButton';
 import { ListingCard } from '@/features/profile/components/ListingCard';
@@ -61,6 +62,7 @@ export default function OtherUserProfileScreen() {
 
   const [activeTab, setActiveTab] = useState<ProfileTab>('grid');
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [shareSheetOpen, setShareSheetOpen] = useState(false);
   const [isUnfollowModalOpen, setIsUnfollowModalOpen] = useState(false);
   const [isBlockModalOpen, setIsBlockModalOpen] = useState(false);
   const [blockChecked, setBlockChecked] = useState(false);
@@ -152,8 +154,7 @@ export default function OtherUserProfileScreen() {
     }
   }, [targetUserId]);
 
-  const handleShareProfile = useCallback(async () => {
-    setIsMenuOpen(false);
+  const handleShareProfileOutside = useCallback(async () => {
     try {
       const username = profile?.username ?? '';
       await Share.share({
@@ -163,6 +164,19 @@ export default function OtherUserProfileScreen() {
       // Annulé
     }
   }, [profile?.username]);
+
+  const handleShareProfileInside = useCallback(() => {
+    if (!profile?.username) return;
+    router.push({
+      pathname: '/messages/share',
+      params: { type: 'profile', username: profile.username },
+    });
+  }, [profile?.username]);
+
+  const handleShareProfile = useCallback(() => {
+    setIsMenuOpen(false);
+    setShareSheetOpen(true);
+  }, []);
 
   const handleBlockUser = useCallback(() => {
     setIsMenuOpen(false);
@@ -419,7 +433,7 @@ export default function OtherUserProfileScreen() {
               height={48}
               justifyContent="flex-start"
               paddingHorizontal="$3"
-              onPress={() => void handleShareProfile()}
+              onPress={handleShareProfile}
               pressStyle={{ backgroundColor: '$surfaceElevated' }}
               borderRadius="$md"
               icon={<Share2 size={20} color="#FFFFFF" />}
@@ -477,6 +491,13 @@ export default function OtherUserProfileScreen() {
         username={profile.username}
         onConfirm={() => void handleBlockConfirm()}
         isPending={isBlocking}
+      />
+
+      <InternalShareOptionsSheet
+        open={shareSheetOpen}
+        onOpenChange={setShareSheetOpen}
+        onShareOutside={() => void handleShareProfileOutside()}
+        onShareInside={handleShareProfileInside}
       />
 
       {/* Toast "User blocked" — E3-09 */}

--- a/app/messages/share.tsx
+++ b/app/messages/share.tsx
@@ -1,0 +1,270 @@
+import { FlashList } from '@shopify/flash-list';
+import { router, Stack, useLocalSearchParams } from 'expo-router';
+import { AlertCircle, ArrowLeft, CheckCircle2, Search, X } from 'lucide-react-native';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Input, Spinner, Text, XStack, YStack } from 'tamagui';
+
+import { useGetOrCreateDm } from '@/features/messaging/hooks/useGetOrCreateDm';
+import { useSendMessage } from '@/features/messaging/hooks/useSendMessage';
+import { UserRow } from '@/features/profile/components/UserRow';
+import { type SearchUserResult, useSearchUsers } from '@/features/profile/hooks/useSearchUsers';
+import { logger } from '@/lib/logger';
+import { Sentry } from '@/lib/sentry';
+import { supabase } from '@/lib/supabase';
+
+type ShareKind = 'post' | 'profile';
+
+type ToastState = {
+  message: string;
+};
+
+function SearchState({ icon, title }: { icon: 'search' | 'error'; title: string }) {
+  const Icon = icon === 'search' ? Search : AlertCircle;
+
+  return (
+    <YStack flex={1} alignItems="center" justifyContent="center" gap="$3" padding="$6">
+      <Icon size={32} color="#A0A0A0" />
+      <Text color="$textSecondary" fontSize={15} textAlign="center">
+        {title}
+      </Text>
+    </YStack>
+  );
+}
+
+function normalizeParam(value: string | string[] | undefined) {
+  return typeof value === 'string' ? value : null;
+}
+
+export default function InternalShareRoute() {
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{
+    type?: ShareKind;
+    postId?: string;
+    username?: string;
+  }>();
+  const shareKind = params.type === 'post' || params.type === 'profile' ? params.type : null;
+  const postId = normalizeParam(params.postId);
+  const username = normalizeParam(params.username);
+  const message =
+    shareKind === 'post' && postId
+      ? `https://doumassi.app/post/${postId}`
+      : shareKind === 'profile' && username
+        ? `https://doumassi.app/profile/${username}`
+        : null;
+
+  const [query, setQuery] = useState('');
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const redirectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { users, debouncedQuery, canSearch, isLoading, isError } = useSearchUsers(query);
+  const getOrCreateDm = useGetOrCreateDm();
+  const sendMessage = useSendMessage();
+
+  useEffect(
+    () => () => {
+      if (redirectTimeoutRef.current) {
+        clearTimeout(redirectTimeoutRef.current);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    void supabase.auth.getSession().then(({ data }) => {
+      setCurrentUserId(data.session?.user.id ?? null);
+    });
+  }, []);
+
+  const handleBack = useCallback(() => {
+    if (redirectTimeoutRef.current) {
+      clearTimeout(redirectTimeoutRef.current);
+    }
+    if (router.canGoBack()) router.back();
+    else router.replace('/(tabs)/messages');
+  }, []);
+
+  const handleSelectUser = useCallback(
+    async (user: SearchUserResult) => {
+      if (!message || !shareKind) return;
+      if (user.id === currentUserId) {
+        setToast({ message: 'Choisissez un autre utilisateur' });
+        return;
+      }
+
+      setSelectedUserId(user.id);
+      try {
+        const conversationId = await getOrCreateDm.mutateAsync(user.id);
+        await sendMessage.mutateAsync({ conversationId, content: message });
+
+        if (shareKind === 'post' && postId) {
+          await supabase.rpc('increment_share_count', { p_post_id: postId });
+          Sentry.captureMessage('post_shared_internal', {
+            level: 'info',
+            extra: { postId, recipientUserId: user.id, conversationId },
+          });
+        } else if (shareKind === 'profile' && username) {
+          Sentry.captureMessage('profile_shared_internal', {
+            level: 'info',
+            extra: { username, recipientUserId: user.id, conversationId },
+          });
+        }
+
+        setToast({ message: 'Envoyé dans DOUMASSI' });
+        redirectTimeoutRef.current = setTimeout(() => {
+          router.replace(`/messages/${conversationId}`);
+        }, 750);
+      } catch (err) {
+        logger.warn('Internal share failed', {
+          message: (err as Error).message,
+          recipientUserId: user.id,
+          shareKind,
+        });
+        setSelectedUserId(null);
+        setToast({ message: 'Envoi impossible, réessayez' });
+      }
+    },
+    [currentUserId, getOrCreateDm, message, postId, sendMessage, shareKind, username]
+  );
+
+  const renderUser = useCallback(
+    ({ item }: { item: SearchUserResult }) => (
+      <UserRow
+        user={item}
+        onPress={() => void handleSelectUser(item)}
+        rightSlot={selectedUserId === item.id ? <Spinner size="small" color="$color" /> : null}
+      />
+    ),
+    [handleSelectUser, selectedUserId]
+  );
+
+  const keyExtractor = useCallback((item: SearchUserResult) => item.id, []);
+  const visibleUsers = currentUserId ? users.filter((user) => user.id !== currentUserId) : users;
+  const showEmptyState = !canSearch;
+  const showNoResults = canSearch && !isLoading && !isError && visibleUsers.length === 0;
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false, presentation: 'card' }} />
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+        <XStack
+          height={56}
+          paddingHorizontal="$3"
+          alignItems="center"
+          gap="$3"
+          borderBottomWidth={StyleSheet.hairlineWidth}
+          borderBottomColor="$borderColor"
+        >
+          <Button
+            circular
+            size="$3"
+            chromeless
+            onPress={handleBack}
+            pressStyle={{ opacity: 0.7 }}
+            accessibilityLabel="Retour"
+          >
+            <ArrowLeft size={24} color="#FFFFFF" />
+          </Button>
+          <Text color="$color" fontSize={18} fontWeight="700">
+            Envoyer dans DOUMASSI
+          </Text>
+        </XStack>
+
+        <YStack paddingHorizontal="$4" paddingTop="$3" paddingBottom="$3">
+          <XStack
+            alignItems="center"
+            gap="$2"
+            height={48}
+            backgroundColor="$surface"
+            borderRadius="$md"
+            paddingHorizontal="$3"
+          >
+            <Search size={20} color="#A0A0A0" />
+            <Input
+              id="internal-share-search-users-input"
+              flex={1}
+              height={48}
+              borderWidth={0}
+              backgroundColor="transparent"
+              color="$color"
+              placeholder="Rechercher un utilisateur..."
+              placeholderTextColor="$placeholderColor"
+              autoCapitalize="none"
+              autoCorrect={false}
+              autoFocus
+              value={query}
+              onChangeText={setQuery}
+              paddingHorizontal={0}
+              fontSize={16}
+            />
+            {query.length > 0 ? (
+              <Button
+                id="internal-share-search-users-clear-button"
+                circular
+                size="$2.5"
+                chromeless
+                onPress={() => setQuery('')}
+                pressStyle={{ opacity: 0.65 }}
+                accessibilityLabel="Effacer la recherche"
+              >
+                <X size={18} color="#A0A0A0" />
+              </Button>
+            ) : null}
+          </XStack>
+        </YStack>
+
+        {!message ? (
+          <SearchState icon="error" title="Lien à partager indisponible." />
+        ) : showEmptyState ? (
+          <SearchState icon="search" title="Recherchez par username ou nom" />
+        ) : isLoading ? (
+          <YStack flex={1} alignItems="center" justifyContent="center">
+            <Spinner size="large" color="$color" />
+          </YStack>
+        ) : isError ? (
+          <SearchState icon="error" title="Recherche impossible. Réessayez." />
+        ) : showNoResults ? (
+          <SearchState icon="search" title={`Aucun utilisateur trouvé pour '@${debouncedQuery}'`} />
+        ) : (
+          <FlashList<SearchUserResult>
+            data={visibleUsers}
+            renderItem={renderUser}
+            keyExtractor={keyExtractor}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            contentContainerStyle={styles.listContent}
+          />
+        )}
+
+        {toast ? (
+          <XStack
+            position="absolute"
+            bottom={24 + insets.bottom}
+            alignSelf="center"
+            backgroundColor="$surfaceElevated"
+            borderWidth={1}
+            borderColor="$accentNeon"
+            borderRadius="$4"
+            paddingHorizontal="$4"
+            paddingVertical="$2"
+            alignItems="center"
+            gap="$2"
+          >
+            <CheckCircle2 size={16} color="#10D970" />
+            <Text color="$color" fontSize={13} fontWeight="700">
+              {toast.message}
+            </Text>
+          </XStack>
+        ) : null}
+      </YStack>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  listContent: {
+    paddingBottom: 24,
+  },
+});

--- a/src/components/feed/PostCard.tsx
+++ b/src/components/feed/PostCard.tsx
@@ -1,5 +1,6 @@
 import * as Haptics from 'expo-haptics';
 import { Image } from 'expo-image';
+import { router } from 'expo-router';
 import { Bookmark, Heart, MessageCircle, MoreHorizontal, Play, Send } from 'lucide-react-native';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -13,6 +14,7 @@ import {
 } from 'react-native';
 import { Text, XStack, YStack } from 'tamagui';
 
+import { InternalShareOptionsSheet } from '@/components/share/InternalShareOptionsSheet';
 import { supabase } from '@/lib/supabase';
 import { formatViewCount } from '@/utils/formatCount';
 
@@ -293,6 +295,7 @@ export const PostCard = memo(function PostCard({
 }: PostCardProps) {
   const likeScale = useRef(new Animated.Value(1)).current;
   const bookmarkSpin = useRef(new Animated.Value(0)).current;
+  const [shareSheetOpen, setShareSheetOpen] = useState(false);
 
   useEffect(() => {
     bookmarkSpin.setValue(0);
@@ -330,7 +333,7 @@ export const PostCard = memo(function PostCard({
     onBookmark?.();
   }, [bookmarkSpin, onBookmark]);
 
-  const handleShare = useCallback(async () => {
+  const handleShareOutside = useCallback(async () => {
     if (onShare) {
       onShare();
       return;
@@ -347,6 +350,13 @@ export const PostCard = memo(function PostCard({
     }
   }, [onShare, post.id]);
 
+  const handleShareInside = useCallback(() => {
+    router.push({
+      pathname: '/messages/share',
+      params: { type: 'post', postId: post.id },
+    });
+  }, [post.id]);
+
   const bookmarkRotation = bookmarkSpin.interpolate({
     inputRange: [0, 1],
     outputRange: ['0deg', '360deg'],
@@ -359,107 +369,116 @@ export const PostCard = memo(function PostCard({
   }
 
   return (
-    <YStack
-      width="100%"
-      paddingHorizontal={16}
-      paddingTop={14}
-      paddingBottom={12}
-      borderBottomWidth={StyleSheet.hairlineWidth}
-      borderBottomColor="$borderColor"
-      backgroundColor="$background"
-    >
-      <XStack alignItems="center" gap={10}>
-        <Avatar
-          username={post.author_username}
-          avatarUrl={post.author_avatar_url}
-          onPress={onOpenProfile}
-        />
+    <>
+      <YStack
+        width="100%"
+        paddingHorizontal={16}
+        paddingTop={14}
+        paddingBottom={12}
+        borderBottomWidth={StyleSheet.hairlineWidth}
+        borderBottomColor="$borderColor"
+        backgroundColor="$background"
+      >
+        <XStack alignItems="center" gap={10}>
+          <Avatar
+            username={post.author_username}
+            avatarUrl={post.author_avatar_url}
+            onPress={onOpenProfile}
+          />
 
-        <Pressable
-          onPress={onOpenProfile}
-          hitSlop={HIT_SLOP}
-          accessibilityRole="button"
-          accessibilityLabel={`Voir le profil de @${post.author_username}`}
-          style={styles.authorPressable}
-        >
-          <XStack alignItems="baseline" flexShrink={1} gap={5}>
-            <Text color="$color" fontSize={15} fontWeight="700" numberOfLines={1}>
-              @{post.author_username}
-            </Text>
-            <Text color="$textSecondary" fontSize={13} numberOfLines={1}>
-              · {relativeTime}
-            </Text>
-          </XStack>
-        </Pressable>
-
-        <XStack flex={1} />
-
-        {onMenuPress ? (
           <Pressable
-            onPress={onMenuPress}
+            onPress={onOpenProfile}
             hitSlop={HIT_SLOP}
             accessibilityRole="button"
-            accessibilityLabel={`Ouvrir le menu du post de @${post.author_username}`}
+            accessibilityLabel={`Voir le profil de @${post.author_username}`}
+            style={styles.authorPressable}
           >
-            <MoreHorizontal size={20} color="#FFFFFF" />
+            <XStack alignItems="baseline" flexShrink={1} gap={5}>
+              <Text color="$color" fontSize={15} fontWeight="700" numberOfLines={1}>
+                @{post.author_username}
+              </Text>
+              <Text color="$textSecondary" fontSize={13} numberOfLines={1}>
+                · {relativeTime}
+              </Text>
+            </XStack>
           </Pressable>
-        ) : null}
-      </XStack>
-
-      <YStack marginTop={10}>
-        <PostContent content={post.content} onOpenDetail={onOpenDetail} />
-        {hasMedia ? <PostMedia post={post} onOpenDetail={onOpenDetail} /> : null}
-      </YStack>
-
-      {variant === 'detail' ? null : (
-        <XStack alignItems="center" gap={20} marginTop={12} width="100%">
-          <CountAction
-            label={`Aimer le post de @${post.author_username}`}
-            count={post.like_count}
-            onPress={handleLike}
-          >
-            <Animated.View style={{ transform: [{ scale: likeScale }] }}>
-              <Heart
-                size={22}
-                color={post.liked_by_me ? '#FF3B30' : '#FFFFFF'}
-                fill={post.liked_by_me ? '#FF3B30' : 'transparent'}
-              />
-            </Animated.View>
-          </CountAction>
-
-          <CountAction
-            label={`Commenter le post de @${post.author_username}`}
-            count={post.comment_count}
-            onPress={onOpenComments}
-          >
-            <MessageCircle size={22} color="#FFFFFF" />
-          </CountAction>
-
-          <CountAction
-            label={`Partager le post de @${post.author_username}`}
-            count={post.share_count}
-            onPress={() => void handleShare()}
-          >
-            <Send size={22} color="#FFFFFF" />
-          </CountAction>
 
           <XStack flex={1} />
 
-          <CountAction
-            label={`Sauvegarder le post de @${post.author_username}`}
-            onPress={handleBookmark}
-          >
-            <Animated.View style={{ transform: [{ rotate: bookmarkRotation }] }}>
-              <Bookmark
-                size={22}
-                color={post.bookmarked_by_me ? '#10D970' : '#FFFFFF'}
-                fill={post.bookmarked_by_me ? '#10D970' : 'transparent'}
-              />
-            </Animated.View>
-          </CountAction>
+          {onMenuPress ? (
+            <Pressable
+              onPress={onMenuPress}
+              hitSlop={HIT_SLOP}
+              accessibilityRole="button"
+              accessibilityLabel={`Ouvrir le menu du post de @${post.author_username}`}
+            >
+              <MoreHorizontal size={20} color="#FFFFFF" />
+            </Pressable>
+          ) : null}
         </XStack>
-      )}
-    </YStack>
+
+        <YStack marginTop={10}>
+          <PostContent content={post.content} onOpenDetail={onOpenDetail} />
+          {hasMedia ? <PostMedia post={post} onOpenDetail={onOpenDetail} /> : null}
+        </YStack>
+
+        {variant === 'detail' ? null : (
+          <XStack alignItems="center" gap={20} marginTop={12} width="100%">
+            <CountAction
+              label={`Aimer le post de @${post.author_username}`}
+              count={post.like_count}
+              onPress={handleLike}
+            >
+              <Animated.View style={{ transform: [{ scale: likeScale }] }}>
+                <Heart
+                  size={22}
+                  color={post.liked_by_me ? '#FF3B30' : '#FFFFFF'}
+                  fill={post.liked_by_me ? '#FF3B30' : 'transparent'}
+                />
+              </Animated.View>
+            </CountAction>
+
+            <CountAction
+              label={`Commenter le post de @${post.author_username}`}
+              count={post.comment_count}
+              onPress={onOpenComments}
+            >
+              <MessageCircle size={22} color="#FFFFFF" />
+            </CountAction>
+
+            <CountAction
+              label={`Partager le post de @${post.author_username}`}
+              count={post.share_count}
+              onPress={() => setShareSheetOpen(true)}
+            >
+              <Send size={22} color="#FFFFFF" />
+            </CountAction>
+
+            <XStack flex={1} />
+
+            <CountAction
+              label={`Sauvegarder le post de @${post.author_username}`}
+              onPress={handleBookmark}
+            >
+              <Animated.View style={{ transform: [{ rotate: bookmarkRotation }] }}>
+                <Bookmark
+                  size={22}
+                  color={post.bookmarked_by_me ? '#10D970' : '#FFFFFF'}
+                  fill={post.bookmarked_by_me ? '#10D970' : 'transparent'}
+                />
+              </Animated.View>
+            </CountAction>
+          </XStack>
+        )}
+      </YStack>
+
+      <InternalShareOptionsSheet
+        open={shareSheetOpen}
+        onOpenChange={setShareSheetOpen}
+        onShareOutside={() => void handleShareOutside()}
+        onShareInside={handleShareInside}
+      />
+    </>
   );
 });
 

--- a/src/components/share/InternalShareOptionsSheet.tsx
+++ b/src/components/share/InternalShareOptionsSheet.tsx
@@ -1,0 +1,93 @@
+import { ExternalLink, Send } from 'lucide-react-native';
+import { Button, Sheet, Text, XStack, YStack } from 'tamagui';
+
+type InternalShareOptionsSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onShareOutside: () => void;
+  onShareInside: () => void;
+};
+
+export function InternalShareOptionsSheet({
+  open,
+  onOpenChange,
+  onShareOutside,
+  onShareInside,
+}: InternalShareOptionsSheetProps) {
+  const close = () => onOpenChange(false);
+
+  const handleShareOutside = () => {
+    close();
+    onShareOutside();
+  };
+
+  const handleShareInside = () => {
+    close();
+    onShareInside();
+  };
+
+  return (
+    <Sheet modal open={open} onOpenChange={onOpenChange} snapPoints={[24]} dismissOnSnapToBottom>
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="rgba(0,0,0,0.5)"
+      />
+      <Sheet.Frame
+        backgroundColor="$surface"
+        borderTopLeftRadius={16}
+        borderTopRightRadius={16}
+        paddingHorizontal="$4"
+        paddingTop="$3"
+        paddingBottom="$5"
+      >
+        <XStack justifyContent="center" marginBottom="$3">
+          <YStack width={36} height={4} borderRadius={2} backgroundColor="$borderColorHover" />
+        </XStack>
+
+        <YStack gap="$1">
+          <ShareOption
+            label="Partager hors DOUMASSI"
+            icon={<ExternalLink size={20} color="#FFFFFF" />}
+            onPress={handleShareOutside}
+          />
+          <ShareOption
+            label="Envoyer dans DOUMASSI"
+            icon={<Send size={20} color="#FFFFFF" />}
+            onPress={handleShareInside}
+          />
+        </YStack>
+      </Sheet.Frame>
+    </Sheet>
+  );
+}
+
+function ShareOption({
+  label,
+  icon,
+  onPress,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  onPress: () => void;
+}) {
+  return (
+    <Button
+      backgroundColor="transparent"
+      height={48}
+      justifyContent="flex-start"
+      paddingHorizontal="$3"
+      borderRadius="$md"
+      onPress={onPress}
+      pressStyle={{ backgroundColor: '$surfaceElevated' }}
+    >
+      <XStack alignItems="center" gap={10}>
+        {icon}
+        <Text color="$color" fontSize={15} fontWeight="500">
+          {label}
+        </Text>
+      </XStack>
+    </Button>
+  );
+}

--- a/supabase/migrations/20260618100000_fix_message_attachment_type_text.sql
+++ b/supabase/migrations/20260618100000_fix_message_attachment_type_text.sql
@@ -1,0 +1,4 @@
+-- Fix DEV/legacy DB drift: text messages are sent with attachment_type = 'text'.
+-- Some environments had message_attachment_type without this enum value.
+
+alter type public.message_attachment_type add value if not exists 'text';


### PR DESCRIPTION
## Ticket lié

Closes #208

## Changes

| Fichier | Rôle |
|---|---|
| `src/components/share/InternalShareOptionsSheet.tsx` | Sheet à 2 options : « Partager hors DOUMASSI » (Share natif OS) ou « Envoyer dans DOUMASSI » (nouveau) |
| `app/messages/share.tsx` | Écran search users + tap → `get_or_create_dm` + `useSendMessage` avec le lien pré-rempli |
| `src/components/feed/PostCard.tsx` | Intégration de la sheet sur le bouton Send (à la place du Share direct) |
| `app/(feed)/post/[id].tsx` | Intégration sur la vue détail post |
| `app/(tabs)/profile/[id]/index.tsx` | Intégration sur le menu kebab du profil tiers |
| `supabase/migrations/20260618100000_fix_message_attachment_type_text.sql` | Migration corrective enum `text` (déjà appliquée DEV+STAGING par le CTO) |

## Décisions

- Réutilisation complète des hooks/composants existants : `useSearchUsers`, `UserRow`, `useGetOrCreateDm`, `useSendMessage`, RPC `increment_share_count`
- Filtre `currentUserId` côté liste users + garde côté `handleSelectUser` (défense en profondeur)
- Toast feedback (« Envoyé dans DOUMASSI » / « Envoi impossible ») + redirect retardé 750ms vers la conv pour laisser voir le toast
- Tracking Sentry contextuel : `post_shared_internal` / `profile_shared_internal`

## Test plan

- [x] `pnpm typecheck` + `pnpm lint` passent
- [x] Partage d'un post → sheet → « Envoyer dans DOUMASSI » → search → envoi OK
- [x] Partage d'un profil → idem
- [x] Garde anti-self : tap sur moi-même affiche un toast
- [x] Cas d'erreur : si l'envoi échoue, toast d'erreur et state reset (pas de blocage)