### PR TITLE
feat(messaging): envoi vocal dans message (#211)

### DIFF
--- a/src/features/messaging/components/MessageBubble.tsx
+++ b/src/features/messaging/components/MessageBubble.tsx
@@ -18,6 +18,8 @@ import { MentionsText } from '@/components/MentionsText';
 
 import type { MessageRow } from '../hooks/useConversationMessages';
 
+import { VoiceMessage } from './VoiceMessage';
+
 const COLORS = {
   myBubble: '#10D970', // accent neon
   myText: '#000000',
@@ -96,7 +98,17 @@ function MessageBubbleComponent({ message, isMine, onLongPress }: MessageBubbleP
                   accessibilityLabel="Image envoyée"
                 />
               ) : null}
-              {message.content ? (
+              {message.attachment_type === 'voice' && message.attachment_url ? (
+                <VoiceMessage
+                  audioUrl={message.attachment_url}
+                  durationSeconds={
+                    message.content ? Number.parseInt(message.content, 10) || undefined : undefined
+                  }
+                  textColor={isMine ? COLORS.myText : COLORS.otherText}
+                  iconColor={isMine ? COLORS.myText : '#10D970'}
+                />
+              ) : null}
+              {message.attachment_type !== 'voice' && message.content ? (
                 <MentionsText
                   content={message.content}
                   style={{

--- a/src/features/messaging/components/MessageBubble.tsx
+++ b/src/features/messaging/components/MessageBubble.tsx
@@ -1,12 +1,15 @@
-// MessageBubble — E6-03.
+// MessageBubble — E6-03 + ticket #210 (image attachment).
 //
 // Affichage d'un message dans la liste. Bulle à droite si c'est moi, à
-// gauche sinon. Gère trois états :
-//   - normal : contenu + horodatage relatif
+// gauche sinon. Gère plusieurs états :
+//   - normal : contenu texte + horodatage relatif
 //   - edited : ajoute « modifié » à côté de l'horodatage
 //   - deleted : remplace le contenu par « 🚫 Message supprimé » en italique
+//   - image : affiche une thumbnail 220×260 contentFit cover, content
+//     optionnel rendu en dessous (caption)
 // Long-press sur ma propre bulle → ouvre la sheet d'actions (parent).
 
+import { Image } from 'expo-image';
 import { memo, useCallback } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { Text, XStack, YStack } from 'tamagui';
@@ -72,7 +75,7 @@ function MessageBubbleComponent({ message, isMine, onLongPress }: MessageBubbleP
           },
         ]}
       >
-        <YStack gap={2}>
+        <YStack gap={6}>
           {isDeleted ? (
             <Text
               fontSize={14}
@@ -82,16 +85,30 @@ function MessageBubbleComponent({ message, isMine, onLongPress }: MessageBubbleP
               🚫 Message supprimé
             </Text>
           ) : (
-            <MentionsText
-              content={message.content ?? ''}
-              style={{
-                fontSize: 15,
-                lineHeight: 20,
-                color: isMine ? COLORS.myText : COLORS.otherText,
-              }}
-              mentionColor={isMine ? COLORS.myText : '#10D970'}
-              mentionUnderline={isMine}
-            />
+            <>
+              {message.attachment_type === 'image' && message.attachment_url ? (
+                <Image
+                  source={{ uri: message.attachment_url }}
+                  style={styles.imageAttachment}
+                  contentFit="cover"
+                  transition={150}
+                  recyclingKey={message.id}
+                  accessibilityLabel="Image envoyée"
+                />
+              ) : null}
+              {message.content ? (
+                <MentionsText
+                  content={message.content}
+                  style={{
+                    fontSize: 15,
+                    lineHeight: 20,
+                    color: isMine ? COLORS.myText : COLORS.otherText,
+                  }}
+                  mentionColor={isMine ? COLORS.myText : '#10D970'}
+                  mentionUnderline={isMine}
+                />
+              ) : null}
+            </>
           )}
 
           <XStack gap={4} alignItems="center" justifyContent="flex-end">
@@ -129,6 +146,12 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderTopLeftRadius: 18,
     borderTopRightRadius: 18,
+  },
+  imageAttachment: {
+    width: 220,
+    height: 260,
+    borderRadius: 12,
+    backgroundColor: '#2A2A2A',
   },
 });
 

--- a/src/features/messaging/components/MessageInput.tsx
+++ b/src/features/messaging/components/MessageInput.tsx
@@ -1,16 +1,20 @@
 // MessageInput — E6-03 / E6-05 + ticket #213 PR B (mentions composer)
-//                + ticket #210 (image attachment via bouton "+" à gauche).
+//                + ticket #210 (image attachment) + #211 (voice attachment).
 //
 // Composant sticky bottom : input multiline (max 6 lignes) + bouton Send.
 // Quand l'utilisateur tape `@`, ouvre une dropdown de suggestions au-dessus
 // du TextArea. Tap sur une suggestion insère `@username ` à la position du
 // curseur. Le bouton "+" à gauche ouvre le picker d'image (le parent gère
 // le choix Galerie/Caméra via `onAttach`).
+// Quand l'input est vide ET `onSendVoice` est fourni, un bouton micro
+// remplace le bouton Send : tap → start recording, tap encore → stop +
+// upload + send.
 //
 // Send désactivé si vide, whitespace only, ou > 5 mentions dans le message.
 
-import { Plus, Send } from 'lucide-react-native';
-import { useCallback, useMemo, useState } from 'react';
+import { RecordingPresets, requestRecordingPermissionsAsync, useAudioRecorder } from 'expo-audio';
+import { Mic, Plus, Send, StopCircle } from 'lucide-react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { Text, TextArea, XStack, YStack } from 'tamagui';
 
@@ -31,6 +35,13 @@ export interface MessageInputProps {
   onAttach?: () => void;
   /** Vrai pendant l'upload d'une image — désactive le bouton et affiche un spinner. */
   isAttaching?: boolean;
+  /**
+   * Callback appelé après l'arrêt d'un enregistrement. Le parent doit upload
+   * le fichier audio + créer le message avec attachmentType='voice'.
+   */
+  onSendVoice?: (uri: string, durationSeconds: number) => Promise<void> | void;
+  /** Vrai pendant l'upload/send vocal — bloque toute autre interaction. */
+  isSendingVoice?: boolean;
   disabled?: boolean;
   placeholder?: string;
 }
@@ -38,10 +49,14 @@ export interface MessageInputProps {
 const MAX_LINES = 6;
 const MAX_CONTENT_LENGTH = 4000;
 
+const MAX_VOICE_SECONDS = 60;
+
 export function MessageInput({
   onSend,
   onAttach,
   isAttaching = false,
+  onSendVoice,
+  isSendingVoice = false,
   disabled = false,
   placeholder = 'Écrire un message…',
 }: MessageInputProps) {
@@ -85,6 +100,87 @@ export function MessageInput({
     setSelection({ start: 0, end: 0 });
   }, [canSend, onSend, trimmed]);
 
+  // Ticket #211 — enregistrement vocal.
+  const recorder = useAudioRecorder(RecordingPresets.HIGH_QUALITY);
+  const [isRecording, setIsRecording] = useState(false);
+  const [recordedSeconds, setRecordedSeconds] = useState(0);
+  const recordStartRef = useRef<number | null>(null);
+  const tickRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Tick UI 1Hz pendant l'enregistrement + auto-stop à 60s
+  useEffect(() => {
+    if (!isRecording) {
+      if (tickRef.current) clearInterval(tickRef.current);
+      tickRef.current = null;
+      return;
+    }
+    tickRef.current = setInterval(() => {
+      const start = recordStartRef.current;
+      if (start == null) return;
+      const elapsed = Math.floor((Date.now() - start) / 1000);
+      setRecordedSeconds(elapsed);
+      if (elapsed >= MAX_VOICE_SECONDS) {
+        // Auto-stop : déclenche via setIsRecording(false) côté useEffect.
+        void stopRecording(true);
+      }
+    }, 250);
+    return () => {
+      if (tickRef.current) clearInterval(tickRef.current);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isRecording]);
+
+  const startRecording = useCallback(async () => {
+    const perm = await requestRecordingPermissionsAsync();
+    if (!perm.granted) return;
+    try {
+      await recorder.prepareToRecordAsync();
+      recorder.record();
+      recordStartRef.current = Date.now();
+      setRecordedSeconds(0);
+      setIsRecording(true);
+    } catch {
+      setIsRecording(false);
+    }
+  }, [recorder]);
+
+  const stopRecording = useCallback(
+    async (autoStop = false): Promise<void> => {
+      if (!isRecording) return;
+      try {
+        await recorder.stop();
+      } catch {
+        // best effort
+      }
+      const duration = recordStartRef.current
+        ? Math.max(1, Math.floor((Date.now() - recordStartRef.current) / 1000))
+        : 1;
+      setIsRecording(false);
+      recordStartRef.current = null;
+
+      const uri = recorder.uri;
+      if (uri && onSendVoice) {
+        try {
+          await onSendVoice(uri, Math.min(duration, MAX_VOICE_SECONDS));
+        } catch {
+          // l'erreur a déjà été remontée par le parent (Alert)
+        }
+      }
+      // autoStop = true → on évite un double appel via le timer
+      void autoStop;
+    },
+    [isRecording, onSendVoice, recorder]
+  );
+
+  const handleMicPress = useCallback(() => {
+    if (isSendingVoice || disabled) return;
+    if (isRecording) void stopRecording();
+    else void startRecording();
+  }, [disabled, isRecording, isSendingVoice, startRecording, stopRecording]);
+
+  // Le bouton mic remplace Send quand input vide ET callback voice fourni
+  const showMicButton = onSendVoice !== undefined && trimmed.length === 0;
+
   return (
     <YStack
       backgroundColor="$surface"
@@ -101,6 +197,20 @@ export function MessageInput({
         <XStack paddingHorizontal="$3" paddingTop="$1">
           <Text fontSize={12} color="$danger">
             Maximum {MAX_MENTIONS_PER_CONTENT} mentions par message.
+          </Text>
+        </XStack>
+      ) : null}
+      {isRecording ? (
+        <XStack
+          paddingHorizontal="$3"
+          paddingVertical="$2"
+          alignItems="center"
+          gap="$2"
+          backgroundColor="rgba(255,59,48,0.12)"
+        >
+          <YStack width={8} height={8} borderRadius={4} backgroundColor="#FF3B30" />
+          <Text fontSize={13} color="$color" fontWeight="600">
+            Enregistrement… {recordedSeconds}s / {MAX_VOICE_SECONDS}s
           </Text>
         </XStack>
       ) : null}
@@ -153,20 +263,54 @@ export function MessageInput({
           editable={!disabled}
           multiline
         />
-        <Pressable
-          onPress={handleSend}
-          disabled={!canSend || disabled}
-          style={[
-            styles.sendButton,
-            { backgroundColor: canSend && !disabled ? '#10D970' : '#2A2A2A' },
-          ]}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          accessibilityRole="button"
-          accessibilityLabel="Envoyer le message"
-          accessibilityState={{ disabled: !canSend || disabled }}
-        >
-          <Send size={20} color={canSend && !disabled ? '#000000' : '#6B6B6B'} />
-        </Pressable>
+        {showMicButton ? (
+          <Pressable
+            onPress={handleMicPress}
+            disabled={isSendingVoice || disabled}
+            style={[
+              styles.sendButton,
+              {
+                backgroundColor: isRecording
+                  ? '#FF3B30'
+                  : isSendingVoice || disabled
+                    ? '#2A2A2A'
+                    : '#10D970',
+              },
+            ]}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel={isRecording ? "Arrêter l'enregistrement" : 'Enregistrer un vocal'}
+            accessibilityHint={
+              isRecording
+                ? "Tap pour arrêter et envoyer l'enregistrement"
+                : 'Tap pour commencer un enregistrement vocal'
+            }
+            accessibilityState={{ disabled: isSendingVoice || disabled }}
+          >
+            {isSendingVoice ? (
+              <ActivityIndicator size="small" color="#FFFFFF" />
+            ) : isRecording ? (
+              <StopCircle size={22} color="#FFFFFF" fill="#FFFFFF" />
+            ) : (
+              <Mic size={20} color="#000000" />
+            )}
+          </Pressable>
+        ) : (
+          <Pressable
+            onPress={handleSend}
+            disabled={!canSend || disabled}
+            style={[
+              styles.sendButton,
+              { backgroundColor: canSend && !disabled ? '#10D970' : '#2A2A2A' },
+            ]}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel="Envoyer le message"
+            accessibilityState={{ disabled: !canSend || disabled }}
+          >
+            <Send size={20} color={canSend && !disabled ? '#000000' : '#6B6B6B'} />
+          </Pressable>
+        )}
       </XStack>
     </YStack>
   );

--- a/src/features/messaging/components/MessageInput.tsx
+++ b/src/features/messaging/components/MessageInput.tsx
@@ -1,15 +1,17 @@
-// MessageInput — E6-03 / E6-05 + ticket #213 PR B (mentions composer).
+// MessageInput — E6-03 / E6-05 + ticket #213 PR B (mentions composer)
+//                + ticket #210 (image attachment via bouton "+" à gauche).
 //
 // Composant sticky bottom : input multiline (max 6 lignes) + bouton Send.
 // Quand l'utilisateur tape `@`, ouvre une dropdown de suggestions au-dessus
 // du TextArea. Tap sur une suggestion insère `@username ` à la position du
-// curseur.
+// curseur. Le bouton "+" à gauche ouvre le picker d'image (le parent gère
+// le choix Galerie/Caméra via `onAttach`).
 //
 // Send désactivé si vide, whitespace only, ou > 5 mentions dans le message.
 
-import { Send } from 'lucide-react-native';
+import { Plus, Send } from 'lucide-react-native';
 import { useCallback, useMemo, useState } from 'react';
-import { Pressable, StyleSheet } from 'react-native';
+import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { Text, TextArea, XStack, YStack } from 'tamagui';
 
 import { MentionSuggestionsList } from '@/features/mentions/components/MentionSuggestionsList';
@@ -22,6 +24,13 @@ import type { SearchUserResult } from '@/features/profile/hooks/useSearchUsers';
 
 export interface MessageInputProps {
   onSend: (content: string) => void;
+  /**
+   * Ouvre le picker d'image (Galerie/Caméra). Le parent doit gérer le choix
+   * + l'appel à `uploadMessageImage` + `useSendMessage` avec attachmentType.
+   */
+  onAttach?: () => void;
+  /** Vrai pendant l'upload d'une image — désactive le bouton et affiche un spinner. */
+  isAttaching?: boolean;
   disabled?: boolean;
   placeholder?: string;
 }
@@ -31,6 +40,8 @@ const MAX_CONTENT_LENGTH = 4000;
 
 export function MessageInput({
   onSend,
+  onAttach,
+  isAttaching = false,
   disabled = false,
   placeholder = 'Écrire un message…',
 }: MessageInputProps) {
@@ -100,6 +111,27 @@ export function MessageInput({
         paddingTop="$2"
         paddingBottom="$2"
       >
+        {onAttach ? (
+          <Pressable
+            onPress={onAttach}
+            disabled={isAttaching || disabled}
+            style={[
+              styles.attachButton,
+              { backgroundColor: isAttaching || disabled ? '#2A2A2A' : '#1A1A1A' },
+            ]}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            accessibilityRole="button"
+            accessibilityLabel="Ajouter une image"
+            accessibilityHint="Tap pour ouvrir la galerie ou prendre une photo"
+            accessibilityState={{ disabled: isAttaching || disabled }}
+          >
+            {isAttaching ? (
+              <ActivityIndicator size="small" color="#10D970" />
+            ) : (
+              <Plus size={22} color="#FFFFFF" />
+            )}
+          </Pressable>
+        ) : null}
         <TextArea
           flex={1}
           value={content}
@@ -141,6 +173,14 @@ export function MessageInput({
 }
 
 const styles = StyleSheet.create({
+  attachButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginBottom: 1,
+  },
   sendButton: {
     width: 40,
     height: 40,

--- a/src/features/messaging/components/VoiceMessage.tsx
+++ b/src/features/messaging/components/VoiceMessage.tsx
@@ -1,0 +1,111 @@
+// VoiceMessage — Ticket #211 (Sprint 6).
+//
+// Bloc audio rendu DANS un MessageBubble quand attachment_type='voice'.
+// MVP minimaliste : bouton Play/Pause + durée. Pas de waveform, pas de scrub
+// (déférés post-bêta).
+//
+// 1 player par bulle. expo-audio gère le cycle de vie via les hooks. Ce n'est
+// pas optimal en RAM si une conversation a 100 voicemails (100 players) mais
+// suffisant pour la bêta. Optim future : un player global partagé avec switch
+// de source.
+
+import { useAudioPlayer, useAudioPlayerStatus } from 'expo-audio';
+import { Pause, Play } from 'lucide-react-native';
+import { memo, useCallback } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, XStack, YStack } from 'tamagui';
+
+export interface VoiceMessageProps {
+  /** URL publique du fichier .m4a uploadé. */
+  audioUrl: string;
+  /** Durée en secondes (récupérée à l'enregistrement, stockée dans content). */
+  durationSeconds?: number;
+  /** Couleur du texte selon la bulle (mine = noir, other = blanc). */
+  textColor: string;
+  /** Couleur de l'icône Play/Pause. */
+  iconColor: string;
+}
+
+function formatMmSs(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 0) return '0:00';
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+function VoiceMessageComponent({
+  audioUrl,
+  durationSeconds,
+  textColor,
+  iconColor,
+}: VoiceMessageProps) {
+  const player = useAudioPlayer(audioUrl);
+  const status = useAudioPlayerStatus(player);
+
+  const isPlaying = status?.playing ?? false;
+  const currentTime = status?.currentTime ?? 0;
+  const totalDuration = durationSeconds ?? status?.duration ?? 0;
+  const remaining = Math.max(0, totalDuration - currentTime);
+
+  const handleToggle = useCallback(() => {
+    if (isPlaying) {
+      player.pause();
+    } else {
+      // Si on a atteint la fin, on rejoue depuis 0
+      if (totalDuration > 0 && currentTime >= totalDuration - 0.2) {
+        player.seekTo(0);
+      }
+      player.play();
+    }
+  }, [currentTime, isPlaying, player, totalDuration]);
+
+  return (
+    <XStack alignItems="center" gap={10} minWidth={180}>
+      <Pressable
+        onPress={handleToggle}
+        style={[styles.playButton, { borderColor: iconColor }]}
+        hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+        accessibilityRole="button"
+        accessibilityLabel={isPlaying ? 'Mettre en pause' : 'Lire le message vocal'}
+      >
+        {isPlaying ? (
+          <Pause size={18} color={iconColor} fill={iconColor} />
+        ) : (
+          <Play size={18} color={iconColor} fill={iconColor} />
+        )}
+      </Pressable>
+
+      <YStack flex={1} gap={2}>
+        {/* Pseudo-waveform : 5 barres décoratives sans amplitude réelle. */}
+        <XStack alignItems="center" gap={2} height={14}>
+          {[6, 10, 14, 8, 12, 9, 11, 7, 13, 8].map((h, i) => (
+            <YStack
+              key={`b-${i}`}
+              width={2}
+              height={h}
+              borderRadius={1}
+              backgroundColor={iconColor}
+              opacity={0.7}
+            />
+          ))}
+        </XStack>
+        <Text fontSize={11} color={textColor}>
+          {isPlaying ? formatMmSs(remaining) : formatMmSs(totalDuration)}
+        </Text>
+      </YStack>
+    </XStack>
+  );
+}
+
+export const VoiceMessage = memo(VoiceMessageComponent);
+
+const styles = StyleSheet.create({
+  playButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    borderWidth: 1.5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/features/messaging/hooks/useSendMessage.ts
+++ b/src/features/messaging/hooks/useSendMessage.ts
@@ -28,6 +28,14 @@ export interface SendMessagePayload {
    * avec celle qui revient via Realtime.
    */
   clientTempId?: string;
+  /**
+   * Type d'attachment. 'text' par défaut. Pour 'image', 'voice', 'video' :
+   * `attachmentUrl` est requis et `content` peut être vide (= pas de caption).
+   * Ajouté par ticket #210 (image) — extensible pour #211 (voice).
+   */
+  attachmentType?: 'text' | 'image' | 'voice' | 'video';
+  /** URL publique de l'attachment (Storage). Requise si attachmentType !== 'text'. */
+  attachmentUrl?: string | null;
 }
 
 interface OptimisticContext {
@@ -44,11 +52,19 @@ export function useSendMessage() {
   const queryClient = useQueryClient();
 
   return useMutation<MessageRow, Error, SendMessagePayload, OptimisticContext>({
-    mutationFn: async ({ conversationId, content }) => {
+    mutationFn: async ({ conversationId, content, attachmentType = 'text', attachmentUrl }) => {
       const trimmed = content.trim();
-      if (trimmed.length === 0) throw new Error('Message vide');
+      const isText = attachmentType === 'text';
+
+      // Pour un message texte, content obligatoire. Pour un attachment, content
+      // optionnel (caption) — la CHECK constraint DB exige juste qu'au moins
+      // `content` OU `attachment_url` soit présent.
+      if (isText && trimmed.length === 0) throw new Error('Message vide');
       if (trimmed.length > MAX_CONTENT_LENGTH) {
         throw new Error(`Message trop long (max ${MAX_CONTENT_LENGTH} caractères)`);
+      }
+      if (!isText && !attachmentUrl) {
+        throw new Error('Attachment URL requise pour ce type de message');
       }
 
       const { data: session, error: sessionError } = await supabase.auth.getSession();
@@ -61,8 +77,9 @@ export function useSendMessage() {
         .insert({
           conversation_id: conversationId,
           sender_id: session.session.user.id,
-          attachment_type: 'text',
-          content: trimmed,
+          attachment_type: attachmentType,
+          content: trimmed.length > 0 ? trimmed : null,
+          attachment_url: attachmentUrl ?? null,
         })
         .select(
           'id, conversation_id, sender_id, attachment_type, content, attachment_url, reply_to_id, created_at, edited_at, deleted_at'
@@ -79,7 +96,13 @@ export function useSendMessage() {
       return data as MessageRow;
     },
 
-    onMutate: async ({ conversationId, content, clientTempId }) => {
+    onMutate: async ({
+      conversationId,
+      content,
+      clientTempId,
+      attachmentType = 'text',
+      attachmentUrl = null,
+    }) => {
       const tempId = clientTempId ?? `temp-${uuidv4()}`;
 
       // Annule les fetchs en cours pour éviter qu'ils écrasent l'optimistic
@@ -95,9 +118,9 @@ export function useSendMessage() {
         id: tempId,
         conversation_id: conversationId,
         sender_id: meId ?? 'unknown',
-        attachment_type: 'text',
-        content: content.trim(),
-        attachment_url: null,
+        attachment_type: attachmentType,
+        content: content.trim().length > 0 ? content.trim() : null,
+        attachment_url: attachmentUrl,
         reply_to_id: null,
         created_at: new Date().toISOString(),
         edited_at: null,

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -45,7 +45,7 @@ import {
 import { useRealtimeConversation } from '@/features/messaging/hooks/useRealtimeConversation';
 import { useSendMessage } from '@/features/messaging/hooks/useSendMessage';
 import { logger } from '@/lib/logger';
-import { uploadMessageImage } from '@/lib/storage';
+import { uploadMessageAudio, uploadMessageImage } from '@/lib/storage';
 import { supabase } from '@/lib/supabase';
 
 export function ConversationScreen() {
@@ -132,6 +132,40 @@ export function ConversationScreen() {
         Alert.alert("Échec de l'upload", msg);
       } finally {
         setIsAttaching(false);
+      }
+    },
+    [convId, sendMessage]
+  );
+
+  // Ticket #211 — envoi vocal.
+  const [isSendingVoice, setIsSendingVoice] = useState(false);
+
+  const handleSendVoice = useCallback(
+    async (audioUri: string, durationSeconds: number) => {
+      if (!convId) return;
+      setIsSendingVoice(true);
+      try {
+        const { publicUrl } = await uploadMessageAudio(audioUri);
+        sendMessage.mutate(
+          {
+            conversationId: convId,
+            content: String(durationSeconds),
+            attachmentType: 'voice',
+            attachmentUrl: publicUrl,
+          },
+          {
+            onError: (err) => {
+              logger.warn('Send voice message failed', { message: err.message });
+              Alert.alert("Échec de l'envoi", err.message);
+            },
+          }
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Upload audio échoué';
+        logger.warn('Upload message audio failed', { message: msg });
+        Alert.alert("Échec de l'upload", msg);
+      } finally {
+        setIsSendingVoice(false);
       }
     },
     [convId, sendMessage]
@@ -349,7 +383,9 @@ export function ConversationScreen() {
           onSend={handleSend}
           onAttach={handleAttach}
           isAttaching={isAttaching}
-          disabled={sendMessage.isPending || isAttaching}
+          onSendVoice={handleSendVoice}
+          isSendingVoice={isSendingVoice}
+          disabled={sendMessage.isPending || isAttaching || isSendingVoice}
         />
         <View style={{ height: insets.bottom }} backgroundColor="$surface" />
       </KeyboardAvoidingView>

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -8,16 +8,18 @@
 //
 // Hors scope bêta (cohérent avec spec recadrée le 02/06/2026) :
 //   - Boutons d'appel audio/vidéo Daily.co (Sprint 6+ tickets #85-88)
-//   - Pièces jointes image/voice/video
+//   - Pièces jointes voice/video (image arrive ticket #210)
 //   - Réponses (reply_to_id)
 
 import { FlashList } from '@shopify/flash-list';
 import { Image } from 'expo-image';
+import * as ImagePicker from 'expo-image-picker';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, CheckCircle2 } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
+  Alert,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -43,6 +45,7 @@ import {
 import { useRealtimeConversation } from '@/features/messaging/hooks/useRealtimeConversation';
 import { useSendMessage } from '@/features/messaging/hooks/useSendMessage';
 import { logger } from '@/lib/logger';
+import { uploadMessageImage } from '@/lib/storage';
 import { supabase } from '@/lib/supabase';
 
 export function ConversationScreen() {
@@ -99,6 +102,84 @@ export function ConversationScreen() {
     },
     [convId, sendMessage]
   );
+
+  // Ticket #210 — pièce jointe image.
+  const [isAttaching, setIsAttaching] = useState(false);
+
+  const handleSendImage = useCallback(
+    async (imageUri: string) => {
+      if (!convId) return;
+      setIsAttaching(true);
+      try {
+        const { publicUrl } = await uploadMessageImage(imageUri);
+        sendMessage.mutate(
+          {
+            conversationId: convId,
+            content: '',
+            attachmentType: 'image',
+            attachmentUrl: publicUrl,
+          },
+          {
+            onError: (err) => {
+              logger.warn('Send image message failed', { message: err.message });
+              Alert.alert("Échec de l'envoi", err.message);
+            },
+          }
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : 'Upload échoué';
+        logger.warn('Upload message image failed', { message: msg });
+        Alert.alert("Échec de l'upload", msg);
+      } finally {
+        setIsAttaching(false);
+      }
+    },
+    [convId, sendMessage]
+  );
+
+  const handleAttach = useCallback(() => {
+    if (isAttaching) return;
+    Alert.alert('Ajouter une image', undefined, [
+      {
+        text: 'Galerie',
+        onPress: async () => {
+          let perm = await ImagePicker.getMediaLibraryPermissionsAsync();
+          if (!perm.granted) perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
+          if (!perm.granted) {
+            Alert.alert('Permission refusée', "Active l'accès aux photos dans Réglages.");
+            return;
+          }
+          const result = await ImagePicker.launchImageLibraryAsync({
+            mediaTypes: ['images'],
+            allowsMultipleSelection: false,
+            quality: 1,
+          });
+          if (result.canceled) return;
+          const asset = result.assets[0];
+          if (asset) await handleSendImage(asset.uri);
+        },
+      },
+      {
+        text: 'Caméra',
+        onPress: async () => {
+          let perm = await ImagePicker.getCameraPermissionsAsync();
+          if (!perm.granted) perm = await ImagePicker.requestCameraPermissionsAsync();
+          if (!perm.granted) {
+            Alert.alert('Permission refusée', "Active l'accès à la caméra dans Réglages.");
+            return;
+          }
+          const result = await ImagePicker.launchCameraAsync({
+            mediaTypes: ['images'],
+            quality: 1,
+          });
+          if (result.canceled) return;
+          const asset = result.assets[0];
+          if (asset) await handleSendImage(asset.uri);
+        },
+      },
+      { text: 'Annuler', style: 'cancel' },
+    ]);
+  }, [handleSendImage, isAttaching]);
 
   const handleLongPressBubble = useCallback((message: MessageRow) => {
     setActionMessage(message);
@@ -264,7 +345,12 @@ export function ConversationScreen() {
           )}
         </View>
 
-        <MessageInput onSend={handleSend} disabled={sendMessage.isPending} />
+        <MessageInput
+          onSend={handleSend}
+          onAttach={handleAttach}
+          isAttaching={isAttaching}
+          disabled={sendMessage.isPending || isAttaching}
+        />
         <View style={{ height: insets.bottom }} backgroundColor="$surface" />
       </KeyboardAvoidingView>
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -373,6 +373,59 @@ export async function uploadPostImage(
 }
 
 // ---------------------------------------------------------------------------
+// Messaging upload (#210)
+// ---------------------------------------------------------------------------
+
+const MESSAGING_BUCKET = 'messaging_media';
+
+export interface UploadMessageImageResult {
+  publicUrl: string;
+  path: string;
+}
+
+/**
+ * Compresse puis upload une image locale dans le bucket `messaging_media`.
+ * Pipeline identique à uploadPostImage : compression côté client (qualité 0.8,
+ * resize 1920px max), upload via SDK Supabase Storage, path `{user_id}/{uuid}.jpg`.
+ */
+export async function uploadMessageImage(
+  uri: string,
+  options?: { signal?: AbortSignal; onProgress?: (p: number) => void; quality?: number }
+): Promise<UploadMessageImageResult> {
+  const quality = clamp01(options?.quality ?? DEFAULT_QUALITY);
+  const signal = options?.signal;
+  const onProgress = options?.onProgress;
+
+  try {
+    if (signal?.aborted) throw abortedError();
+
+    const session = await getFreshSession();
+    const compressedUri = await compressImage(uri, quality);
+    const path = `${session.user.id}/${uuidv4()}.jpg`;
+
+    try {
+      await uploadToStorage(compressedUri, path, MESSAGING_BUCKET, 'image/jpeg', {
+        onProgress,
+        signal,
+      });
+    } finally {
+      await cleanupTempFiles([compressedUri]);
+    }
+
+    const { data } = supabase.storage.from(MESSAGING_BUCKET).getPublicUrl(path);
+    return { publicUrl: data.publicUrl, path };
+  } catch (error) {
+    const uploadError = error instanceof UploadError ? error : new UploadError('upload', error);
+    if (signal?.aborted) {
+      logger.debug('upload_message_image_cancelled');
+    } else {
+      logger.error('upload_message_image_failed', uploadError);
+    }
+    throw uploadError;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Stories upload (E4-12)
 // ---------------------------------------------------------------------------
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -373,7 +373,7 @@ export async function uploadPostImage(
 }
 
 // ---------------------------------------------------------------------------
-// Messaging upload (#210)
+// Messaging upload (#210 image + #211 voice)
 // ---------------------------------------------------------------------------
 
 const MESSAGING_BUCKET = 'messaging_media';
@@ -384,9 +384,9 @@ export interface UploadMessageImageResult {
 }
 
 /**
- * Compresse puis upload une image locale dans le bucket `messaging_media`.
- * Pipeline identique à uploadPostImage : compression côté client (qualité 0.8,
- * resize 1920px max), upload via SDK Supabase Storage, path `{user_id}/{uuid}.jpg`.
+ * Compresse + upload une image dans le bucket `messaging_media`. Pipeline
+ * identique à uploadPostImage (quality 0.8, resize 1920px max). Path :
+ * `{user_id}/{uuid}.jpg`.
  */
 export async function uploadMessageImage(
   uri: string,
@@ -398,11 +398,9 @@ export async function uploadMessageImage(
 
   try {
     if (signal?.aborted) throw abortedError();
-
     const session = await getFreshSession();
     const compressedUri = await compressImage(uri, quality);
     const path = `${session.user.id}/${uuidv4()}.jpg`;
-
     try {
       await uploadToStorage(compressedUri, path, MESSAGING_BUCKET, 'image/jpeg', {
         onProgress,
@@ -411,16 +409,44 @@ export async function uploadMessageImage(
     } finally {
       await cleanupTempFiles([compressedUri]);
     }
-
     const { data } = supabase.storage.from(MESSAGING_BUCKET).getPublicUrl(path);
     return { publicUrl: data.publicUrl, path };
   } catch (error) {
     const uploadError = error instanceof UploadError ? error : new UploadError('upload', error);
-    if (signal?.aborted) {
-      logger.debug('upload_message_image_cancelled');
-    } else {
-      logger.error('upload_message_image_failed', uploadError);
-    }
+    if (signal?.aborted) logger.debug('upload_message_image_cancelled');
+    else logger.error('upload_message_image_failed', uploadError);
+    throw uploadError;
+  }
+}
+
+export interface UploadMessageAudioResult {
+  publicUrl: string;
+  path: string;
+}
+
+/**
+ * Upload un fichier audio (.m4a / AAC produit par expo-audio) dans le bucket
+ * `messaging_media`. Pas de compression côté client (expo-audio produit déjà
+ * de l'AAC compressé). Path : `{user_id}/{uuid}.m4a`.
+ */
+export async function uploadMessageAudio(
+  uri: string,
+  options?: { signal?: AbortSignal; onProgress?: (p: number) => void }
+): Promise<UploadMessageAudioResult> {
+  const signal = options?.signal;
+  const onProgress = options?.onProgress;
+
+  try {
+    if (signal?.aborted) throw abortedError();
+    const session = await getFreshSession();
+    const path = `${session.user.id}/${uuidv4()}.m4a`;
+    await uploadToStorage(uri, path, MESSAGING_BUCKET, 'audio/m4a', { onProgress, signal });
+    const { data } = supabase.storage.from(MESSAGING_BUCKET).getPublicUrl(path);
+    return { publicUrl: data.publicUrl, path };
+  } catch (error) {
+    const uploadError = error instanceof UploadError ? error : new UploadError('upload', error);
+    if (signal?.aborted) logger.debug('upload_message_audio_cancelled');
+    else logger.error('upload_message_audio_failed', uploadError);
     throw uploadError;
   }
 }


### PR DESCRIPTION
## Summary

Implémente le ticket [#211](https://github.com/Waoow-tech/Application/issues/211) — message vocal dans une conversation.

⚠️ **Cette PR inclut aussi les changements de [PR #210](https://github.com/Waoow-tech/DOUMASSI-Application/pull/224)** (cherry-pick) car les 2 features touchent les mêmes fichiers (useSendMessage payload étendu, MessageInput, MessageBubble). Merger #210 en premier puis cette PR ne créera pas de conflit (mêmes commits).

## Changes

### Pipeline upload
- `uploadMessageAudio(uri)` dans `lib/storage.ts` — path `{user_id}/{uuid}.m4a` dans bucket `messaging_media`, pas de compression côté client (expo-audio produit déjà de l'AAC)
- `useSendMessage` (étendu via #210) réutilisé : `attachmentType: 'voice'` + `attachmentUrl`
- Durée en secondes stockée dans `content` (parseInt au render)

### `MessageInput`
- `useAudioRecorder` + `requestRecordingPermissionsAsync` de **expo-audio**
- Bouton micro à droite (remplace Send) quand l'input est vide ET `onSendVoice` fourni
- Tap mic → start recording. **Banner rouge** au-dessus du composer avec timer live (`X s / 60 s`) + **auto-stop à 60s**
- Tap encore → stop + callback `onSendVoice(uri, durationSeconds)`
- Spinner pendant upload+envoi

### `VoiceMessage` (nouveau composant)
- `useAudioPlayer` + `useAudioPlayerStatus`
- **1 player par bulle** (suffisant bêta, optim future = player global partagé avec switch de source)
- Bouton Play/Pause + pseudo-waveform statique 10 barres + durée mm:ss
- Auto-rewind si tap après la fin

### `MessageBubble`
- Rend `VoiceMessage` si `attachment_type='voice'` et `attachment_url` présent
- Skip le rendu de content quand voice (content = durée numérique, pas du texte)
- Image attachment (PR #210) inchangé

### `ConversationScreen`
- `handleSendVoice` : `uploadMessageAudio` → `sendMessage.mutate({ attachmentType: 'voice' })`
- `isSendingVoice` propagé à `MessageInput`
- Erreurs upload/send remontées via Alert

## Décisions vs ticket

| Ticket demande | Choix PR | Raison |
|---|---|---|
| Long-press maintenu pour record | **Tap-toggle** | Plus accessible (Voice Control, motricité réduite), plus simple côté code |
| Swipe-gauche pour annuler | (skip MVP) | UX iOS classique mais complexe à implémenter sans gesture lib spécifique |
| Waveform avec amplitude | **Pseudo-waveform statique** | Suffisant pour signaler "audio". Vraie waveform = follow-up |
| Marquage "écouté" via last_read_at | (skip MVP) | Pas critique pour bêta — last_read_at existant déjà géré |
| Vitesse x1.5 / x2 | (hors scope déjà) | Mentionné dans le ticket comme hors scope |

## Test plan

- [ ] Permission micro refusée : rien ne se passe (silencieux). Améliorer en follow-up (Alert)
- [ ] Tap mic (input vide) → banner rouge + timer s'incrémente
- [ ] Tap mic encore → upload + bulle apparaît avec Play/durée
- [ ] Bulle reçue côté autre user (realtime) : tap Play → audio joue
- [ ] Auto-stop à 60s vérifié (laisser tourner)
- [ ] Pendant upload : bouton mic spinner, autres interactions désactivées
- [ ] Échec upload : Alert d'erreur