### PR TITLE
feat(messaging): envoi image dans message (#210)

### DIFF
--- a/src/features/messaging/components/MessageBubble.tsx
+++ b/src/features/messaging/components/MessageBubble.tsx
@@ -1,12 +1,15 @@
-// MessageBubble — E6-03.
+// MessageBubble — E6-03 + ticket #210 (image attachment).
 //
 // Affichage d'un message dans la liste. Bulle à droite si c'est moi, à
-// gauche sinon. Gère trois états :
-//   - normal : contenu + horodatage relatif
+// gauche sinon. Gère plusieurs états :
+//   - normal : contenu texte + horodatage relatif
 //   - edited : ajoute « modifié » à côté de l'horodatage
 //   - deleted : remplace le contenu par « 🚫 Message supprimé » en italique
+//   - image : affiche une thumbnail 220×260 contentFit cover, content
+//     optionnel rendu en dessous (caption)
 // Long-press sur ma propre bulle → ouvre la sheet d'actions (parent).
 
+import { Image } from 'expo-image';
 import { memo, useCallback } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { Text, XStack, YStack } from 'tamagui';
@@ -70,7 +73,7 @@ function MessageBubbleComponent({ message, isMine, onLongPress }: MessageBubbleP
           },
         ]}
       >
-        <YStack gap={2}>
+        <YStack gap={6}>
           {isDeleted ? (
             <Text
               fontSize={14}
@@ -80,16 +83,30 @@ function MessageBubbleComponent({ message, isMine, onLongPress }: MessageBubbleP
               🚫 Message supprimé
             </Text>
           ) : (
-            <MentionsText
-              content={message.content ?? ''}
-              style={{
-                fontSize: 15,
-                lineHeight: 20,
-                color: isMine ? COLORS.myText : COLORS.otherText,
-              }}
-              mentionColor={isMine ? COLORS.myText : '#10D970'}
-              mentionUnderline={isMine}
-            />
+            <>
+              {message.attachment_type === 'image' && message.attachment_url ? (
+                <Image
+                  source={{ uri: message.attachment_url }}
+                  style={styles.imageAttachment}
+                  contentFit="cover"
+                  transition={150}
+                  recyclingKey={message.id}
+                  accessibilityLabel="Image envoyée"
+                />
+              ) : null}
+              {message.content ? (
+                <MentionsText
+                  content={message.content}
+                  style={{
+                    fontSize: 15,
+                    lineHeight: 20,
+                    color: isMine ? COLORS.myText : COLORS.otherText,
+                  }}
+                  mentionColor={isMine ? COLORS.myText : '#10D970'}
+                  mentionUnderline={isMine}
+                />
+              ) : null}
+            </>
           )}
 
           <XStack gap={4} alignItems="center" justifyContent="flex-end">
@@ -127,6 +144,12 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
+  },
+  imageAttachment: {
+    width: 220,
+    height: 260,
+    borderRadius: 12,
+    backgroundColor: '#2A2A2A',
   },
 });
 

--- a/src/features/messaging/components/MessageInput.tsx
+++ b/src/features/messaging/components/MessageInput.tsx
@@ -1,15 +1,17 @@
-// MessageInput — E6-03 / E6-05 + ticket #213 PR B (mentions composer).
+// MessageInput — E6-03 / E6-05 + ticket #213 PR B (mentions composer)
+//                + ticket #210 (image attachment via bouton "+" à gauche).
 //
 // Composant sticky bottom : input multiline (max 6 lignes) + bouton Send.
 // Quand l'utilisateur tape `@`, ouvre une dropdown de suggestions au-dessus
 // du TextArea. Tap sur une suggestion insère `@username ` à la position du
-// curseur.
+// curseur. Le bouton "+" à gauche ouvre le picker d'image (le parent gère
+// le choix Galerie/Caméra via `onAttach`).
 //
 // Send désactivé si vide, whitespace only, ou > 5 mentions dans le message.
 
-import { Send } from 'lucide-react-native';
+import { Plus, Send } from 'lucide-react-native';
 import { useCallback, useMemo, useState } from 'react';
-import { Pressable, StyleSheet } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { Text, TextArea, XStack, YStack } from 'tamagui';
 
 import { MentionSuggestionsList } from '@/features/mentions/components/MentionSuggestionsList';
@@ -22,6 +24,13 @@ import type { SearchUserResult } from '@/features/profile/hooks/useSearchUsers';
 
 export interface MessageInputProps {
   onSend: (content: string) => void;
+  /**
+   * Ouvre le picker d'image (Galerie/Caméra). Le parent doit gérer le choix
+   * + l'appel à `uploadMessageImage` + `useSendMessage` avec attachmentType.
+   */
+  onAttach?: () => void;
+  /** Vrai pendant l'upload d'une image — désactive le bouton et affiche un spinner. */
+  isAttaching?: boolean;
   disabled?: boolean;
   placeholder?: string;
 }
@@ -31,6 +40,8 @@ const MAX_CONTENT_LENGTH = 4000;
 
 export function MessageInput({
   onSend,
+  onAttach,
+  isAttaching = false,
   disabled = false,
   placeholder = 'Écrire un message…',
 }: MessageInputProps) {
@@ -100,6 +111,27 @@ export function MessageInput({
         paddingTop="$2"
         paddingBottom="$2"
       >
+        {onAttach ? (
+          <Pressable
+            onPress={onAttach}
+            disabled={isAttaching || disabled}
+            style={[
+              styles.attachButton,
+              { backgroundColor: isAttaching || disabled ? '#2A2A2A' : '#1A1A1A' },
+            ]}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel="Ajouter une image"
+            accessibilityHint="Tap pour ouvrir la galerie ou prendre une photo"
+            accessibilityState={{ disabled: isAttaching || disabled }}
+          >
+            {isAttaching ? (
+              <ActivityIndicator size="small" color="#10D970" />
+            ) : (
+              <Plus size={22} color="#FFFFFF" />
+            )}
+          </Pressable>
+        ) : null}
         <TextArea
           flex={1}
           value={content}
@@ -141,6 +173,14 @@ export function MessageInput({
 }
 
 const styles = StyleSheet.create({
+  attachButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 1,
+  },
   sendButton: {
     width: 40,
     height: 40,

--- a/src/features/messaging/hooks/useSendMessage.ts
+++ b/src/features/messaging/hooks/useSendMessage.ts
@@ -28,6 +28,14 @@ export interface SendMessagePayload {
    * avec celle qui revient via Realtime.
    */
   clientTempId?: string;
+  /**
+   * Type d'attachment. 'text' par défaut. Pour 'image', 'voice', 'video' :
+   * `attachmentUrl` est requis et `content` peut être vide (= pas de caption).
+   * Ajouté par ticket #210 (image) — extensible pour #211 (voice).
+   */
+  attachmentType?: 'text' | 'image' | 'voice' | 'video';
+  /** URL publique de l'attachment (Storage). Requise si attachmentType !== 'text'. */
+  attachmentUrl?: string | null;
 }
 
 interface OptimisticContext {
@@ -44,11 +52,19 @@ export function useSendMessage() {
   const queryClient = useQueryClient();
 
   return useMutation<MessageRow, Error, SendMessagePayload, OptimisticContext>({
-    mutationFn: async ({ conversationId, content }) => {
+    mutationFn: async ({ conversationId, content, attachmentType = 'text', attachmentUrl }) => {
       const trimmed = content.trim();
-      if (trimmed.length === 0) throw new Error('Message vide');
+      const isText = attachmentType === 'text';
+
+      // Pour un message texte, content obligatoire. Pour un attachment, content
+      // optionnel (caption) — la CHECK constraint DB exige juste qu'au moins
+      // `content` OU `attachment_url` soit présent.
+      if (isText && trimmed.length === 0) throw new Error('Message vide');
       if (trimmed.length > MAX_CONTENT_LENGTH) {
         throw new Error(`Message trop long (max ${MAX_CONTENT_LENGTH} caractères)`);
+      }
+      if (!isText && !attachmentUrl) {
+        throw new Error('Attachment URL requise pour ce type de message');
       }
 
       const { data: session, error: sessionError } = await supabase.auth.getSession();
@@ -61,8 +77,9 @@ export function useSendMessage() {
         .insert({
           conversation_id: conversationId,
           sender_id: session.session.user.id,
-          attachment_type: 'text',
-          content: trimmed,
+          attachment_type: attachmentType,
+          content: trimmed.length > 0 ? trimmed : null,
+          attachment_url: attachmentUrl ?? null,
         })
         .select(
           'id, conversation_id, sender_id, attachment_type, content, attachment_url, reply_to_id, created_at, edited_at, deleted_at'
@@ -79,7 +96,13 @@ export function useSendMessage() {
       return data as MessageRow;
     },
 
-    onMutate: async ({ conversationId, content, clientTempId }) => {
+    onMutate: async ({
+      conversationId,
+      content,
+      clientTempId,
+      attachmentType = 'text',
+      attachmentUrl = null,
+    }) => {
       const tempId = clientTempId ?? `temp-${uuidv4()}`;
 
       // Annule les fetchs en cours pour éviter qu'ils écrasent l'optimistic
@@ -95,9 +118,9 @@ export function useSendMessage() {
         id: tempId,
         conversation_id: conversationId,
         sender_id: meId ?? 'unknown',
-        attachment_type: 'text',
-        content: content.trim(),
-        attachment_url: null,
+        attachment_type: attachmentType,
+        content: content.trim().length > 0 ? content.trim() : null,
+        attachment_url: attachmentUrl,
         reply_to_id: null,
         created_at: new Date().toISOString(),
         edited_at: null,

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -8,16 +8,18 @@
 //
 // Hors scope bêta (cohérent avec spec recadrée le 02/06/2026) :
 //   - Boutons d'appel audio/vidéo Daily.co (Sprint 6+ tickets #85-88)
-//   - Pièces jointes image/voice/video
+//   - Pièces jointes voice/video (image arrive ticket #210)
 //   - Réponses (reply_to_id)
 
 import { FlashList } from '@shopify/flash-list';
 import { Image } from 'expo-image';
+import * as ImagePicker from 'expo-image-picker';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, CheckCircle2 } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -43,6 +45,7 @@ import {
 import { useRealtimeConversation } from '@/features/messaging/hooks/useRealtimeConversation';
 import { useSendMessage } from '@/features/messaging/hooks/useSendMessage';
 import { logger } from '@/lib/logger';
+import { uploadMessageImage } from '@/lib/storage';
 import { supabase } from '@/lib/supabase';
 
 export function ConversationScreen() {
@@ -99,6 +102,84 @@ export function ConversationScreen() {
     },
     [convId, sendMessage]
   );
+
+  // Ticket #210 — pièce jointe image.
+  const [isAttaching, setIsAttaching] = useState(false);
+
+  const handleSendImage = useCallback(
+    async (imageUri: string) => {
+      if (!convId) return;
+      setIsAttaching(true);
+      try {
+        const { publicUrl } = await uploadMessageImage(imageUri);
+        sendMessage.mutate(
+          {
+            conversationId: convId,
+            content: '',
+            attachmentType: 'image',
+            attachmentUrl: publicUrl,
+          },
+          {
+            onError: (err) => {
+              logger.warn('Send image message failed', { message: err.message });
+              Alert.alert("Échec de l'envoi", err.message);
+            },
+          }
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Upload échoué';
+        logger.warn('Upload message image failed', { message: msg });
+        Alert.alert("Échec de l'upload", msg);
+      } finally {
+        setIsAttaching(false);
+      }
+    },
+    [convId, sendMessage]
+  );
+
+  const handleAttach = useCallback(() => {
+    if (isAttaching) return;
+    Alert.alert('Ajouter une image', undefined, [
+      {
+        text: 'Galerie',
+        onPress: async () => {
+          let perm = await ImagePicker.getMediaLibraryPermissionsAsync();
+          if (!perm.granted) perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+          if (!perm.granted) {
+            Alert.alert('Permission refusée', "Active l'accès aux photos dans Réglages.");
+            return;
+          }
+          const result = await ImagePicker.launchImageLibraryAsync({
+            mediaTypes: ['images'],
+            allowsMultipleSelection: false,
+            quality: 1,
+          });
+          if (result.canceled) return;
+          const asset = result.assets[0];
+          if (asset) await handleSendImage(asset.uri);
+        },
+      },
+      {
+        text: 'Caméra',
+        onPress: async () => {
+          let perm = await ImagePicker.getCameraPermissionsAsync();
+          if (!perm.granted) perm = await ImagePicker.requestCameraPermissionsAsync();
+          if (!perm.granted) {
+            Alert.alert('Permission refusée', "Active l'accès à la caméra dans Réglages.");
+            return;
+          }
+          const result = await ImagePicker.launchCameraAsync({
+            mediaTypes: ['images'],
+            quality: 1,
+          });
+          if (result.canceled) return;
+          const asset = result.assets[0];
+          if (asset) await handleSendImage(asset.uri);
+        },
+      },
+      { text: 'Annuler', style: 'cancel' },
+    ]);
+  }, [handleSendImage, isAttaching]);
 
   const handleLongPressBubble = useCallback((message: MessageRow) => {
     setActionMessage(message);
@@ -264,7 +345,12 @@ export function ConversationScreen() {
           )}
         </View>
 
-        <MessageInput onSend={handleSend} disabled={sendMessage.isPending} />
+        <MessageInput
+          onSend={handleSend}
+          onAttach={handleAttach}
+          isAttaching={isAttaching}
+          disabled={sendMessage.isPending || isAttaching}
+        />
         <View style={{ height: insets.bottom }} backgroundColor="$surface" />
       </KeyboardAvoidingView>
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -373,6 +373,59 @@ export async function uploadPostImage(
 }
 
 // ---------------------------------------------------------------------------
+// Messaging upload (#210)
+// ---------------------------------------------------------------------------
+
+const MESSAGING_BUCKET = 'messaging_media';
+
+export interface UploadMessageImageResult {
+  publicUrl: string;
+  path: string;
+}
+
+/**
+ * Compresse puis upload une image locale dans le bucket `messaging_media`.
+ * Pipeline identique à uploadPostImage : compression côté client (qualité 0.8,
+ * resize 1920px max), upload via SDK Supabase Storage, path `{user_id}/{uuid}.jpg`.
+ */
+export async function uploadMessageImage(
+  uri: string,
+  options?: { signal?: AbortSignal; onProgress?: (p: number) => void; quality?: number }
+): Promise<UploadMessageImageResult> {
+  const quality = clamp01(options?.quality ?? DEFAULT_QUALITY);
+  const signal = options?.signal;
+  const onProgress = options?.onProgress;
+
+  try {
+    if (signal?.aborted) throw abortedError();
+
+    const session = await getFreshSession();
+    const compressedUri = await compressImage(uri, quality);
+    const path = `${session.user.id}/${uuidv4()}.jpg`;
+
+    try {
+      await uploadToStorage(compressedUri, path, MESSAGING_BUCKET, 'image/jpeg', {
+        onProgress,
+        signal,
+      });
+    } finally {
+      await cleanupTempFiles([compressedUri]);
+    }
+
+    const { data } = supabase.storage.from(MESSAGING_BUCKET).getPublicUrl(path);
+    return { publicUrl: data.publicUrl, path };
+  } catch (error) {
+    const uploadError = error instanceof UploadError ? error : new UploadError('upload', error);
+    if (signal?.aborted) {
+      logger.debug('upload_message_image_cancelled');
+    } else {
+      logger.error('upload_message_image_failed', uploadError);
+    }
+    throw uploadError;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Stories upload (E4-12)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implémente le ticket [#210](https://github.com/Waoow-tech/Application/issues/210) (assigné Ilias initialement, repris pour avancer le sprint). Le schéma DB support (`attachment_type='image'` + `attachment_url`) était déjà en place via PR #192.

## Changes

### Storage
- `uploadMessageImage(uri)` ajouté dans `lib/storage.ts`. Pipeline identique à `uploadPostImage` (compression 1920px max, quality 0.8, retry+backoff) → bucket **`messaging_media`**, path `{user_id}/{uuid}.jpg`.

### `useSendMessage` étendu (rétro-compatible)
- `attachmentType?: 'text' | 'image' | 'voice' | 'video'` (défaut `'text'`)
- `attachmentUrl?: string | null` (requise si attachmentType ≠ 'text')
- Content devient optionnel pour les messages avec attachment (caption)
- Optimistic update propage les nouveaux champs

### `MessageInput`
- Bouton **`+`** à gauche (`Plus` icon) visible uniquement si `onAttach` passé
- `isAttaching` désactive le bouton et affiche un `ActivityIndicator`
- accessibilityLabel + hint

### `MessageBubble`
- Render image **220×260** (`contentFit="cover"`) si `attachment_type='image'`
- Caption rendu en dessous via `MentionsText` si `content` non null
- États existants (deleted/edited/optimistic/failed) conservés

### `ConversationScreen`
- `handleAttach` : `Alert.alert` 3 options (Galerie / Caméra / Annuler) + permissions
- `handleSendImage` : `uploadMessageImage` → `sendMessage.mutate({ attachmentType: 'image', attachmentUrl })`
- `isAttaching` propagé à `MessageInput`
- Erreurs remontées via `Alert`

## Hors scope (follow-up)

- **Viewer plein écran** au tap sur l'image — TODO post-bêta
- **Caption** (texte + image dans le même message) — la stack le supporte mais l'UX du composer n'a pas encore le bouton « envoyer avec caption »
- **Multi-images** dans un seul message

## Test plan

- [ ] Conversation 1-to-1 : tap sur "+" → Alert s'affiche
- [ ] Choisir "Galerie" → permission OK → sélection → upload → bulle apparaît avec image
- [ ] Choisir "Caméra" → permission OK → prise → upload → bulle apparaît
- [ ] Pendant l'upload : le bouton "+" affiche un spinner, bouton Send désactivé
- [ ] L'autre participant voit l'image en realtime via Supabase Realtime (déjà câblé)
- [ ] Permission refusée : Alert d'instructions
- [ ] Échec upload : Alert d'erreur
- [ ] Texte + image : non supporté côté UX pour cette PR (caption visible côté render uniquement si message arrive avec `content` non null — cas serveur side)