### PR TITLE
feat(messaging): UI création groupe conversations (#212)

### DIFF
--- a/app/messages/new.tsx
+++ b/app/messages/new.tsx
@@ -1,19 +1,33 @@
+// Écran « Nouvelle conversation » — DM et Groupe (ticket #212).
+//
+// Toggle en tête pour basculer entre :
+//   - DM (défaut, comportement existant)   : tap user → ouvre/crée DM
+//   - Groupe (ticket #212)                 : champ nom + multi-select +
+//                                            bouton Créer → RPC
+//                                            create_group_conversation
+//
+// La RPC valide côté serveur (nom non vide, ≥1 participant, pas de blocage
+// bilatéral). On bloque côté client le bouton Créer si nom vide ou aucun
+// participant pour éviter l'aller-retour réseau inutile.
+
 import { FlashList } from '@shopify/flash-list';
 import { router, Stack } from 'expo-router';
-import { AlertCircle, ArrowLeft, Search, X } from 'lucide-react-native';
-import { useCallback, useState } from 'react';
-import { StyleSheet } from 'react-native';
+import { AlertCircle, ArrowLeft, Search, Users, X } from 'lucide-react-native';
+import { useCallback, useMemo, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Input, Spinner, Text, XStack, YStack } from 'tamagui';
 
+import { useCreateGroupConversation } from '@/features/messaging/hooks/useCreateGroupConversation';
 import { useGetOrCreateDm } from '@/features/messaging/hooks/useGetOrCreateDm';
 import { UserRow } from '@/features/profile/components/UserRow';
 import { type SearchUserResult, useSearchUsers } from '@/features/profile/hooks/useSearchUsers';
 import { logger } from '@/lib/logger';
 
+type Mode = 'dm' | 'group';
+
 function SearchState({ icon, title }: { icon: 'search' | 'error'; title: string }) {
   const Icon = icon === 'search' ? Search : AlertCircle;
-
   return (
     <YStack flex={1} alignItems="center" justifyContent="center" gap="$3" padding="$6">
       <Icon size={32} color="#A0A0A0" />
@@ -24,19 +38,56 @@ function SearchState({ icon, title }: { icon: 'search' | 'error'; title: string 
   );
 }
 
+function ModeToggle({ mode, onChange }: { mode: Mode; onChange: (m: Mode) => void }) {
+  return (
+    <XStack
+      gap="$1"
+      padding={4}
+      backgroundColor="$surface"
+      borderRadius="$10"
+      marginHorizontal="$4"
+      marginTop="$3"
+    >
+      {(['dm', 'group'] as const).map((m) => (
+        <Pressable
+          key={m}
+          onPress={() => onChange(m)}
+          accessibilityRole="button"
+          accessibilityLabel={m === 'dm' ? 'Nouvelle conversation 1-to-1' : 'Nouveau groupe'}
+          accessibilityState={{ selected: mode === m }}
+          style={[styles.toggleChip, mode === m ? styles.toggleChipActive : null]}
+        >
+          <Text
+            color={mode === m ? '#000000' : '$color'}
+            fontSize={14}
+            fontWeight={mode === m ? '700' : '500'}
+          >
+            {m === 'dm' ? 'Conversation' : 'Groupe'}
+          </Text>
+        </Pressable>
+      ))}
+    </XStack>
+  );
+}
+
 export default function NewMessageRoute() {
   const insets = useSafeAreaInsets();
+  const [mode, setMode] = useState<Mode>('dm');
   const [query, setQuery] = useState('');
   const [selectedUserId, setSelectedUserId] = useState<string | null>(null);
+  const [groupName, setGroupName] = useState('');
+  const [selectedParticipants, setSelectedParticipants] = useState<SearchUserResult[]>([]);
+
   const { users, debouncedQuery, canSearch, isLoading, isError } = useSearchUsers(query);
   const getOrCreateDm = useGetOrCreateDm();
+  const createGroup = useCreateGroupConversation();
 
   const handleBack = useCallback(() => {
     if (router.canGoBack()) router.back();
     else router.replace('/(tabs)/messages');
   }, []);
 
-  const handleSelectUser = useCallback(
+  const handleSelectUserDm = useCallback(
     (user: SearchUserResult) => {
       setSelectedUserId(user.id);
       getOrCreateDm.mutate(user.id, {
@@ -52,20 +103,79 @@ export default function NewMessageRoute() {
     [getOrCreateDm]
   );
 
+  const handleToggleParticipant = useCallback((user: SearchUserResult) => {
+    setSelectedParticipants((prev) =>
+      prev.some((p) => p.id === user.id) ? prev.filter((p) => p.id !== user.id) : [...prev, user]
+    );
+  }, []);
+
+  const handleCreateGroup = useCallback(() => {
+    createGroup.mutate(
+      {
+        name: groupName,
+        participantIds: selectedParticipants.map((u) => u.id),
+      },
+      {
+        onSuccess: (conversationId) => {
+          router.replace(`/messages/${conversationId}`);
+        },
+        onError: (err) => {
+          logger.warn('Create group failed', { message: err.message });
+        },
+      }
+    );
+  }, [createGroup, groupName, selectedParticipants]);
+
   const renderUser = useCallback(
-    ({ item }: { item: SearchUserResult }) => (
-      <UserRow
-        user={item}
-        onPress={() => handleSelectUser(item)}
-        rightSlot={selectedUserId === item.id ? <Spinner size="small" color="$color" /> : null}
-      />
-    ),
-    [handleSelectUser, selectedUserId]
+    ({ item }: { item: SearchUserResult }) => {
+      if (mode === 'dm') {
+        return (
+          <UserRow
+            user={item}
+            onPress={() => handleSelectUserDm(item)}
+            rightSlot={selectedUserId === item.id ? <Spinner size="small" color="$color" /> : null}
+          />
+        );
+      }
+      const isSelected = selectedParticipants.some((p) => p.id === item.id);
+      return (
+        <UserRow
+          user={item}
+          onPress={() => handleToggleParticipant(item)}
+          rightSlot={
+            isSelected ? (
+              <XStack
+                width={24}
+                height={24}
+                borderRadius={12}
+                backgroundColor="$accentNeon"
+                alignItems="center"
+                justifyContent="center"
+              >
+                <Text fontSize={14} color="#000000" fontWeight="700">
+                  ✓
+                </Text>
+              </XStack>
+            ) : null
+          }
+        />
+      );
+    },
+    [mode, selectedUserId, selectedParticipants, handleSelectUserDm, handleToggleParticipant]
   );
 
   const keyExtractor = useCallback((item: SearchUserResult) => item.id, []);
   const showEmptyState = !canSearch;
   const showNoResults = canSearch && !isLoading && !isError && users.length === 0;
+
+  const canCreateGroup = useMemo(
+    () =>
+      mode === 'group' &&
+      groupName.trim().length > 0 &&
+      selectedParticipants.length > 0 &&
+      !createGroup.isPending,
+    [createGroup.isPending, groupName, mode, selectedParticipants.length]
+  );
 
   return (
     <>
@@ -90,9 +200,55 @@ export default function NewMessageRoute() {
             <ArrowLeft size={24} color="#FFFFFF" />
           </Button>
           <Text color="$color" fontSize={18} fontWeight="700">
-            Nouvelle conversation
+            {mode === 'dm' ? 'Nouvelle conversation' : 'Nouveau groupe'}
           </Text>
         </XStack>
+
+        <ModeToggle mode={mode} onChange={setMode} />
+
+        {mode === 'group' ? (
+          <YStack paddingHorizontal="$4" paddingTop="$3" gap="$2">
+            <Input
+              placeholder="Nom du groupe"
+              placeholderTextColor="$placeholderColor"
+              value={groupName}
+              onChangeText={setGroupName}
+              maxLength={80}
+              backgroundColor="$surface"
+              borderWidth={0}
+              borderRadius="$md"
+              color="$color"
+              height={44}
+              paddingHorizontal="$3"
+              fontSize={15}
+              accessibilityLabel="Nom du groupe"
+            />
+            {selectedParticipants.length > 0 ? (
+              <ScrollView
+                horizontal
+                showsHorizontalScrollIndicator={false}
+                style={styles.chipsScroll}
+              >
+                <XStack gap="$2" paddingVertical="$2">
+                  {selectedParticipants.map((p) => (
+                    <Pressable
+                      key={p.id}
+                      onPress={() => handleToggleParticipant(p)}
+                      accessibilityRole="button"
+                      accessibilityLabel={`Retirer @${p.username}`}
+                      style={styles.chip}
+                    >
+                      <Text color="#FFFFFF" fontSize={13} fontWeight="600">
+                        @{p.username}
+                      </Text>
+                      <X size={14} color="#FFFFFF" />
+                    </Pressable>
+                  ))}
+                </XStack>
+              </ScrollView>
+            ) : null}
+          </YStack>
+        ) : null}
 
         <YStack paddingHorizontal="$4" paddingTop="$3" paddingBottom="$3">
           <XStack
@@ -105,25 +261,27 @@ export default function NewMessageRoute() {
           >
             <Search size={20} color="#A0A0A0" />
             <Input
-              id="new-message-search-users-input"
               flex={1}
               height={48}
               borderWidth={0}
               backgroundColor="transparent"
               color="$color"
-              placeholder="Rechercher un utilisateur..."
+              placeholder={
+                mode === 'dm' ? 'Rechercher un utilisateur...' : 'Ajouter des membres...'
+              }
               placeholderTextColor="$placeholderColor"
               autoCapitalize="none"
               autoCorrect={false}
-              autoFocus
               value={query}
               onChangeText={setQuery}
               paddingHorizontal={0}
               fontSize={16}
+              accessibilityLabel={
+                mode === 'dm' ? 'Rechercher un utilisateur' : 'Rechercher pour ajouter au groupe'
+              }
             />
             {query.length > 0 ? (
               <Button
-                id="new-message-search-users-clear-button"
                 circular
                 size="$2.5"
                 chromeless
@@ -138,7 +296,14 @@ export default function NewMessageRoute() {
         </YStack>
 
         {showEmptyState ? (
-          <SearchState icon="search" title="Recherchez par username ou nom" />
+          <SearchState
+            icon="search"
+            title={
+              mode === 'dm'
+                ? 'Recherchez par username ou nom'
+                : 'Recherchez et tape sur les membres pour les ajouter'
+            }
+          />
         ) : isLoading ? (
           <YStack flex={1} alignItems="center" justifyContent="center">
             <Spinner size="large" color="$color" />
@@ -157,13 +322,75 @@ export default function NewMessageRoute() {
             contentContainerStyle={styles.listContent}
           />
         )}
+
+        {mode === 'group' ? (
+          <YStack
+            paddingHorizontal="$4"
+            paddingTop="$2"
+            paddingBottom={insets.bottom + 12}
+            borderTopWidth={StyleSheet.hairlineWidth}
+            borderTopColor="$borderColor"
+            backgroundColor="$background"
+          >
+            {createGroup.isError ? (
+              <Text color="$danger" fontSize={13} marginBottom="$2" textAlign="center">
+                {createGroup.error?.message ?? 'Création échouée'}
+              </Text>
+            ) : null}
+            <Button
+              onPress={handleCreateGroup}
+              disabled={!canCreateGroup}
+              backgroundColor={canCreateGroup ? '$accentNeon' : '$surface'}
+              color={canCreateGroup ? '#000000' : '$textSecondary'}
+              fontWeight="700"
+              size="$5"
+              borderRadius="$10"
+              accessibilityRole="button"
+              accessibilityLabel="Créer le groupe"
+              accessibilityState={{ disabled: !canCreateGroup }}
+            >
+              <Users size={18} color={canCreateGroup ? '#000000' : '#A0A0A0'} />
+              <Text
+                fontSize={15}
+                fontWeight="700"
+                color={canCreateGroup ? '#000000' : '$textSecondary'}
+              >
+                {createGroup.isPending
+                  ? 'Création…'
+                  : `Créer le groupe (${selectedParticipants.length})`}
+              </Text>
+            </Button>
+          </YStack>
+        ) : null}
       </YStack>
     </>
   );
 }
 
 const styles = StyleSheet.create({
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    backgroundColor: '#10D970',
+    borderRadius: 9999,
+  },
+  chipsScroll: {
+    maxHeight: 50,
+  },
   listContent: {
     paddingBottom: 24,
+  },
+  toggleChip: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 9999,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  toggleChipActive: {
+    backgroundColor: '#10D970',
   },
 });

--- a/src/features/messaging/hooks/useCreateGroupConversation.ts
+++ b/src/features/messaging/hooks/useCreateGroupConversation.ts
@@ -1,0 +1,46 @@
+// useCreateGroupConversation — Sprint 6, ticket #212.
+//
+// Wrapper TanStack autour de la RPC `create_group_conversation(name, ids[])`
+// livrée Sprint 0 (cf migration 20260602120000_messaging_schema.sql). Retourne
+// l'UUID de la conversation créée. Refuse côté RPC si un participant a un
+// blocage bilatéral avec moi.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export interface CreateGroupPayload {
+  name: string;
+  participantIds: string[];
+}
+
+export function useCreateGroupConversation() {
+  const queryClient = useQueryClient();
+
+  return useMutation<string, Error, CreateGroupPayload>({
+    mutationFn: async ({ name, participantIds }) => {
+      const trimmed = name.trim();
+      if (trimmed.length === 0) throw new Error('Le nom du groupe est requis');
+      if (trimmed.length > 80) throw new Error('Nom trop long (max 80 caractères)');
+      if (participantIds.length === 0) throw new Error('Sélectionne au moins un participant');
+
+      const { data, error } = await supabase.rpc('create_group_conversation', {
+        p_name: trimmed,
+        p_participant_ids: participantIds,
+      });
+
+      if (error) {
+        logger.warn('create_group_conversation failed', { message: error.message });
+        throw error;
+      }
+      if (typeof data !== 'string') {
+        throw new Error('Réponse RPC invalide');
+      }
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['conversations', 'my'] });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Implémente la création de groupes conversations dans l'écran « Nouvelle conversation ». RPC `create_group_conversation(name, ids[])` était déjà livrée Sprint 0 (cf migration `20260602120000_messaging_schema.sql`).

## Changes

### `useCreateGroupConversation` (nouveau hook)
- Wrapper TanStack autour de la RPC
- Validation client : nom ≤ 80 char, ≥ 1 participant
- Refus serveur si blocage bilatéral avec un participant (géré par la RPC)
- Invalidation `['conversations', 'my']` à succès

### `app/messages/new.tsx` (refacto)
- **Toggle pill** en haut : « Conversation » / « Groupe »
- **Mode DM** : comportement existant inchangé
- **Mode Groupe** :
  - Input « Nom du groupe »
  - Multi-select via tap des `UserRow` (checkmark vert si sélectionné)
  - **Chips** horizontaux scrollables des participants (X pour retirer)
  - Bouton sticky bottom « Créer le groupe (N) » avec icône Users
  - Désactivé si nom vide ou aucun participant
  - Message d'erreur sous le bouton si échec RPC

`ConversationRow` et `useConversationHeader` gèrent déjà `is_group` côté existant. La liste conversations affichera donc le nom du groupe + icône Users automatiquement après cette PR.

## Hors scope (follow-up)

- Quitter un groupe via kebab menu de `ConversationScreen`
- Renommer le groupe (admin uniquement)
- Ajouter/retirer membres après création
- Affichage avatar + username du sender dans les bulles d'un groupe (`MessageBubble` n'a pas encore le concept)

## Test plan

- [ ] Tab Messages → "+" → écran new
- [ ] Toggle "Groupe" → champ nom + checkmarks apparaissent
- [ ] Tap 3 users → chips apparaissent
- [ ] Tap chip → retire du groupe
- [ ] Bouton "Créer le groupe (3)" → push dans la conversation
- [ ] Conversation visible dans la liste avec le nom + icône groupe (déjà géré par ConversationRow existant)
- [ ] Si nom vide ou 0 participant : bouton grisé
- [ ] Si participant a un blocage bilatéral : message d'erreur RPC (déjà géré par la RPC)