### PR TITLE
feat(mentions): composer + dropdown suggestions (#213 PR B)

### DIFF
--- a/src/features/feed/screens/CreatePostScreen.tsx
+++ b/src/features/feed/screens/CreatePostScreen.tsx
@@ -3,8 +3,9 @@
 // uploadPostImage (E4-04) puis crée le post via useCreatePost (E4-05, qui
 // invalide déjà le cache feed). Modale full-screen, header custom.
 //
-// Hors scope : vidéos, mentions @, hashtags #, géoloc, audience, brouillons,
+// Hors scope : vidéos, hashtags #, géoloc, audience, brouillons,
 // preview plein écran d'une image (optionnel MVP du ticket).
+// Mentions @ : ajoutées via ticket #213 (PR B) — dropdown au-dessus du clavier.
 
 import * as ImagePicker from 'expo-image-picker';
 import { router, useNavigation } from 'expo-router';
@@ -22,7 +23,14 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { Button, ScrollView, Text, TextArea, XStack, YStack } from 'tamagui';
 
 import { useCreatePost } from '@/features/feed/hooks/useCreatePost';
+import { MentionSuggestionsList } from '@/features/mentions/components/MentionSuggestionsList';
+import { useMentionSuggestions } from '@/features/mentions/hooks/useMentionSuggestions';
+import {
+  countMentions,
+  MAX_MENTIONS_PER_CONTENT,
+} from '@/features/mentions/schemas/mentionsSchema';
 import { useCurrentProfile } from '@/features/profile/hooks/useProfile';
+import type { SearchUserResult } from '@/features/profile/hooks/useSearchUsers';
 import { logger } from '@/lib/logger';
 import { uploadPostImage } from '@/lib/storage';
 
@@ -55,9 +63,24 @@ export function CreatePostScreen() {
   const createPost = useCreatePost();
 
   const [content, setContent] = useState('');
+  const [selection, setSelection] = useState({ start: 0, end: 0 });
   const [media, setMedia] = useState<MediaItem[]>([]);
   const [isPublishing, setIsPublishing] = useState(false);
   const [publishError, setPublishError] = useState<string | null>(null);
+
+  const { activeQuery, suggestions, isLoading, replaceMention } = useMentionSuggestions(
+    content,
+    selection.end
+  );
+
+  const mentionsCount = countMentions(content);
+  const tooManyMentions = mentionsCount > MAX_MENTIONS_PER_CONTENT;
+
+  const handleSuggestionPick = (user: SearchUserResult) => {
+    const next = replaceMention(user.username);
+    setContent(next.text);
+    setSelection({ start: next.cursor, end: next.cursor });
+  };
 
   const abortRef = useRef<AbortController | null>(null);
   // Flag pour court-circuiter la confirmation quand la nav est déjà validée.
@@ -65,7 +88,7 @@ export function CreatePostScreen() {
 
   const hasContent = content.trim().length > 0 || media.length > 0;
   const isAnyUploading = media.some((m) => m.status === 'uploading');
-  const publishDisabled = !hasContent || isPublishing || isAnyUploading;
+  const publishDisabled = !hasContent || isPublishing || isAnyUploading || tooManyMentions;
   const profile = profileQuery.data;
 
   // Intercepte sortie d'écran (X, back hardware, swipe) si du contenu en cours.
@@ -304,7 +327,9 @@ export function CreatePostScreen() {
             <TextArea
               flex={1}
               value={content}
+              selection={selection}
               onChangeText={setContent}
+              onSelectionChange={(e) => setSelection(e.nativeEvent.selection)}
               maxLength={MAX_CONTENT}
               placeholder="Quoi de neuf ?"
               placeholderTextColor="$placeholderColor"
@@ -416,6 +441,30 @@ export function CreatePostScreen() {
               >
                 Réessayer
               </Button>
+            </XStack>
+          ) : null}
+
+          {/* Dropdown suggestions @mentions (au-dessus de la toolbar) */}
+          <MentionSuggestionsList
+            suggestions={suggestions}
+            isLoading={isLoading}
+            visible={activeQuery !== null}
+            onSelect={handleSuggestionPick}
+          />
+
+          {/* Garde-fou max 5 mentions */}
+          {tooManyMentions ? (
+            <XStack
+              alignItems="center"
+              backgroundColor="rgba(239,68,68,0.15)"
+              paddingHorizontal="$3"
+              paddingVertical="$2"
+              borderTopWidth={1}
+              borderColor="rgba(239,68,68,0.3)"
+            >
+              <Text flex={1} color={ERROR_RED} fontSize={13}>
+                Maximum {MAX_MENTIONS_PER_CONTENT} mentions par post.
+              </Text>
             </XStack>
           ) : null}
 

--- a/src/features/mentions/components/MentionSuggestionsList.tsx
+++ b/src/features/mentions/components/MentionSuggestionsList.tsx
@@ -1,0 +1,149 @@
+// MentionSuggestionsList — Sprint 6, ticket #213 (PR B).
+//
+// Dropdown horizontal de suggestions affichée AU-DESSUS d'un composer texte
+// quand l'utilisateur est en train de taper `@xxx`. Tap sur une suggestion =
+// insère `@username ` à la position du curseur (via le helper du hook).
+//
+// On utilise un ScrollView horizontal de "chips" plutôt qu'une liste verticale :
+//   - Prend peu de hauteur (~52px) → ne mange pas l'écran
+//   - Lecture rapide
+//   - Cohérent avec l'UX des composers modernes (Twitter, Discord)
+//
+// Hauteur fixée pour éviter les sauts de layout. Si pas de suggestions
+// (chargement, vide, query trop courte), on n'affiche pas le composant
+// (à gérer côté parent avec un `activeQuery !== null` mais on rend quand
+// même en mode loading pour montrer un feedback visuel).
+
+import { Image } from 'expo-image';
+import { User as UserIcon } from 'lucide-react-native';
+import { Pressable, ScrollView, StyleSheet } from 'react-native';
+import { Spinner, Text, XStack, YStack } from 'tamagui';
+
+import type { SearchUserResult } from '@/features/profile/hooks/useSearchUsers';
+
+export interface MentionSuggestionsListProps {
+  suggestions: SearchUserResult[];
+  isLoading: boolean;
+  /** Vrai dès qu'une mention est en cours (même si query trop courte). */
+  visible: boolean;
+  onSelect: (user: SearchUserResult) => void;
+}
+
+const HEIGHT = 52;
+const AVATAR_SIZE = 28;
+
+export function MentionSuggestionsList({
+  suggestions,
+  isLoading,
+  visible,
+  onSelect,
+}: MentionSuggestionsListProps) {
+  if (!visible) return null;
+
+  // Cas chargement : on affiche un spinner pour signaler à l'utilisateur que
+  // sa frappe est captée. Sinon on aurait l'impression que la dropdown bug.
+  if (isLoading) {
+    return (
+      <XStack
+        height={HEIGHT}
+        backgroundColor="$surface"
+        borderTopWidth={StyleSheet.hairlineWidth}
+        borderTopColor="$borderColor"
+        alignItems="center"
+        justifyContent="center"
+        gap="$2"
+      >
+        <Spinner size="small" color="$accentNeon" />
+        <Text fontSize={13} color="$textSecondary">
+          Recherche…
+        </Text>
+      </XStack>
+    );
+  }
+
+  // Cas vide : aucune suggestion (query > 2 chars mais 0 résultat). On affiche
+  // un placeholder discret pour signaler "rien trouvé" sans masquer le texte.
+  if (suggestions.length === 0) {
+    return (
+      <XStack
+        height={HEIGHT}
+        backgroundColor="$surface"
+        borderTopWidth={StyleSheet.hairlineWidth}
+        borderTopColor="$borderColor"
+        alignItems="center"
+        justifyContent="center"
+        paddingHorizontal="$3"
+      >
+        <Text fontSize={13} color="$textSecondary">
+          Aucun utilisateur trouvé
+        </Text>
+      </XStack>
+    );
+  }
+
+  return (
+    <XStack
+      height={HEIGHT}
+      backgroundColor="$surface"
+      borderTopWidth={StyleSheet.hairlineWidth}
+      borderTopColor="$borderColor"
+    >
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        keyboardShouldPersistTaps="always"
+        contentContainerStyle={styles.scrollContent}
+      >
+        {suggestions.map((user) => (
+          <Pressable
+            key={user.id}
+            onPress={() => onSelect(user)}
+            accessibilityRole="button"
+            accessibilityLabel={`Mentionner @${user.username}`}
+            style={styles.chip}
+          >
+            <YStack
+              width={AVATAR_SIZE}
+              height={AVATAR_SIZE}
+              borderRadius={9999}
+              backgroundColor="$surfaceElevated"
+              alignItems="center"
+              justifyContent="center"
+              overflow="hidden"
+            >
+              {user.avatar_url ? (
+                <Image
+                  source={{ uri: user.avatar_url }}
+                  style={{ width: AVATAR_SIZE, height: AVATAR_SIZE }}
+                  contentFit="cover"
+                />
+              ) : (
+                <UserIcon size={14} color="#A0A0A0" />
+              )}
+            </YStack>
+            <Text fontSize={14} fontWeight="600" color="$color">
+              @{user.username}
+            </Text>
+          </Pressable>
+        ))}
+      </ScrollView>
+    </XStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    marginRight: 8,
+    backgroundColor: '#252525',
+    borderRadius: 9999,
+  },
+  scrollContent: {
+    paddingHorizontal: 12,
+    alignItems: 'center',
+  },
+});

--- a/src/features/mentions/hooks/useMentionSuggestions.ts
+++ b/src/features/mentions/hooks/useMentionSuggestions.ts
@@ -1,0 +1,152 @@
+// useMentionSuggestions — Sprint 6, ticket #213 (PR B).
+//
+// Détecte si l'utilisateur est en train de saisir une mention `@xxx` à la
+// position du curseur dans un composer (post, message). Si oui, expose la
+// liste de suggestions issue de `search_users`, et un helper pour insérer
+// la mention choisie en remplaçant le `@xxx` partiel.
+//
+// Utilisation typique côté composer :
+//
+//   const [text, setText] = useState('');
+//   const [cursor, setCursor] = useState(0);
+//   const { activeQuery, suggestions, isLoading, replaceMention } =
+//     useMentionSuggestions(text, cursor);
+//
+//   <TextArea
+//     value={text}
+//     onChangeText={(v) => { setText(v); setCursor(v.length); }}
+//     onSelectionChange={(e) => setCursor(e.nativeEvent.selection.end)}
+//   />
+//   {activeQuery !== null ? (
+//     <MentionSuggestionsList
+//       suggestions={suggestions}
+//       onSelect={(u) => {
+//         const next = replaceMention(u.username);
+//         setText(next.text);
+//         setCursor(next.cursor);
+//       }}
+//     />
+//   ) : null}
+
+import { useMemo } from 'react';
+
+import { useSearchUsers, type SearchUserResult } from '@/features/profile/hooks/useSearchUsers';
+
+// Pattern d'un username DOUMASSI (cohérent avec RPC update_username + helper
+// SQL fn_extract_mentions). Les longueurs 0-30 ici, mais en pratique la RPC
+// search_users ne matchera rien sous 2 caractères (cf `canSearch`).
+const MENTION_TYPING_CHAR = /[A-Za-z0-9_]/;
+
+interface ActiveMention {
+  /** Index du `@` dans `text`. */
+  start: number;
+  /** Index juste après le dernier char tapé (= curseur). */
+  end: number;
+  /** Ce qui suit le `@`, en lowercase (vide si curseur juste après `@`). */
+  query: string;
+}
+
+/**
+ * Trouve la mention en cours de saisie à la position du curseur.
+ * Retourne null si rien d'actif (curseur dans du texte normal, ou mention
+ * déjà "terminée" par un espace).
+ */
+function findActiveMention(text: string, cursorPosition: number): ActiveMention | null {
+  if (!text || cursorPosition < 0 || cursorPosition > text.length) {
+    return null;
+  }
+
+  // Remonte depuis le curseur jusqu'à trouver `@` (ou un séparateur qui
+  // invalide la mention). Tout caractère entre `@` et le curseur doit être
+  // dans [A-Za-z0-9_].
+  for (let i = cursorPosition - 1; i >= 0; i -= 1) {
+    const char = text[i];
+    if (char === '@') {
+      // Le `@` doit être en début de chaîne ou précédé d'un caractère non-word.
+      // Sinon `mon.email@x` matcherait `@x` comme mention, ce qui est faux.
+      const prevChar = i > 0 ? text[i - 1] : undefined;
+      if (prevChar !== undefined && /[A-Za-z0-9_]/.test(prevChar)) {
+        return null;
+      }
+      const query = text.slice(i + 1, cursorPosition).toLowerCase();
+      // Sécurité : ne déclenche pas la dropdown au-delà de 30 chars (limite
+      // username). Au-delà, soit l'utilisateur écrit autre chose, soit on a
+      // déjà passé la mention.
+      if (query.length > 30) {
+        return null;
+      }
+      return { start: i, end: cursorPosition, query };
+    }
+    if (char === undefined || !MENTION_TYPING_CHAR.test(char)) {
+      // Saut de ligne, espace, ponctuation → pas de mention active à ce curseur
+      return null;
+    }
+  }
+  return null;
+}
+
+export interface MentionReplacement {
+  /** Nouveau contenu du composer avec la mention insérée. */
+  text: string;
+  /** Position du curseur après insertion (= juste après `@username `). */
+  cursor: number;
+}
+
+export interface UseMentionSuggestionsResult {
+  /** Query active (sans le `@`) ou null si pas de mention en cours. */
+  activeQuery: string | null;
+  /** Position début/fin du `@xxx` en cours (utile pour styliser). */
+  activeRange: { start: number; end: number } | null;
+  /** Suggestions issues de search_users (vide si activeQuery < 2 chars). */
+  suggestions: SearchUserResult[];
+  isLoading: boolean;
+  isError: boolean;
+  /**
+   * Remplace le `@xxx` actif par `@username ` (avec espace final).
+   * Renvoie le nouveau texte et la position du curseur après insertion.
+   * À utiliser comme retour de `onSelect` dans la dropdown.
+   *
+   * Si appelée alors qu'aucune mention n'est active, retourne le texte
+   * inchangé (no-op safe).
+   */
+  replaceMention: (selectedUsername: string) => MentionReplacement;
+}
+
+export function useMentionSuggestions(
+  text: string,
+  cursorPosition: number
+): UseMentionSuggestionsResult {
+  const active = useMemo(() => findActiveMention(text, cursorPosition), [text, cursorPosition]);
+
+  // useSearchUsers a son propre debounce (300ms). Le ticket demande 200ms,
+  // mais 300ms est cohérent avec le reste de l'app. Pas de duplication de la
+  // logique RPC ici — on délègue.
+  const search = useSearchUsers(active?.query ?? '');
+
+  return useMemo(() => {
+    const replaceMention = (selectedUsername: string): MentionReplacement => {
+      if (!active) {
+        return { text, cursor: cursorPosition };
+      }
+      const before = text.slice(0, active.start);
+      const after = text.slice(active.end);
+      // Espace final pour permettre d'enchaîner la frappe. Si `after` commence
+      // déjà par un espace, on n'en ajoute pas un second.
+      const needsSpace = !after.startsWith(' ');
+      const insertion = `@${selectedUsername.toLowerCase()}${needsSpace ? ' ' : ''}`;
+      return {
+        text: before + insertion + after,
+        cursor: before.length + insertion.length,
+      };
+    };
+
+    return {
+      activeQuery: active ? active.query : null,
+      activeRange: active ? { start: active.start, end: active.end } : null,
+      suggestions: active && active.query.length >= 2 ? search.users : [],
+      isLoading: active && active.query.length >= 2 ? search.isLoading : false,
+      isError: search.isError,
+      replaceMention,
+    };
+  }, [active, cursorPosition, search.users, search.isLoading, search.isError, text]);
+}

--- a/src/features/messaging/components/MessageInput.tsx
+++ b/src/features/messaging/components/MessageInput.tsx
@@ -1,12 +1,24 @@
-// MessageInput — E6-03 / E6-05.
+// MessageInput — E6-03 / E6-05 + ticket #213 PR B (mentions composer).
 //
 // Composant sticky bottom : input multiline (max 6 lignes) + bouton Send.
-// Send désactivé si vide ou whitespace only.
+// Quand l'utilisateur tape `@`, ouvre une dropdown de suggestions au-dessus
+// du TextArea. Tap sur une suggestion insère `@username ` à la position du
+// curseur.
+//
+// Send désactivé si vide, whitespace only, ou > 5 mentions dans le message.
 
 import { Send } from 'lucide-react-native';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
-import { TextArea, XStack, YStack } from 'tamagui';
+import { Text, TextArea, XStack, YStack } from 'tamagui';
+
+import { MentionSuggestionsList } from '@/features/mentions/components/MentionSuggestionsList';
+import { useMentionSuggestions } from '@/features/mentions/hooks/useMentionSuggestions';
+import {
+  countMentions,
+  MAX_MENTIONS_PER_CONTENT,
+} from '@/features/mentions/schemas/mentionsSchema';
+import type { SearchUserResult } from '@/features/profile/hooks/useSearchUsers';
 
 export interface MessageInputProps {
   onSend: (content: string) => void;
@@ -23,14 +35,43 @@ export function MessageInput({
   placeholder = 'Écrire un message…',
 }: MessageInputProps) {
   const [content, setContent] = useState('');
+  const [selection, setSelection] = useState({ start: 0, end: 0 });
+
+  const { activeQuery, suggestions, isLoading, replaceMention } = useMentionSuggestions(
+    content,
+    selection.end
+  );
 
   const trimmed = content.trim();
-  const canSend = trimmed.length > 0 && trimmed.length <= MAX_CONTENT_LENGTH;
+  const mentionsCount = useMemo(() => countMentions(content), [content]);
+  const tooManyMentions = mentionsCount > MAX_MENTIONS_PER_CONTENT;
+  const canSend = trimmed.length > 0 && trimmed.length <= MAX_CONTENT_LENGTH && !tooManyMentions;
+
+  const handleChangeText = useCallback((text: string) => {
+    setContent(text.slice(0, MAX_CONTENT_LENGTH));
+  }, []);
+
+  const handleSelectionChange = useCallback(
+    (event: { nativeEvent: { selection: { start: number; end: number } } }) => {
+      setSelection(event.nativeEvent.selection);
+    },
+    []
+  );
+
+  const handleSuggestionPick = useCallback(
+    (user: SearchUserResult) => {
+      const next = replaceMention(user.username);
+      setContent(next.text);
+      setSelection({ start: next.cursor, end: next.cursor });
+    },
+    [replaceMention]
+  );
 
   const handleSend = useCallback(() => {
     if (!canSend) return;
     onSend(trimmed);
     setContent('');
+    setSelection({ start: 0, end: 0 });
   }, [canSend, onSend, trimmed]);
 
   return (
@@ -38,15 +79,33 @@ export function MessageInput({
       backgroundColor="$surface"
       borderTopWidth={StyleSheet.hairlineWidth}
       borderTopColor="$borderColor"
-      paddingHorizontal="$3"
-      paddingTop="$2"
-      paddingBottom="$2"
     >
-      <XStack alignItems="flex-end" gap="$2">
+      <MentionSuggestionsList
+        suggestions={suggestions}
+        isLoading={isLoading}
+        visible={activeQuery !== null}
+        onSelect={handleSuggestionPick}
+      />
+      {tooManyMentions ? (
+        <XStack paddingHorizontal="$3" paddingTop="$1">
+          <Text fontSize={12} color="$danger">
+            Maximum {MAX_MENTIONS_PER_CONTENT} mentions par message.
+          </Text>
+        </XStack>
+      ) : null}
+      <XStack
+        alignItems="flex-end"
+        gap="$2"
+        paddingHorizontal="$3"
+        paddingTop="$2"
+        paddingBottom="$2"
+      >
         <TextArea
           flex={1}
           value={content}
-          onChangeText={(text) => setContent(text.slice(0, MAX_CONTENT_LENGTH))}
+          selection={selection}
+          onChangeText={handleChangeText}
+          onSelectionChange={handleSelectionChange}
           placeholder={placeholder}
           placeholderTextColor="$placeholderColor"
           backgroundColor="$background"


### PR DESCRIPTION
## Summary

PR **B** sur le ticket [#213](https://github.com/Waoow-tech/Application/issues/213) — clôture la moitié saisie après la PR A (render + backend) mergée dans [#218](https://github.com/Waoow-tech/DOUMASSI-Application/pull/218).

### Hook `useMentionSuggestions(text, cursor)`

Détecte si le curseur est sur un `@xxx` actif (entre un `@` non précédé d'un char word, et la position courante avec un suffixe `[A-Za-z0-9_]*`).

- Retourne `{ activeQuery, suggestions, isLoading, replaceMention }`
- `suggestions` = résultat de `useSearchUsers(activeQuery)` (debounce 300ms hérité du hook existant)
- `replaceMention(username)` → `{ text, cursor }` — insère `@username ` à la position et renvoie la nouvelle position du curseur

### UI `MentionSuggestionsList`

Dropdown horizontal de chips avatar + `@name` au-dessus du composer.

- États : loading (spinner + « Recherche… »), vide (« Aucun utilisateur trouvé »), suggestions
- `keyboardShouldPersistTaps="always"` pour que tap ne ferme pas le clavier
- Hauteur fixe 52px (pas de saut de layout)

### Intégrations

- **`MessageInput`** : `selection` controlled + dropdown au-dessus du TextArea
- **`CreatePostScreen`** : idem, dropdown au-dessus de la toolbar (galerie/caméra)
- Tooltip d'erreur rouge sous le composer si > 5 mentions

### Validation max 5 mentions

- **Client** : send/publish désactivé si `countMentions > 5`, banner rouge informatif
- **Serveur** : déjà câblé via PR #218 — trigger DB rollback avec `P0001` si dépassé

## Hors scope

- ~~Render des mentions cliquables~~ → fait en PR A (#218)
- ~~Backend trigger + notifs~~ → fait en PR A (#218)
- Auto-complétion fuzzy : pour la bêta on garde le `LIKE` de la RPC `search_users`. Fuzzy/trigram à voir post-bêta si besoin.

## Test plan

- [ ] Composer post : taper `@al` → dropdown apparaît, montre des suggestions
- [ ] Taper sur une suggestion → `@alice ` inséré à la position du curseur, curseur juste après l'espace
- [ ] Tap dans un texte existant `Hello world` au milieu → taper `@bo` → dropdown apparaît
- [ ] Continuer à taper `@x` au-delà de 30 chars → dropdown disparaît
- [ ] Taper `email@example.com` → la dropdown ne s'ouvre PAS (le `@` est précédé d'une lettre)
- [ ] Atteindre 6 mentions → bouton Publier/Envoyer grisé + banner « Maximum 5 mentions »
- [ ] Composer message : tous les cas ci-dessus
- [ ] Tap sur dropdown ne ferme PAS le clavier (`keyboardShouldPersistTaps`)
- [ ] Insertion fonctionne sur iOS et Android (selection controlled)