### PR TITLE
feat(rgpd): modale annulation suppression compte au login (#214)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -8,7 +8,9 @@ import { Platform, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import GuardLoader from '@/components/GuardLoader';
+import { PendingDeletionModal } from '@/features/auth/components/PendingDeletionModal';
 import { useAuthGuard } from '@/features/auth/hooks/useAuthGuard';
+import { usePendingDeletionReminder } from '@/features/auth/hooks/usePendingDeletionReminder';
 import { usePushToken } from '@/features/auth/hooks/usePushToken';
 import { useNotificationsUnreadCount } from '@/features/notifications/hooks/useNotifications';
 import { usePushNotificationsHandler } from '@/features/notifications/hooks/usePushNotificationsHandler';
@@ -49,6 +51,11 @@ function AuthenticatedTabs() {
   usePushToken();
   usePushNotificationsHandler();
 
+  // Ticket #214 : rappel de suppression de compte programmée. La modale
+  // s'affiche 1× par session si une `deletion_requests` active existe pour
+  // l'user courant.
+  const deletionReminder = usePendingDeletionReminder();
+
   // Tab bar dynamique : on remonte la barre de la zone safe area système
   // (gesture navigation Android moderne + home indicator iOS). Sans ça,
   // la barre est posée au ras du bas → icônes coupées par la zone gestes.
@@ -61,54 +68,63 @@ function AuthenticatedTabs() {
   ];
 
   return (
-    <Tabs
-      screenOptions={{
-        headerShown: false,
-        tabBarShowLabel: false,
-        tabBarStyle: tabBarStyle,
-        tabBarActiveTintColor: ACTIVE_COLOR,
-        tabBarInactiveTintColor: INACTIVE_COLOR,
-      }}
-    >
-      <Tabs.Screen
-        name="feed"
-        options={{
-          tabBarIcon: ({ focused }) => <TabIcon Icon={Home} focused={focused} />,
-          tabBarAccessibilityLabel: 'Accueil',
+    <>
+      {deletionReminder.shouldShow && deletionReminder.request ? (
+        <PendingDeletionModal
+          open={deletionReminder.shouldShow}
+          request={deletionReminder.request}
+          onClose={deletionReminder.dismiss}
+        />
+      ) : null}
+      <Tabs
+        screenOptions={{
+          headerShown: false,
+          tabBarShowLabel: false,
+          tabBarStyle: tabBarStyle,
+          tabBarActiveTintColor: ACTIVE_COLOR,
+          tabBarInactiveTintColor: INACTIVE_COLOR,
         }}
-      />
-      <Tabs.Screen
-        name="notifications"
-        options={{
-          tabBarIcon: ({ focused }) => <TabIcon Icon={Bell} focused={focused} />,
-          tabBarAccessibilityLabel: 'Notifications',
-          // Cap à "99+" pour éviter un débordement visuel du badge sur les
-          // gros volumes (la cible MVP n'y arrivera pas mais c'est défensif).
-          tabBarBadge: unreadCount > 99 ? '99+' : unreadCount > 0 ? unreadCount : undefined,
-        }}
-      />
-      <Tabs.Screen
-        name="studio-ai"
-        options={{
-          tabBarIcon: ({ focused }) => <TabIcon Icon={Hash} focused={focused} />,
-          tabBarAccessibilityLabel: 'Doumassi AI',
-        }}
-      />
-      <Tabs.Screen
-        name="messages"
-        options={{
-          tabBarIcon: ({ focused }) => <TabIcon Icon={Send} focused={focused} />,
-          tabBarAccessibilityLabel: 'Messages',
-        }}
-      />
-      <Tabs.Screen
-        name="profile"
-        options={{
-          tabBarIcon: ({ focused }) => <TabIcon Icon={User} focused={focused} />,
-          tabBarAccessibilityLabel: 'Mon profil',
-        }}
-      />
-    </Tabs>
+      >
+        <Tabs.Screen
+          name="feed"
+          options={{
+            tabBarIcon: ({ focused }) => <TabIcon Icon={Home} focused={focused} />,
+            tabBarAccessibilityLabel: 'Accueil',
+          }}
+        />
+        <Tabs.Screen
+          name="notifications"
+          options={{
+            tabBarIcon: ({ focused }) => <TabIcon Icon={Bell} focused={focused} />,
+            tabBarAccessibilityLabel: 'Notifications',
+            // Cap à "99+" pour éviter un débordement visuel du badge sur les
+            // gros volumes (la cible MVP n'y arrivera pas mais c'est défensif).
+            tabBarBadge: unreadCount > 99 ? '99+' : unreadCount > 0 ? unreadCount : undefined,
+          }}
+        />
+        <Tabs.Screen
+          name="studio-ai"
+          options={{
+            tabBarIcon: ({ focused }) => <TabIcon Icon={Hash} focused={focused} />,
+            tabBarAccessibilityLabel: 'Doumassi AI',
+          }}
+        />
+        <Tabs.Screen
+          name="messages"
+          options={{
+            tabBarIcon: ({ focused }) => <TabIcon Icon={Send} focused={focused} />,
+            tabBarAccessibilityLabel: 'Messages',
+          }}
+        />
+        <Tabs.Screen
+          name="profile"
+          options={{
+            tabBarIcon: ({ focused }) => <TabIcon Icon={User} focused={focused} />,
+            tabBarAccessibilityLabel: 'Mon profil',
+          }}
+        />
+      </Tabs>
+    </>
   );
 }
 

--- a/src/features/auth/components/PendingDeletionModal.tsx
+++ b/src/features/auth/components/PendingDeletionModal.tsx
@@ -1,0 +1,153 @@
+// PendingDeletionModal — Sprint 6, ticket #214.
+//
+// Modal Tamagui Sheet affichée 1× par session quand un utilisateur avec une
+// demande de suppression de compte active se reconnecte. Lui propose de
+// l'annuler avant l'échéance J+30.
+//
+// Cas d'usage : un user a tapé "Supprimer mon compte" il y a 10 jours,
+// l'a oublié, et se reconnecte aujourd'hui. Sans cette modale, son compte
+// serait supprimé à J+30 sans rappel visible. On évite la perte de données
+// involontaire.
+//
+// Comportement :
+//   - Tap "Annuler la demande" : RPC cancelDeletion + ferme la modale +
+//     invalide la query deletion-request (gérée par le hook)
+//   - Tap "Plus tard" : ferme la modale sans annuler (le compte reste en
+//     pending). La modale ne réapparaît plus dans cette session, mais
+//     revient à la prochaine reconnexion.
+//   - Tap backdrop : équivaut à "Plus tard"
+
+import { router } from 'expo-router';
+import { useCallback } from 'react';
+import { Alert } from 'react-native';
+import { Button, Sheet, Text, YStack } from 'tamagui';
+
+import {
+  useCancelDeletion,
+  type DeletionRequestRow,
+} from '@/features/auth/hooks/useDeletionRequest';
+
+export interface PendingDeletionModalProps {
+  open: boolean;
+  request: DeletionRequestRow;
+  onClose: () => void;
+}
+
+function formatScheduledDateFr(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleDateString('fr-FR', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+function formatDaysRemaining(iso: string): number {
+  const target = new Date(iso).getTime();
+  if (Number.isNaN(target)) return 0;
+  const days = Math.max(0, Math.ceil((target - Date.now()) / (1000 * 60 * 60 * 24)));
+  return days;
+}
+
+export function PendingDeletionModal({ open, request, onClose }: PendingDeletionModalProps) {
+  const cancelDeletion = useCancelDeletion();
+  const formattedDate = formatScheduledDateFr(request.scheduled_delete_at);
+  const daysLeft = formatDaysRemaining(request.scheduled_delete_at);
+
+  const handleCancel = useCallback(() => {
+    cancelDeletion.mutate(undefined, {
+      onSuccess: () => {
+        onClose();
+        // Confirmation simple via Alert pour ne pas dépendre d'un toast system.
+        Alert.alert(
+          'Suppression annulée',
+          'Bienvenue ! Ton compte est conservé. Tu peux refaire une demande à tout moment depuis Paramètres.'
+        );
+      },
+      onError: (err) => {
+        Alert.alert(
+          'Erreur',
+          err instanceof Error ? err.message : "Impossible d'annuler pour le moment. Réessaie."
+        );
+      },
+    });
+  }, [cancelDeletion, onClose]);
+
+  const handleOpenSettings = useCallback(() => {
+    onClose();
+    router.push('/settings');
+  }, [onClose]);
+
+  return (
+    <Sheet
+      modal
+      open={open}
+      onOpenChange={(next: boolean) => {
+        if (!next) onClose();
+      }}
+      snapPoints={[55]}
+      dismissOnSnapToBottom
+      animation="medium"
+    >
+      <Sheet.Overlay backgroundColor="rgba(0,0,0,0.7)" />
+      <Sheet.Frame backgroundColor="$background" padding="$5" gap="$4">
+        <Sheet.Handle backgroundColor="$borderColor" />
+
+        <YStack gap="$2">
+          <Text fontSize={22} fontWeight="700" color="$color">
+            Suppression programmée
+          </Text>
+          <Text fontSize={15} color="$textSecondary" lineHeight={22}>
+            Tu as demandé la suppression de ton compte. Sans action, il sera supprimé définitivement
+            le{' '}
+            <Text fontSize={15} color="$color" fontWeight="600">
+              {formattedDate}
+            </Text>
+            {daysLeft > 0 ? ` (dans ${daysLeft} jour${daysLeft > 1 ? 's' : ''})` : ''}.
+          </Text>
+        </YStack>
+
+        <YStack gap="$3" marginTop="$2">
+          <Button
+            onPress={handleCancel}
+            disabled={cancelDeletion.isPending}
+            backgroundColor="$accentNeon"
+            color="#000000"
+            fontWeight="700"
+            size="$5"
+            borderRadius="$10"
+            accessibilityRole="button"
+            accessibilityLabel="Annuler la demande de suppression"
+          >
+            {cancelDeletion.isPending ? 'Annulation…' : 'Annuler la demande'}
+          </Button>
+
+          <Button
+            onPress={handleOpenSettings}
+            variant="outlined"
+            color="$color"
+            size="$4"
+            borderRadius="$10"
+            accessibilityRole="button"
+            accessibilityLabel="Ouvrir les paramètres du compte"
+          >
+            Gérer dans les paramètres
+          </Button>
+
+          <Button
+            onPress={onClose}
+            backgroundColor="transparent"
+            color="$textSecondary"
+            size="$3"
+            accessibilityRole="button"
+            accessibilityLabel="Fermer et continuer"
+          >
+            Plus tard
+          </Button>
+        </YStack>
+      </Sheet.Frame>
+    </Sheet>
+  );
+}

--- a/src/features/auth/hooks/usePendingDeletionReminder.ts
+++ b/src/features/auth/hooks/usePendingDeletionReminder.ts
@@ -1,0 +1,42 @@
+// usePendingDeletionReminder — Sprint 6, ticket #214.
+//
+// Détermine s'il faut afficher la modale de rappel de suppression de compte
+// à l'utilisateur courant. La modale s'affiche AU PLUS UNE FOIS PAR SESSION :
+// dès que l'utilisateur la ferme (annule OU "Plus tard"), on la masque
+// jusqu'à la prochaine reconnexion.
+//
+// Le "1×/session" est implémenté par un useState local : ce hook étant monté
+// dans `(tabs)/_layout.tsx` derrière le guard auth, le state est unmount à
+// chaque logout/login (le composant `AuthenticatedTabs` est démonté quand
+// le guard repasse par 'unauthenticated'). Pas besoin d'AsyncStorage.
+
+import { useCallback, useState } from 'react';
+
+import {
+  useDeletionRequest,
+  type DeletionRequestRow,
+} from '@/features/auth/hooks/useDeletionRequest';
+
+export interface PendingDeletionReminder {
+  /** La modale doit-elle être affichée ? */
+  shouldShow: boolean;
+  /** Row active si présente (utile pour passer à la modale). */
+  request: DeletionRequestRow | null;
+  /** À appeler quand l'utilisateur ferme la modale (annulée OU "Plus tard"). */
+  dismiss: () => void;
+}
+
+export function usePendingDeletionReminder(): PendingDeletionReminder {
+  const { data: request } = useDeletionRequest();
+  const [dismissed, setDismissed] = useState(false);
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+  }, []);
+
+  return {
+    shouldShow: !dismissed && request !== null && request !== undefined,
+    request: request ?? null,
+    dismiss,
+  };
+}


### PR DESCRIPTION
## Summary

Implémente le ticket [#214](https://github.com/Waoow-tech/DOUMASSI-Application/issues/214) (assigné à Farah initialement, repris pour avancer le sprint).

**Avant** : un user qui avait demandé "Supprimer mon compte" pouvait se reconnecter et accéder à l'app normalement sans rappel visible. Son compte était supprimé à J+30 sans qu'il en soit averti à chaque login → risque de perte de données involontaire.

**Après** : à chaque ouverture de l'app post-login, si une `deletion_requests` active existe pour l'user, une modale plein écran (Tamagui Sheet) s'affiche immédiatement.

## Implémentation

### `PendingDeletionModal.tsx` (nouveau)

Sheet plein écran avec :
- Titre **« Suppression programmée »**
- Date d'effet formatée FR (`samedi 23 juillet 2026`) + jours restants
- **Bouton primaire vert** « Annuler la demande » → `useCancelDeletion.mutate()` → Alert de confirmation + close
- **Bouton secondaire** « Gérer dans les paramètres » → ouvre `/settings`
- **Bouton tertiaire** « Plus tard » → close (sans annulation)
- Tap backdrop = "Plus tard"

### `usePendingDeletionReminder.ts` (nouveau)

Hook qui combine `useDeletionRequest` (existant) + un `useState` local pour le flag "1× par session". Retourne `{ shouldShow, request, dismiss }`.

Le "1× par session" est garanti par le cycle de vie de `AuthenticatedTabs` : à chaque logout, le composant est démonté (auth guard redirige vers welcome), donc le `useState` revient à initial à la prochaine connexion.

### Intégration `(tabs)/_layout.tsx`

- Montage du hook dans `AuthenticatedTabs` (sous le guard auth, comme `usePushToken`)
- Rendu conditionnel de la modale en sibling des `<Tabs>`

## Critères d'acceptation (cf ticket)

- [x] Au mount de `(tabs)/_layout.tsx` après guard auth, hook appelé
- [x] Si row active → modale plein écran avec titre, date, boutons
- [x] Bouton primaire : annule + ferme + Alert de confirmation
- [x] Bouton "Plus tard" : ferme sans annuler
- [x] Modale 1× par session (state local)
- [x] Logout/login → modale revient (composant démonté → state reset)
- [x] Skip en onboarding/incomplete (déjà géré par le guard auth qui short-circuit avec un Redirect avant `AuthenticatedTabs`)

## Test plan

- [ ] Tap "Supprimer mon compte" dans Settings → confirme → logout
- [ ] Login à nouveau → la modale apparaît sur le feed
- [ ] Tap "Plus tard" → la modale se ferme, ne réapparaît pas pendant la session
- [ ] Naviguer entre les tabs → pas de modale
- [ ] Logout → Login → la modale réapparaît
- [ ] Tap "Annuler la demande" → succès, Alert de confirmation, modale fermée, `deletion_requests.cancelled_at` est set côté DB
- [ ] Vérifier en DB que la query `deletion_requests` filtre bien `cancelled_at IS NULL AND processed_at IS NULL`