### PR TITLE
feat(messaging): avatar + username du sender dans les bulles de groupe

### DIFF
--- a/src/features/messaging/components/MessageBubble.tsx
+++ b/src/features/messaging/components/MessageBubble.tsx
@@ -14,7 +14,7 @@
 // d'actions (le parent gère l'affichage conditionnel selon `isMine`).
 
 import { Image } from 'expo-image';
-import { CornerUpLeft } from 'lucide-react-native';
+import { CornerUpLeft, User as UserIcon } from 'lucide-react-native';
 import { memo, useCallback } from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import { Text, XStack, YStack } from 'tamagui';
@@ -57,9 +57,25 @@ export interface ReplyParentPreview {
   isDeleted: boolean;
 }
 
+export interface SenderPreview {
+  username: string;
+  avatar_url: string | null;
+}
+
 export interface MessageBubbleProps {
   message: MessageRow;
   isMine: boolean;
+  /**
+   * Vrai si la conversation est un groupe. Dans ce cas, on affiche
+   * l'avatar + le username au-dessus des bulles des AUTRES participants
+   * (style WhatsApp/Telegram), pour identifier qui parle.
+   */
+  isGroup?: boolean;
+  /**
+   * Profile du sender. Pour les bulles "à moi" : non utilisé. Pour les bulles
+   * "autres" en groupe : on l'affiche au-dessus de la bulle.
+   */
+  senderProfile?: SenderPreview | null;
   /**
    * Preview du message parent si `message.reply_to_id !== null`. Le parent
    * (ConversationScreen) doit le résoudre en cherchant dans la liste flat.
@@ -73,6 +89,8 @@ export interface MessageBubbleProps {
 function MessageBubbleComponent({
   message,
   isMine,
+  isGroup = false,
+  senderProfile,
   replyParent,
   onReplyPress,
   onLongPress,
@@ -94,132 +112,171 @@ function MessageBubbleComponent({
     onReplyPress(message.reply_to_id);
   }, [message.reply_to_id, onReplyPress]);
 
+  // En groupe ET pour les bulles des autres, on affiche un mini-avatar + le
+  // username (style WhatsApp). On wrap l'XStack original dans un autre XStack
+  // qui aligne avatar | (username + bulle).
+  const showSenderHeader = isGroup && !isMine;
+
   return (
     <XStack
       paddingHorizontal="$3"
       paddingVertical={3}
       justifyContent={isMine ? 'flex-end' : 'flex-start'}
+      alignItems="flex-end"
+      gap={6}
     >
-      <Pressable
-        onLongPress={handleLongPress}
-        delayLongPress={350}
-        style={[
-          styles.bubble,
-          {
-            backgroundColor: isMine ? COLORS.myBubble : COLORS.otherBubble,
-            borderBottomRightRadius: isMine ? 4 : 18,
-            borderBottomLeftRadius: isMine ? 18 : 4,
-            opacity: isOptimistic || isFailed ? 0.6 : 1,
-          },
-        ]}
-      >
-        <YStack gap={6}>
-          {message.reply_to_id && replyParent ? (
-            <Pressable
-              onPress={handleReplyPress}
-              accessibilityRole="button"
-              accessibilityLabel={`Aller au message de ${replyParent.authorLabel}`}
-              style={[
-                styles.replyEmbed,
-                {
-                  backgroundColor: isMine ? 'rgba(0,0,0,0.18)' : 'rgba(255,255,255,0.06)',
-                  borderLeftColor: isMine ? '#000000' : '#10D970',
-                },
-              ]}
-            >
-              <XStack alignItems="center" gap={6}>
-                <CornerUpLeft size={12} color={isMine ? '#000000' : '#10D970'} />
-                <Text fontSize={12} fontWeight="700" color={isMine ? COLORS.myText : '#10D970'}>
-                  {replyParent.authorLabel}
-                </Text>
-              </XStack>
-              <Text
-                fontSize={13}
-                color={
-                  replyParent.isDeleted
-                    ? isMine
-                      ? 'rgba(0,0,0,0.5)'
-                      : COLORS.deletedText
-                    : isMine
-                      ? 'rgba(0,0,0,0.75)'
-                      : COLORS.metaText
-                }
-                fontStyle={replyParent.isDeleted ? 'italic' : 'normal'}
-                numberOfLines={2}
-              >
-                {replyParent.isDeleted ? '🚫 Message supprimé' : replyParent.preview}
-              </Text>
-            </Pressable>
-          ) : null}
-          {isDeleted ? (
-            <Text
-              fontSize={14}
-              fontStyle="italic"
-              color={isMine ? COLORS.myText : COLORS.deletedText}
-            >
-              🚫 Message supprimé
-            </Text>
+      {showSenderHeader ? (
+        <YStack
+          width={28}
+          height={28}
+          borderRadius={9999}
+          backgroundColor="$surface"
+          overflow="hidden"
+          alignItems="center"
+          justifyContent="center"
+          marginBottom={2}
+        >
+          {senderProfile?.avatar_url ? (
+            <Image
+              source={{ uri: senderProfile.avatar_url }}
+              style={styles.senderAvatarImage}
+              contentFit="cover"
+            />
           ) : (
-            <>
-              {message.attachment_type === 'image' && message.attachment_url ? (
-                <Image
-                  source={{ uri: message.attachment_url }}
-                  style={styles.imageAttachment}
-                  contentFit="cover"
-                  transition={150}
-                  recyclingKey={message.id}
-                  accessibilityLabel="Image envoyée"
-                />
-              ) : null}
-              {message.attachment_type === 'voice' && message.attachment_url ? (
-                <VoiceMessage
-                  audioUrl={message.attachment_url}
-                  durationSeconds={
-                    message.content ? Number.parseInt(message.content, 10) || undefined : undefined
-                  }
-                  textColor={isMine ? COLORS.myText : COLORS.otherText}
-                  iconColor={isMine ? COLORS.myText : '#10D970'}
-                />
-              ) : null}
-              {message.attachment_type !== 'voice' && message.content ? (
-                <MentionsText
-                  content={message.content}
-                  style={{
-                    fontSize: 15,
-                    lineHeight: 20,
-                    color: isMine ? COLORS.myText : COLORS.otherText,
-                  }}
-                  mentionColor={isMine ? COLORS.myText : '#10D970'}
-                  mentionUnderline={isMine}
-                />
-              ) : null}
-            </>
+            <UserIcon size={14} color="#A0A0A0" />
           )}
-
-          <XStack gap={4} alignItems="center" justifyContent="flex-end">
-            {isFailed ? (
-              <Text fontSize={11} color="#FF3B30" fontWeight="600">
-                Échec — taper pour réessayer
+        </YStack>
+      ) : null}
+      <YStack flex={0} maxWidth="78%" gap={2}>
+        {showSenderHeader && senderProfile ? (
+          <Text fontSize={12} fontWeight="700" color="$accentNeon" paddingLeft={4}>
+            @{senderProfile.username}
+          </Text>
+        ) : null}
+        <Pressable
+          onLongPress={handleLongPress}
+          delayLongPress={350}
+          style={[
+            styles.bubble,
+            showSenderHeader ? { maxWidth: undefined } : null,
+            {
+              backgroundColor: isMine ? COLORS.myBubble : COLORS.otherBubble,
+              borderBottomRightRadius: isMine ? 4 : 18,
+              borderBottomLeftRadius: isMine ? 18 : 4,
+              opacity: isOptimistic || isFailed ? 0.6 : 1,
+            },
+          ]}
+        >
+          <YStack gap={6}>
+            {message.reply_to_id && replyParent ? (
+              <Pressable
+                onPress={handleReplyPress}
+                accessibilityRole="button"
+                accessibilityLabel={`Aller au message de ${replyParent.authorLabel}`}
+                style={[
+                  styles.replyEmbed,
+                  {
+                    backgroundColor: isMine ? 'rgba(0,0,0,0.18)' : 'rgba(255,255,255,0.06)',
+                    borderLeftColor: isMine ? '#000000' : '#10D970',
+                  },
+                ]}
+              >
+                <XStack alignItems="center" gap={6}>
+                  <CornerUpLeft size={12} color={isMine ? '#000000' : '#10D970'} />
+                  <Text fontSize={12} fontWeight="700" color={isMine ? COLORS.myText : '#10D970'}>
+                    {replyParent.authorLabel}
+                  </Text>
+                </XStack>
+                <Text
+                  fontSize={13}
+                  color={
+                    replyParent.isDeleted
+                      ? isMine
+                        ? 'rgba(0,0,0,0.5)'
+                        : COLORS.deletedText
+                      : isMine
+                        ? 'rgba(0,0,0,0.75)'
+                        : COLORS.metaText
+                  }
+                  fontStyle={replyParent.isDeleted ? 'italic' : 'normal'}
+                  numberOfLines={2}
+                >
+                  {replyParent.isDeleted ? '🚫 Message supprimé' : replyParent.preview}
+                </Text>
+              </Pressable>
+            ) : null}
+            {isDeleted ? (
+              <Text
+                fontSize={14}
+                fontStyle="italic"
+                color={isMine ? COLORS.myText : COLORS.deletedText}
+              >
+                🚫 Message supprimé
               </Text>
             ) : (
               <>
-                {isEdited && !isDeleted ? (
-                  <Text
-                    fontSize={11}
-                    color={isMine ? 'rgba(0,0,0,0.55)' : COLORS.metaText}
-                    fontStyle="italic"
-                  >
-                    modifié
-                  </Text>
+                {message.attachment_type === 'image' && message.attachment_url ? (
+                  <Image
+                    source={{ uri: message.attachment_url }}
+                    style={styles.imageAttachment}
+                    contentFit="cover"
+                    transition={150}
+                    recyclingKey={message.id}
+                    accessibilityLabel="Image envoyée"
+                  />
                 ) : null}
-                <Text fontSize={11} color={isMine ? 'rgba(0,0,0,0.55)' : COLORS.metaText}>
-                  {formatTime(message.created_at)}
-                </Text>
+                {message.attachment_type === 'voice' && message.attachment_url ? (
+                  <VoiceMessage
+                    audioUrl={message.attachment_url}
+                    durationSeconds={
+                      message.content
+                        ? Number.parseInt(message.content, 10) || undefined
+                        : undefined
+                    }
+                    textColor={isMine ? COLORS.myText : COLORS.otherText}
+                    iconColor={isMine ? COLORS.myText : '#10D970'}
+                  />
+                ) : null}
+                {message.attachment_type !== 'voice' && message.content ? (
+                  <MentionsText
+                    content={message.content}
+                    style={{
+                      fontSize: 15,
+                      lineHeight: 20,
+                      color: isMine ? COLORS.myText : COLORS.otherText,
+                    }}
+                    mentionColor={isMine ? COLORS.myText : '#10D970'}
+                    mentionUnderline={isMine}
+                  />
+                ) : null}
               </>
             )}
-          </XStack>
-        </YStack>
-      </Pressable>
+
+            <XStack gap={4} alignItems="center" justifyContent="flex-end">
+              {isFailed ? (
+                <Text fontSize={11} color="#FF3B30" fontWeight="600">
+                  Échec — taper pour réessayer
+                </Text>
+              ) : (
+                <>
+                  {isEdited && !isDeleted ? (
+                    <Text
+                      fontSize={11}
+                      color={isMine ? 'rgba(0,0,0,0.55)' : COLORS.metaText}
+                      fontStyle="italic"
+                    >
+                      modifié
+                    </Text>
+                  ) : null}
+                  <Text fontSize={11} color={isMine ? 'rgba(0,0,0,0.55)' : COLORS.metaText}>
+                    {formatTime(message.created_at)}
+                  </Text>
+                </>
+              )}
+            </XStack>
+          </YStack>
+        </Pressable>
+      </YStack>
     </XStack>
   );
 }
@@ -245,6 +302,10 @@ const styles = StyleSheet.create({
     borderLeftWidth: 3,
     gap: 2,
     marginBottom: 2,
+  },
+  senderAvatarImage: {
+    width: 28,
+    height: 28,
   },
 });
 

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/features/messaging/hooks/useMessageActions';
 import { useRealtimeConversation } from '@/features/messaging/hooks/useRealtimeConversation';
 import { useSendMessage } from '@/features/messaging/hooks/useSendMessage';
+import { useProfilesByIds } from '@/features/profile/hooks/useProfilesByIds';
 import { logger } from '@/lib/logger';
 import { uploadMessageAudio, uploadMessageImage } from '@/lib/storage';
 import { supabase } from '@/lib/supabase';
@@ -102,6 +103,14 @@ export function ConversationScreen() {
     return map;
   }, [messages]);
 
+  // Follow-up #212/#209 — résolution des senders en batch (1 query).
+  const senderIds = useMemo(
+    () => Array.from(new Set(messages.map((m) => m.sender_id).filter((id) => id !== meId))),
+    [meId, messages]
+  );
+  const { profilesById } = useProfilesByIds(senderIds);
+  const isGroup = headerQuery.data?.is_group ?? false;
+
   /** Construit le preview à afficher dans l'encart "Réponse à" ou la bulle. */
   const buildReplyPreview = useCallback(
     (parent: MessageRow): { authorLabel: string; preview: string; isDeleted: boolean } => {
@@ -117,19 +126,25 @@ export function ConversationScreen() {
       } else {
         preview = (parent.content ?? '').slice(0, 50);
       }
-      // Pour les DMs, on connaît le display_name de l'autre via le header. Pour
-      // les groupes, on n'a pas encore le username par sender (chantier follow-up
-      // post-#209) — on utilise "@un membre" comme placeholder.
-      const otherLabel = headerQuery.data?.display_name
-        ? `@${headerQuery.data.display_name}`
-        : '@un membre';
+      // Résolution du username depuis le batch profilesById (follow-up #212).
+      // Fallback sur display_name du header pour les DMs si le profile n'est
+      // pas encore chargé, puis "@un membre" en dernier recours.
+      const senderProfile = profilesById.get(parent.sender_id);
+      let otherLabel: string;
+      if (senderProfile?.username) {
+        otherLabel = `@${senderProfile.username}`;
+      } else if (headerQuery.data?.display_name && !headerQuery.data.is_group) {
+        otherLabel = `@${headerQuery.data.display_name}`;
+      } else {
+        otherLabel = '@un membre';
+      }
       return {
         authorLabel: isParentMine ? 'votre message' : otherLabel,
         preview,
         isDeleted,
       };
     },
-    [headerQuery.data?.display_name, meId]
+    [headerQuery.data?.display_name, headerQuery.data?.is_group, meId, profilesById]
   );
 
   const handleSend = useCallback(
@@ -344,6 +359,8 @@ export function ConversationScreen() {
 
   const renderMessage = useCallback(
     ({ item }: { item: MessageRow }) => {
+      const isMine = item.sender_id === meId;
+      const senderProfile = !isMine ? profilesById.get(item.sender_id) : undefined;
       let replyParent: ReplyParentPreview | null = null;
       if (item.reply_to_id) {
         const parent = messagesById.get(item.reply_to_id);
@@ -363,14 +380,28 @@ export function ConversationScreen() {
       return (
         <MessageBubble
           message={item}
-          isMine={item.sender_id === meId}
+          isMine={isMine}
+          isGroup={isGroup}
+          senderProfile={
+            senderProfile
+              ? { username: senderProfile.username, avatar_url: senderProfile.avatar_url }
+              : null
+          }
           replyParent={replyParent}
           onReplyPress={handleScrollToParent}
           onLongPress={handleLongPressBubble}
         />
       );
     },
-    [buildReplyPreview, handleLongPressBubble, handleScrollToParent, meId, messagesById]
+    [
+      buildReplyPreview,
+      handleLongPressBubble,
+      handleScrollToParent,
+      isGroup,
+      meId,
+      messagesById,
+      profilesById,
+    ]
   );
 
   // Header

--- a/src/features/profile/hooks/useProfilesByIds.ts
+++ b/src/features/profile/hooks/useProfilesByIds.ts
@@ -1,0 +1,65 @@
+// useProfilesByIds — Sprint 6 follow-up #212/#209.
+//
+// Récupère en batch les profils (username, full_name, avatar_url) pour une
+// liste d'`ids` distincts. Utilisé par ConversationScreen pour résoudre
+// `sender_id → username/avatar` sans toucher au SELECT côté messages (qui
+// passerait par PostgREST embed) ni au payload Realtime (qui ne supporte pas
+// les joins).
+//
+// Retourne une Map `id → profile` pour résolution O(1) au render des bulles.
+// Si `ids` est vide, ne fait pas de query (canQuery = false).
+
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export interface ProfilePreview {
+  id: string;
+  username: string;
+  full_name: string | null;
+  avatar_url: string | null;
+}
+
+export function useProfilesByIds(ids: string[]) {
+  // Stabilise la clé : on dédup + on trie pour éviter les invalidations
+  // inutiles à chaque re-render qui ajoute/réorganise des messages.
+  const stableIds = useMemo(() => Array.from(new Set(ids)).sort(), [ids]);
+  const canQuery = stableIds.length > 0;
+
+  const query = useQuery({
+    queryKey: ['profiles', 'by-ids', stableIds],
+    enabled: canQuery,
+    queryFn: async (): Promise<ProfilePreview[]> => {
+      const { data, error } = await supabase
+        .from('profiles')
+        .select('id, username, full_name, avatar_url')
+        .in('id', stableIds);
+      if (error) {
+        logger.warn('useProfilesByIds failed', { message: error.message });
+        throw error;
+      }
+      return ((data ?? []) as Record<string, unknown>[]).map((row) => ({
+        id: String(row.id ?? ''),
+        username: String(row.username ?? ''),
+        full_name: (row.full_name as string | null) ?? null,
+        avatar_url: (row.avatar_url as string | null) ?? null,
+      }));
+    },
+    // 5min : un profil change rarement et on accepte un léger décalage.
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const profilesById = useMemo(() => {
+    const map = new Map<string, ProfilePreview>();
+    for (const p of query.data ?? []) map.set(p.id, p);
+    return map;
+  }, [query.data]);
+
+  return {
+    profilesById,
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up des PRs **#226 (groupes)** et **#228 (réponses)**. Complète deux manques notés "follow-up" dans ces PRs :

1. **Critère de #212** : « Bulles : afficher l'avatar + username de chaque sender » — pas implémenté dans la PR initiale car `MessageRow` n'expose pas le sender_username/avatar.
2. **Label des réponses #209** : pour les groupes, l'`authorLabel` des bulles "autres" affichait `"@un membre"` au lieu du vrai username.

## Changes

### `useProfilesByIds` (nouveau hook)
- Récupère **en batch** (1 query `.in('id', ids)`) les profils pour une liste d'ids distincts
- Retourne `Map<id, ProfilePreview>` pour résolution **O(1)** au render
- `staleTime: 5min` — un profil change rarement
- **Approche cliente** plutôt que SQL/Realtime : le payload Postgres Realtime ne supporte pas les joins, donc joindre côté `useConversationMessages` serait perdu sur les messages reçus en live

### `MessageBubble`
- Nouveaux props `isGroup?: boolean` + `senderProfile?: SenderPreview | null`
- Si **`!isMine` ET `isGroup`** : mini-avatar 28px à gauche de la bulle + username en vert au-dessus (style WhatsApp/Telegram)
- Layout repensé : `XStack(avatar | YStack(username, bulle))` avec `alignItems="flex-end"`

### `ConversationScreen`
- `senderIds` calculé depuis `messages` (set distinct, filter `meId`)
- `useProfilesByIds(senderIds)` → `profilesById`
- `isGroup` tiré de `headerQuery.data.is_group`
- `renderMessage` passe `isGroup` + `senderProfile` à `MessageBubble`
- `buildReplyPreview` résout l'`authorLabel` via `profilesById` en priorité, puis `display_name` du header pour les DMs, puis `"@un membre"` en dernier recours

## Test plan

- [ ] DM 1-to-1 : aucune différence visuelle (les avatars/usernames ne sont affichés QUE pour les groupes)
- [ ] Groupe avec 3+ membres : chaque bulle des autres a son mini-avatar 28px + username vert au-dessus
- [ ] Mes bulles dans un groupe : pas d'avatar/username (style WhatsApp inchangé)
- [ ] Encart "Réponse à" dans un groupe : l'`authorLabel` affiche le vrai `@username` du sender ciblé (pas "@un membre")
- [ ] Bulle avec encart de réponse cliquable : tap → scroll vers parent fonctionne toujours
- [ ] Performance : avec 50 messages d'un groupe à 5 membres → 1 seule query profiles batch