### PR TITLE
feat(messaging): UI réponses dans messages (#209)

### DIFF
--- a/src/features/messaging/components/MessageActionSheet.tsx
+++ b/src/features/messaging/components/MessageActionSheet.tsx
@@ -1,11 +1,15 @@
-// MessageActionSheet — E6-03.
+// MessageActionSheet — E6-03 + #209 (Répondre).
 //
-// Sheet contextuel qui s'ouvre au long-press sur une bulle "à moi".
-// Propose : Modifier (texte seulement), Supprimer.
-// Édition : passe en mode `editing` qui remplace le sheet par un input
+// Sheet contextuel ouvert au long-press sur une bulle. Selon le message et
+// la prop reçue, propose :
+//   - Répondre (toutes bulles non supprimées, si `onReply` fourni)
+//   - Modifier (seulement mes bulles texte)
+//   - Supprimer (seulement mes bulles)
+//
+// Édition : passe en mode `editing` qui remplace le menu par un input
 // pré-rempli + bouton de validation.
 
-import { Edit3, Trash2 } from 'lucide-react-native';
+import { CornerUpLeft, Edit3, Trash2 } from 'lucide-react-native';
 import { useCallback, useEffect, useState } from 'react';
 import { Alert, Pressable, StyleSheet } from 'react-native';
 import { Button, Sheet, Spinner, Text, TextArea, XStack, YStack } from 'tamagui';
@@ -14,10 +18,14 @@ import type { MessageRow } from '../hooks/useConversationMessages';
 
 export interface MessageActionSheetProps {
   message: MessageRow | null;
+  /** Vrai si le message ciblé est de l'user courant (active Modifier/Supprimer). */
+  isMine?: boolean;
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onEdit: (messageId: string, newContent: string) => Promise<void>;
   onDelete: (messageId: string) => Promise<void>;
+  /** Ticket #209 — option "Répondre" en tête du menu. Appelle setReplyTo côté parent. */
+  onReply?: (message: MessageRow) => void;
   editIsPending?: boolean;
   deleteIsPending?: boolean;
 }
@@ -26,10 +34,12 @@ const MAX_CONTENT_LENGTH = 4000;
 
 export function MessageActionSheet({
   message,
+  isMine = false,
   open,
   onOpenChange,
   onEdit,
   onDelete,
+  onReply,
   editIsPending = false,
   deleteIsPending = false,
 }: MessageActionSheetProps) {
@@ -45,7 +55,16 @@ export function MessageActionSheet({
   }, [open, message]);
 
   const isText = message?.attachment_type === 'text';
-  const canEdit = isText && message?.content;
+  const isDeleted = message?.deleted_at != null;
+  const canEdit = isMine && isText && message?.content;
+  const canDelete = isMine && !isDeleted;
+  const canReply = !!onReply && !isDeleted && message != null;
+
+  const handleReply = useCallback(() => {
+    if (!message || !onReply) return;
+    onReply(message);
+    onOpenChange(false);
+  }, [message, onOpenChange, onReply]);
 
   const handleStartEdit = useCallback(() => {
     if (!message?.content) return;
@@ -117,20 +136,49 @@ export function MessageActionSheet({
 
         {mode === 'menu' ? (
           <YStack gap="$2">
+            {canReply ? (
+              <Pressable
+                onPress={handleReply}
+                style={styles.row}
+                accessibilityRole="button"
+                accessibilityLabel="Répondre à ce message"
+              >
+                <CornerUpLeft size={20} color="#FFFFFF" />
+                <Text color="$color" fontSize={16}>
+                  Répondre
+                </Text>
+              </Pressable>
+            ) : null}
             {canEdit ? (
-              <Pressable onPress={handleStartEdit} style={styles.row}>
+              <Pressable
+                onPress={handleStartEdit}
+                style={styles.row}
+                accessibilityRole="button"
+                accessibilityLabel="Modifier ce message"
+              >
                 <Edit3 size={20} color="#FFFFFF" />
                 <Text color="$color" fontSize={16}>
                   Modifier
                 </Text>
               </Pressable>
             ) : null}
-            <Pressable onPress={handleDelete} style={styles.row}>
-              {deleteIsPending ? <Spinner color="#FF3B30" /> : <Trash2 size={20} color="#FF3B30" />}
-              <Text color="$danger" fontSize={16} fontWeight="600">
-                Supprimer
-              </Text>
-            </Pressable>
+            {canDelete ? (
+              <Pressable
+                onPress={handleDelete}
+                style={styles.row}
+                accessibilityRole="button"
+                accessibilityLabel="Supprimer ce message"
+              >
+                {deleteIsPending ? (
+                  <Spinner color="#FF3B30" />
+                ) : (
+                  <Trash2 size={20} color="#FF3B30" />
+                )}
+                <Text color="$danger" fontSize={16} fontWeight="600">
+                  Supprimer
+                </Text>
+              </Pressable>
+            ) : null}
           </YStack>
         ) : (
           <YStack gap="$3">

--- a/src/features/messaging/components/MessageBubble.tsx
+++ b/src/features/messaging/components/MessageBubble.tsx
@@ -1,15 +1,20 @@
-// MessageBubble — E6-03 + ticket #210 (image attachment).
+// MessageBubble — E6-03 + ticket #210 (image) + #211 (voice) + #209 (reply).
 //
 // Affichage d'un message dans la liste. Bulle à droite si c'est moi, à
 // gauche sinon. Gère plusieurs états :
 //   - normal : contenu texte + horodatage relatif
 //   - edited : ajoute « modifié » à côté de l'horodatage
 //   - deleted : remplace le contenu par « 🚫 Message supprimé » en italique
-//   - image : affiche une thumbnail 220×260 contentFit cover, content
-//     optionnel rendu en dessous (caption)
-// Long-press sur ma propre bulle → ouvre la sheet d'actions (parent).
+//   - image : thumbnail 220×260 contentFit cover, caption optionnel dessous
+//   - voice : mini player Play/Pause + durée
+//   - reply : encart cliquable au-dessus du contenu avec auteur + preview
+//     du message parent. Tap → onReplyPress(parentId) (le parent scroll).
+//
+// Long-press sur N'IMPORTE QUELLE bulle non-supprimée → ouvre la sheet
+// d'actions (le parent gère l'affichage conditionnel selon `isMine`).
 
 import { Image } from 'expo-image';
+import { CornerUpLeft } from 'lucide-react-native';
 import { memo, useCallback } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { Text, XStack, YStack } from 'tamagui';
@@ -41,22 +46,53 @@ function formatTime(iso: string): string {
   });
 }
 
+export interface ReplyParentPreview {
+  /** ID du parent (utilisé pour scroll). */
+  id: string;
+  /** Auteur formaté (`@username` ou "votre message"). */
+  authorLabel: string;
+  /** Texte preview (50 char), ou label d'attachment ("Photo", "Vocal"). */
+  preview: string;
+  /** Vrai si le parent est soft-deleted → l'encart affiche "Message supprimé". */
+  isDeleted: boolean;
+}
+
 export interface MessageBubbleProps {
   message: MessageRow;
   isMine: boolean;
+  /**
+   * Preview du message parent si `message.reply_to_id !== null`. Le parent
+   * (ConversationScreen) doit le résoudre en cherchant dans la liste flat.
+   */
+  replyParent?: ReplyParentPreview | null;
+  /** Tap sur l'encart de réponse → scroll vers le parent. */
+  onReplyPress?: (parentMessageId: string) => void;
   onLongPress?: (message: MessageRow) => void;
 }
 
-function MessageBubbleComponent({ message, isMine, onLongPress }: MessageBubbleProps) {
+function MessageBubbleComponent({
+  message,
+  isMine,
+  replyParent,
+  onReplyPress,
+  onLongPress,
+}: MessageBubbleProps) {
   const isDeleted = message.deleted_at !== null;
   const isEdited = message.edited_at !== null;
   const isOptimistic = message.id.startsWith('temp-');
   const isFailed = message.id.startsWith('failed-');
 
+  // #209 — long-press autorisé sur TOUTES les bulles non supprimées (pas
+  // juste les miennes), pour permettre "Répondre" sur les messages des autres.
   const handleLongPress = useCallback(() => {
-    if (!isMine || isDeleted) return;
+    if (isDeleted || isOptimistic || isFailed) return;
     onLongPress?.(message);
-  }, [isMine, isDeleted, onLongPress, message]);
+  }, [isDeleted, isOptimistic, isFailed, onLongPress, message]);
+
+  const handleReplyPress = useCallback(() => {
+    if (!message.reply_to_id || !onReplyPress) return;
+    onReplyPress(message.reply_to_id);
+  }, [message.reply_to_id, onReplyPress]);
 
   return (
     <XStack
@@ -78,6 +114,43 @@ function MessageBubbleComponent({ message, isMine, onLongPress }: MessageBubbleP
         ]}
       >
         <YStack gap={6}>
+          {message.reply_to_id && replyParent ? (
+            <Pressable
+              onPress={handleReplyPress}
+              accessibilityRole="button"
+              accessibilityLabel={`Aller au message de ${replyParent.authorLabel}`}
+              style={[
+                styles.replyEmbed,
+                {
+                  backgroundColor: isMine ? 'rgba(0,0,0,0.18)' : 'rgba(255,255,255,0.06)',
+                  borderLeftColor: isMine ? '#000000' : '#10D970',
+                },
+              ]}
+            >
+              <XStack alignItems="center" gap={6}>
+                <CornerUpLeft size={12} color={isMine ? '#000000' : '#10D970'} />
+                <Text fontSize={12} fontWeight="700" color={isMine ? COLORS.myText : '#10D970'}>
+                  {replyParent.authorLabel}
+                </Text>
+              </XStack>
+              <Text
+                fontSize={13}
+                color={
+                  replyParent.isDeleted
+                    ? isMine
+                      ? 'rgba(0,0,0,0.5)'
+                      : COLORS.deletedText
+                    : isMine
+                      ? 'rgba(0,0,0,0.75)'
+                      : COLORS.metaText
+                }
+                fontStyle={replyParent.isDeleted ? 'italic' : 'normal'}
+                numberOfLines={2}
+              >
+                {replyParent.isDeleted ? '🚫 Message supprimé' : replyParent.preview}
+              </Text>
+            </Pressable>
+          ) : null}
           {isDeleted ? (
             <Text
               fontSize={14}
@@ -164,6 +237,14 @@ const styles = StyleSheet.create({
     height: 260,
     borderRadius: 12,
     backgroundColor: '#2A2A2A',
+  },
+  replyEmbed: {
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderLeftWidth: 3,
+    gap: 2,
+    marginBottom: 2,
   },
 });
 

--- a/src/features/messaging/components/MessageInput.tsx
+++ b/src/features/messaging/components/MessageInput.tsx
@@ -13,7 +13,7 @@
 // Send désactivé si vide, whitespace only, ou > 5 mentions dans le message.
 
 import { RecordingPresets, requestRecordingPermissionsAsync, useAudioRecorder } from 'expo-audio';
-import { Mic, Plus, Send, StopCircle } from 'lucide-react-native';
+import { CornerUpLeft, Mic, Plus, Send, StopCircle, X } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, StyleSheet } from 'react-native';
 import { Text, TextArea, XStack, YStack } from 'tamagui';
@@ -42,8 +42,22 @@ export interface MessageInputProps {
   onSendVoice?: (uri: string, durationSeconds: number) => Promise<void> | void;
   /** Vrai pendant l'upload/send vocal — bloque toute autre interaction. */
   isSendingVoice?: boolean;
+  /**
+   * Ticket #209 — message en cours de réponse. Affiche un encart sticky au-dessus
+   * du composer avec preview du message ciblé + bouton X pour annuler.
+   */
+  replyingTo?: ReplyingPreview | null;
+  /** Appelé quand l'utilisateur tape sur la croix de l'encart de réponse. */
+  onCancelReply?: () => void;
   disabled?: boolean;
   placeholder?: string;
+}
+
+export interface ReplyingPreview {
+  /** Auteur formaté (`@username` ou "votre message"). */
+  authorLabel: string;
+  /** 50 premiers caractères du message ciblé (ou label d'attachment). */
+  preview: string;
 }
 
 const MAX_LINES = 6;
@@ -57,6 +71,8 @@ export function MessageInput({
   isAttaching = false,
   onSendVoice,
   isSendingVoice = false,
+  replyingTo,
+  onCancelReply,
   disabled = false,
   placeholder = 'Écrire un message…',
 }: MessageInputProps) {
@@ -187,6 +203,37 @@ export function MessageInput({
       borderTopWidth={StyleSheet.hairlineWidth}
       borderTopColor="$borderColor"
     >
+      {replyingTo ? (
+        <XStack
+          paddingHorizontal="$3"
+          paddingVertical="$2"
+          gap="$3"
+          alignItems="center"
+          backgroundColor="rgba(16,217,112,0.10)"
+          borderTopWidth={StyleSheet.hairlineWidth}
+          borderTopColor="$borderColor"
+        >
+          <CornerUpLeft size={16} color="#10D970" />
+          <YStack flex={1} minWidth={0}>
+            <Text fontSize={12} color="$accentNeon" fontWeight="700">
+              Réponse à {replyingTo.authorLabel}
+            </Text>
+            <Text fontSize={13} color="$textSecondary" numberOfLines={1}>
+              {replyingTo.preview}
+            </Text>
+          </YStack>
+          {onCancelReply ? (
+            <Pressable
+              onPress={onCancelReply}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Annuler la réponse"
+            >
+              <X size={18} color="#A0A0A0" />
+            </Pressable>
+          ) : null}
+        </XStack>
+      ) : null}
       <MentionSuggestionsList
         suggestions={suggestions}
         isLoading={isLoading}

--- a/src/features/messaging/hooks/useSendMessage.ts
+++ b/src/features/messaging/hooks/useSendMessage.ts
@@ -36,6 +36,12 @@ export interface SendMessagePayload {
   attachmentType?: 'text' | 'image' | 'voice' | 'video';
   /** URL publique de l'attachment (Storage). Requise si attachmentType !== 'text'. */
   attachmentUrl?: string | null;
+  /**
+   * ID du message auquel on répond. Ticket #209 — UI réponses.
+   * Si présent, le INSERT pose `reply_to_id` pour rendre la bulle avec un
+   * encart "réponse à X" cliquable.
+   */
+  replyToId?: string | null;
 }
 
 interface OptimisticContext {
@@ -52,7 +58,13 @@ export function useSendMessage() {
   const queryClient = useQueryClient();
 
   return useMutation<MessageRow, Error, SendMessagePayload, OptimisticContext>({
-    mutationFn: async ({ conversationId, content, attachmentType = 'text', attachmentUrl }) => {
+    mutationFn: async ({
+      conversationId,
+      content,
+      attachmentType = 'text',
+      attachmentUrl,
+      replyToId,
+    }) => {
       const trimmed = content.trim();
       const isText = attachmentType === 'text';
 
@@ -80,6 +92,7 @@ export function useSendMessage() {
           attachment_type: attachmentType,
           content: trimmed.length > 0 ? trimmed : null,
           attachment_url: attachmentUrl ?? null,
+          reply_to_id: replyToId ?? null,
         })
         .select(
           'id, conversation_id, sender_id, attachment_type, content, attachment_url, reply_to_id, created_at, edited_at, deleted_at'
@@ -102,6 +115,7 @@ export function useSendMessage() {
       clientTempId,
       attachmentType = 'text',
       attachmentUrl = null,
+      replyToId = null,
     }) => {
       const tempId = clientTempId ?? `temp-${uuidv4()}`;
 
@@ -121,7 +135,7 @@ export function useSendMessage() {
         attachment_type: attachmentType,
         content: content.trim().length > 0 ? content.trim() : null,
         attachment_url: attachmentUrl,
-        reply_to_id: null,
+        reply_to_id: replyToId,
         created_at: new Date().toISOString(),
         edited_at: null,
         deleted_at: null,

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -8,15 +8,15 @@
 //
 // Hors scope bêta (cohérent avec spec recadrée le 02/06/2026) :
 //   - Boutons d'appel audio/vidéo Daily.co (Sprint 6+ tickets #85-88)
-//   - Pièces jointes voice/video (image arrive ticket #210)
-//   - Réponses (reply_to_id)
+//   - Voice/video : voice livré #211
+//   - Réponses : livré #209 (state replyingTo + scroll vers parent)
 
-import { FlashList } from '@shopify/flash-list';
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { ArrowLeft, CheckCircle2 } from 'lucide-react-native';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -30,8 +30,11 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text, View, XStack, YStack } from 'tamagui';
 
 import { MessageActionSheet } from '@/features/messaging/components/MessageActionSheet';
-import { MessageBubble } from '@/features/messaging/components/MessageBubble';
-import { MessageInput } from '@/features/messaging/components/MessageInput';
+import {
+  MessageBubble,
+  type ReplyParentPreview,
+} from '@/features/messaging/components/MessageBubble';
+import { MessageInput, type ReplyingPreview } from '@/features/messaging/components/MessageInput';
 import { useConversationHeader } from '@/features/messaging/hooks/useConversationHeader';
 import {
   type MessageRow,
@@ -65,6 +68,9 @@ export function ConversationScreen() {
   const [actionSheetOpen, setActionSheetOpen] = useState(false);
   const [actionMessage, setActionMessage] = useState<MessageRow | null>(null);
   const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+  // Ticket #209 — message en cours de réponse (sélectionné via ActionSheet).
+  const [replyingTo, setReplyingTo] = useState<MessageRow | null>(null);
+  const listRef = useRef<FlashListRef<MessageRow>>(null);
 
   // Récupère mon user_id au mount pour identifier les bulles "à moi"
   useEffect(() => {
@@ -88,19 +94,61 @@ export function ConversationScreen() {
     return messagesQuery.data?.pages.flatMap((p) => p.messages) ?? [];
   }, [messagesQuery.data]);
 
+  // Ticket #209 — index id→message pour résoudre les parents en O(1) au
+  // moment du rendu des bulles.
+  const messagesById = useMemo(() => {
+    const map = new Map<string, MessageRow>();
+    for (const m of messages) map.set(m.id, m);
+    return map;
+  }, [messages]);
+
+  /** Construit le preview à afficher dans l'encart "Réponse à" ou la bulle. */
+  const buildReplyPreview = useCallback(
+    (parent: MessageRow): { authorLabel: string; preview: string; isDeleted: boolean } => {
+      const isParentMine = parent.sender_id === meId;
+      const isDeleted = parent.deleted_at !== null;
+      let preview: string;
+      if (parent.attachment_type === 'image') {
+        preview = '📷 Photo';
+      } else if (parent.attachment_type === 'voice') {
+        preview = '🎙️ Message vocal';
+      } else if (parent.attachment_type === 'video') {
+        preview = '🎬 Vidéo';
+      } else {
+        preview = (parent.content ?? '').slice(0, 50);
+      }
+      // Pour les DMs, on connaît le display_name de l'autre via le header. Pour
+      // les groupes, on n'a pas encore le username par sender (chantier follow-up
+      // post-#209) — on utilise "@un membre" comme placeholder.
+      const otherLabel = headerQuery.data?.display_name
+        ? `@${headerQuery.data.display_name}`
+        : '@un membre';
+      return {
+        authorLabel: isParentMine ? 'votre message' : otherLabel,
+        preview,
+        isDeleted,
+      };
+    },
+    [headerQuery.data?.display_name, meId]
+  );
+
   const handleSend = useCallback(
     (content: string) => {
       if (!convId) return;
+      const replyToId = replyingTo?.id ?? null;
       sendMessage.mutate(
-        { conversationId: convId, content },
+        { conversationId: convId, content, replyToId },
         {
           onError: (err) => {
             logger.warn('Send message failed', { message: err.message });
           },
         }
       );
+      // On reset l'état de réponse immédiatement (UX) — si l'envoi échoue,
+      // la bulle apparaît en "failed" mais le composer est libre pour autre chose.
+      setReplyingTo(null);
     },
-    [convId, sendMessage]
+    [convId, replyingTo, sendMessage]
   );
 
   // Ticket #210 — pièce jointe image.
@@ -110,6 +158,7 @@ export function ConversationScreen() {
     async (imageUri: string) => {
       if (!convId) return;
       setIsAttaching(true);
+      const replyToId = replyingTo?.id ?? null;
       try {
         const { publicUrl } = await uploadMessageImage(imageUri);
         sendMessage.mutate(
@@ -118,6 +167,7 @@ export function ConversationScreen() {
             content: '',
             attachmentType: 'image',
             attachmentUrl: publicUrl,
+            replyToId,
           },
           {
             onError: (err) => {
@@ -132,9 +182,10 @@ export function ConversationScreen() {
         Alert.alert("Échec de l'upload", msg);
       } finally {
         setIsAttaching(false);
+        setReplyingTo(null);
       }
     },
-    [convId, sendMessage]
+    [convId, replyingTo, sendMessage]
   );
 
   // Ticket #211 — envoi vocal.
@@ -144,6 +195,7 @@ export function ConversationScreen() {
     async (audioUri: string, durationSeconds: number) => {
       if (!convId) return;
       setIsSendingVoice(true);
+      const replyToId = replyingTo?.id ?? null;
       try {
         const { publicUrl } = await uploadMessageAudio(audioUri);
         sendMessage.mutate(
@@ -152,6 +204,7 @@ export function ConversationScreen() {
             content: String(durationSeconds),
             attachmentType: 'voice',
             attachmentUrl: publicUrl,
+            replyToId,
           },
           {
             onError: (err) => {
@@ -166,9 +219,10 @@ export function ConversationScreen() {
         Alert.alert("Échec de l'upload", msg);
       } finally {
         setIsSendingVoice(false);
+        setReplyingTo(null);
       }
     },
-    [convId, sendMessage]
+    [convId, replyingTo, sendMessage]
   );
 
   const handleAttach = useCallback(() => {
@@ -220,6 +274,43 @@ export function ConversationScreen() {
     setActionSheetOpen(true);
   }, []);
 
+  // Ticket #209 — réponses.
+  const handleReplyFromSheet = useCallback((message: MessageRow) => {
+    setReplyingTo(message);
+  }, []);
+
+  const handleCancelReply = useCallback(() => {
+    setReplyingTo(null);
+  }, []);
+
+  /**
+   * Scroll vers le message parent dans la liste. La liste est INVERTED
+   * (la plus récente en haut), donc l'index 0 = bas visuel du composer.
+   * Si le parent n'est pas dans les pages déjà chargées, on signale via Alert
+   * (charger plus en arrière nécessiterait un fetchNextPage en boucle — pas
+   * dans le scope MVP).
+   */
+  const handleScrollToParent = useCallback(
+    (parentId: string) => {
+      const index = messages.findIndex((m) => m.id === parentId);
+      if (index === -1) {
+        Alert.alert(
+          'Message non chargé',
+          'Le message parent est trop ancien. Faites défiler vers le haut puis réessayez.'
+        );
+        return;
+      }
+      listRef.current?.scrollToIndex({ index, animated: true, viewPosition: 0.5 });
+    },
+    [messages]
+  );
+
+  const replyingPreview = useMemo<ReplyingPreview | null>(() => {
+    if (!replyingTo) return null;
+    const { authorLabel, preview } = buildReplyPreview(replyingTo);
+    return { authorLabel, preview: preview || '...' };
+  }, [buildReplyPreview, replyingTo]);
+
   const handleEdit = useCallback(
     async (messageId: string, newContent: string) => {
       await editMessage.mutateAsync({ messageId, newContent });
@@ -252,14 +343,34 @@ export function ConversationScreen() {
   }, [messagesQuery]);
 
   const renderMessage = useCallback(
-    ({ item }: { item: MessageRow }) => (
-      <MessageBubble
-        message={item}
-        isMine={item.sender_id === meId}
-        onLongPress={handleLongPressBubble}
-      />
-    ),
-    [meId, handleLongPressBubble]
+    ({ item }: { item: MessageRow }) => {
+      let replyParent: ReplyParentPreview | null = null;
+      if (item.reply_to_id) {
+        const parent = messagesById.get(item.reply_to_id);
+        if (parent) {
+          const { authorLabel, preview, isDeleted } = buildReplyPreview(parent);
+          replyParent = { id: parent.id, authorLabel, preview, isDeleted };
+        } else {
+          // Parent pas dans les pages chargées : on rend l'encart en mode "déchargé".
+          replyParent = {
+            id: item.reply_to_id,
+            authorLabel: 'Message',
+            preview: 'Faire défiler pour voir le message original…',
+            isDeleted: false,
+          };
+        }
+      }
+      return (
+        <MessageBubble
+          message={item}
+          isMine={item.sender_id === meId}
+          replyParent={replyParent}
+          onReplyPress={handleScrollToParent}
+          onLongPress={handleLongPressBubble}
+        />
+      );
+    },
+    [buildReplyPreview, handleLongPressBubble, handleScrollToParent, meId, messagesById]
   );
 
   // Header
@@ -346,6 +457,7 @@ export function ConversationScreen() {
             </YStack>
           ) : (
             <FlashList
+              ref={listRef}
               data={messages}
               renderItem={renderMessage}
               keyExtractor={(item) => item.id}
@@ -385,6 +497,8 @@ export function ConversationScreen() {
           isAttaching={isAttaching}
           onSendVoice={handleSendVoice}
           isSendingVoice={isSendingVoice}
+          replyingTo={replyingPreview}
+          onCancelReply={handleCancelReply}
           disabled={sendMessage.isPending || isAttaching || isSendingVoice}
         />
         <View style={{ height: insets.bottom }} backgroundColor="$surface" />
@@ -393,10 +507,12 @@ export function ConversationScreen() {
       {/* Sheet d'actions sur long-press */}
       <MessageActionSheet
         message={actionMessage}
+        isMine={actionMessage?.sender_id === meId}
         open={actionSheetOpen}
         onOpenChange={setActionSheetOpen}
         onEdit={handleEdit}
         onDelete={handleDelete}
+        onReply={handleReplyFromSheet}
         editIsPending={editMessage.isPending}
         deleteIsPending={deleteMessage.isPending}
       />


### PR DESCRIPTION
## Summary

Implémente le ticket [#209](https://github.com/Waoow-tech/Application/issues/209) (assigné Ilias initialement, repris pour avancer). Le schéma DB support (\`messages.reply_to_id\`) était déjà en place via PR #192.

## Changes

### \`useSendMessage\`
- Payload étendu avec \`replyToId?: string | null\`
- INSERT pose \`reply_to_id\` si fourni
- Optimistic update propage \`reply_to_id\` dans la bulle temp pour rendu immédiat de l'encart

### \`MessageActionSheet\`
- Nouvelle option **« Répondre »** (icône \`CornerUpLeft\`) en tête du menu, visible pour TOUTES les bulles non supprimées (mine + autres) si \`onReply\` fourni
- Les options Modifier / Supprimer restent conditionnées sur \`isMine\`
- \`onReply(message)\` → \`setReplyingTo\` côté parent + ferme le sheet

### \`MessageInput\`
- Nouveaux props \`replyingTo?: ReplyingPreview | null\` + \`onCancelReply\`
- Si \`replyingTo\` : encart sticky au-dessus du composer (fond accent translucide, barre verte, auteur + preview 50 char ou label d'attachment, bouton X)

### \`MessageBubble\`
- Nouveaux props \`replyParent?: ReplyParentPreview | null\` + \`onReplyPress\`
- Si \`reply_to_id\` ET \`replyParent\` fourni : encart cliquable au-dessus du contenu avec auteur + preview, fond translucide + barre latérale
- Si \`parent.isDeleted\` : encart affiche **« 🚫 Message supprimé »** en italique
- Long-press autorisé sur toutes les bulles non-deleted/optimistic/failed (avant : seulement les miennes) pour permettre « Répondre » sur les autres

### \`ConversationScreen\`
- State \`replyingTo: MessageRow | null\` + ref \`FlashListRef<MessageRow>\`
- Index \`messagesById: Map<id, MessageRow>\` pour résoudre les parents en **O(1)** au rendu
- \`buildReplyPreview\` avec fallback intelligent pour attachments (📷 Photo, 🎙️ Message vocal, 🎬 Vidéo)
- \`handleScrollToParent\` : \`findIndex\` + \`scrollToIndex({ animated, viewPosition: 0.5 })\`. Si parent pas chargé → \`Alert.alert\` invitant à scroll plus haut
- \`handleSend\` / \`handleSendImage\` / \`handleSendVoice\` : inclut \`replyToId\` + reset \`replyingTo\` après envoi

## Critères du ticket

| Critère | Status |
|---|---|
| Long-press bulle d'un autre → option "Répondre" | ✅ |
| Tap "Répondre" → encart au-dessus de MessageInput + X | ✅ |
| Envoi → INSERT avec reply_to_id | ✅ |
| Encart cliquable dans bulle avec auteur + 50 char | ✅ |
| Tap encart → scroll vers parent | ✅ |
| Parent soft-deleted → "Message supprimé" dans l'encart | ✅ |
| Compatible texte ET attachments (image/voice avec replyToId) | ✅ (bonus — le ticket ne limitait qu'au texte) |

## Hors scope (cohérent avec le ticket)

- Réponse à une réponse (chaînage profond) — l'encart reste à plat
- Notification spéciale "X a répondu à votre message" — pour V2
- **Note groupes** : l'\`authorLabel\` des bulles "autres" affiche "@un membre" en l'absence de mapping \`sender_id → username\` dans la liste (chantier follow-up — pour les DM, on utilise \`display_name\` du header)

## Test plan

- [ ] DM 1-to-1 : long-press sur une bulle de l'autre → option "Répondre" en haut + Modifier/Supprimer absents
- [ ] Long-press sur ma bulle → "Répondre" + Modifier + Supprimer
- [ ] Tap "Répondre" → encart au-dessus de MessageInput avec auteur + preview
- [ ] Tap croix → encart disparaît, replyingTo reset
- [ ] Envoyer texte → bulle apparaît avec l'encart "réponse à" au-dessus, encart sticky disparait
- [ ] Envoyer image ou vocal après "Répondre" → la bulle attachment a l'encart
- [ ] Tap sur l'encart de réponse dans une bulle → la liste scroll vers le parent (centré)
- [ ] Si parent trop ancien (pas chargé) → Alert
- [ ] Si parent soft-deleted → encart affiche "Message supprimé"