### PR TITLE
chore(deeplink): Universal Links /u/{username} (suite #219)

### DIFF
--- a/app.json
+++ b/app.json
@@ -52,6 +52,11 @@
               "scheme": "https",
               "host": "doumassi.app",
               "pathPrefix": "/story"
+            },
+            {
+              "scheme": "https",
+              "host": "doumassi.app",
+              "pathPrefix": "/u"
             }
           ],
           "category": ["BROWSABLE", "DEFAULT"]

--- a/doumassi-landing/.well-known/apple-app-site-association
+++ b/doumassi-landing/.well-known/apple-app-site-association
@@ -4,7 +4,7 @@
     "details": [
       {
         "appID": "TEAMID_PLACEHOLDER.com.doumassi.app",
-        "paths": ["/post/*", "/profile/*", "/story/*"]
+        "paths": ["/post/*", "/profile/*", "/story/*", "/u/*"]
       }
     ]
   }

--- a/doumassi-landing/vercel.json
+++ b/doumassi-landing/vercel.json
@@ -21,6 +21,7 @@
   "rewrites": [
     { "source": "/post/:id", "destination": "/" },
     { "source": "/profile/:id", "destination": "/" },
-    { "source": "/story/:id", "destination": "/" }
+    { "source": "/story/:id", "destination": "/" },
+    { "source": "/u/:username", "destination": "/" }
   ]
 }


### PR DESCRIPTION
## Summary

Suite de la [PR #219](https://github.com/Waoow-tech/DOUMASSI-Application/pull/219) qui a ajouté l'URL `https://doumassi.app/u/{username}` au message de partage natif **sans** déclarer ce path comme Universal Link / App Link.

Conséquence : tap sur le lien partagé ouvrait le browser sur une 404 au lieu d'ouvrir l'app sur le profil cible. Cette PR complète la chaîne.

## Changes

- **`doumassi-landing/.well-known/apple-app-site-association`** — ajout `/u/*` aux paths iOS Universal Links
- **`app.json`** — ajout d'un intent filter Android avec `pathPrefix: /u`
- **`doumassi-landing/vercel.json`** — rewrite `/u/:username → /` (fallback browser si app pas installée)

Cohérent avec la route helper Expo Router `/profile/u/[username]` ajoutée dans la [PR #218](https://github.com/Waoow-tech/DOUMASSI-Application/pull/218) (mentions) qui résout `username → user.id` et redirige vers `/profile/[id]`. Les **mentions** clickables depuis l'extérieur (lien WhatsApp/Slack avec `@username`) reposent aussi sur ce path.

## ⚠️ Pré-requis post-merge

- [ ] **Redeploy automatique Vercel** de la landing (webhook Vercel sur merge dans dev). Vérifier après merge que https://doumassi.app/.well-known/apple-app-site-association liste bien `/u/*`
- [ ] **Rebuild Dev Build** requis (changement de manifest natif : Android intent filters + iOS associated domains nécessitent un build natif)

## Test plan

- [ ] Après redeploy Vercel : `curl https://doumassi.app/.well-known/apple-app-site-association` → contient `/u/*`
- [ ] Après rebuild Dev Build Android : tap sur `https://doumassi.app/u/{username}` depuis WhatsApp → ouvre l'app directement sur le profil
- [ ] Même test sur iOS via TestFlight ou Dev Build iOS
- [ ] Si l'app n'est pas installée : browser ouvre la landing https://doumassi.app (pas 404)