### PR TITLE
fix(share): URL profil + Universal Links /u/{username}

### DIFF
--- a/app/(tabs)/profile/[id]/index.tsx
+++ b/app/(tabs)/profile/[id]/index.tsx
@@ -155,10 +155,13 @@ export default function OtherUserProfileScreen() {
   }, [targetUserId]);
 
   const handleShareProfileOutside = useCallback(async () => {
+    const username = profile?.username;
+    if (!username) return;
     try {
-      const username = profile?.username ?? '';
+      // URL incluse dans `message` car Android ignore la prop `url` de
+      // Share.share et ne lit que `message` (cf bug remonté 2026-06-24).
       await Share.share({
-        message: `Check out @${username} on DOUMASSI! 🚀`,
+        message: `Découvre le profil de @${username} sur DOUMASSI ! 🚀\nhttps://doumassi.app/u/${username}`,
       });
     } catch {
       // Annulé

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -42,12 +42,18 @@ export function ProfileScreen() {
   }, []);
 
   const handleShare = useCallback(async () => {
+    const username = profile?.username;
+    if (!username) return;
     try {
-      await Share.share({ message: copy.shareMessage });
+      // URL incluse dans `message` car Android ignore la prop `url` de
+      // Share.share et ne lit que `message` (cf bug remonté 2026-06-24).
+      await Share.share({
+        message: `${copy.shareMessage}\nhttps://doumassi.app/u/${username}`,
+      });
     } catch {
       // L'utilisateur a annulé le partage.
     }
-  }, [copy.shareMessage]);
+  }, [copy.shareMessage, profile?.username]);
 
   const handleKebabPress = useCallback(() => setIsMenuOpen(true), []);
 


### PR DESCRIPTION
## Summary

Bug remonté par Abdou pendant les tests du 2026-06-24 : taper « Partager mon profil » ouvrait le sheet natif avec « Découvre mon profil sur DOUMASSI ! 🚀 » mais **sans URL** derrière. En creusant, on a aussi découvert que l'URL qu'on construirait n'était pas encore reconnue comme Universal Link → la PR couvre les **2 problèmes** :

1. **Concaténer l'URL au message de partage** (fix du bug remonté)
2. **Déclarer `/u/{username}` comme Universal Link / App Link** côté manifests + Vercel pour que tap sur le lien ouvre l'app native au lieu du browser sur 404

## 1. Bug originel — URL absente du message

`Share.share()` de React Native a 3 props : `message`, `url`, `title`. **Android ignore complètement `url`** et ne lit que `message`. iOS la respecte selon l'app cible (Mail oui, Messages parfois non, WhatsApp non). Le code des 2 écrans ne passait ni l'un ni l'autre — juste le tagline.

→ URL concaténée dans `message`, séparée par `\n`. Pattern aligné sur ce qui est déjà fait pour les posts ([PostCard.tsx:334](src/components/feed/PostCard.tsx#L334)).

Au passage : sur le profil d'un autre user, on avait du copy en anglais (« Check out @x on DOUMASSI! ») au lieu du FR. Aligné sur le ton du reste de l'app.

## 2. Extension Universal Links — `/u/{username}`

Avant cette PR, l'archi deep link ne reconnaissait que `/post/*`, `/profile/*` et `/story/*`. Donc l'URL `https://doumassi.app/u/X` qu'on partage maintenant aurait ouvert le browser sur 404 au lieu de l'app.

Modifs :

- **`doumassi-landing/.well-known/apple-app-site-association`** : ajout `/u/*` aux paths iOS Universal Links
- **`app.json`** : ajout d'un intent filter Android avec `pathPrefix: /u`
- **`doumassi-landing/vercel.json`** : rewrite `/u/:username → /` (fallback browser si app pas installée)

Cohérent avec la route helper Expo Router `/profile/u/[username]` ajoutée dans la [PR #218](https://github.com/Waoow-tech/DOUMASSI-Application/pull/218) (mentions) qui résout `username → user.id` et redirige vers `/profile/[id]`. Les **mentions** auront aussi besoin de ce deep link path pour être cliquables depuis l'extérieur.

## ⚠️ Pré-requis post-merge

- [ ] **Redeploy automatique Vercel** de la landing (devrait se faire au merge via webhook). Vérifier que https://doumassi.app/.well-known/apple-app-site-association liste bien `/u/*` après merge
- [ ] **Rebuild Dev Build** requis (changement de manifest natif Android intent filters + iOS associated domains)

## Changes

| Fichier | Type |
|---|---|
| [src/features/profile/screens/ProfileScreen.tsx](src/features/profile/screens/ProfileScreen.tsx) | fix code |
| [app/(tabs)/profile/[id]/index.tsx](app/(tabs)/profile/[id]/index.tsx) | fix code + traduction FR |
| [doumassi-landing/.well-known/apple-app-site-association](doumassi-landing/.well-known/apple-app-site-association) | manifest iOS |
| [app.json](app.json) | intent filter Android |
| [doumassi-landing/vercel.json](doumassi-landing/vercel.json) | rewrite landing |

## Test plan

- [ ] Mon profil → kebab → « Partager mon profil » → message inclut `\nhttps://doumassi.app/u/{my_username}`
- [ ] Profil d'un autre user → kebab → « Partager hors DOUMASSI » → message FR + URL
- [ ] Tap sur le lien partagé depuis WhatsApp/SMS sur Android avec l'app installée → ouvre l'app sur le profil cible (pas le browser)
- [ ] Idem sur iOS via TestFlight
- [ ] Tap sur le lien si l'app **pas** installée → browser ouvre la landing https://doumassi.app