### PR TITLE
feat(calls): finalisation MVP appels — #233, #234, #235, #236

### DIFF
--- a/app.json
+++ b/app.json
@@ -30,7 +30,9 @@
         "android.permission.MODIFY_AUDIO_SETTINGS",
         "android.permission.FOREGROUND_SERVICE",
         "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK",
-        "android.permission.POST_NOTIFICATIONS"
+        "android.permission.POST_NOTIFICATIONS",
+        "android.permission.BLUETOOTH_CONNECT",
+        "android.permission.WAKE_LOCK"
       ],
       "package": "com.doumassi.app",
       "intentFilters": [

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -4,6 +4,7 @@
 
 import { Redirect, Tabs } from 'expo-router';
 import { Bell, Hash, Home, Send, User } from 'lucide-react-native';
+import { useEffect, useState } from 'react';
 import { Platform, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -12,8 +13,10 @@ import { PendingDeletionModal } from '@/features/auth/components/PendingDeletion
 import { useAuthGuard } from '@/features/auth/hooks/useAuthGuard';
 import { usePendingDeletionReminder } from '@/features/auth/hooks/usePendingDeletionReminder';
 import { usePushToken } from '@/features/auth/hooks/usePushToken';
+import { useIncomingCallListener } from '@/features/calls/hooks/useIncomingCallListener';
 import { useNotificationsUnreadCount } from '@/features/notifications/hooks/useNotifications';
 import { usePushNotificationsHandler } from '@/features/notifications/hooks/usePushNotificationsHandler';
+import { supabase } from '@/lib/supabase';
 
 const ACTIVE_COLOR = '#FFFFFF';
 const INACTIVE_COLOR = '#A0A0A0';
@@ -55,6 +58,18 @@ function AuthenticatedTabs() {
   // s'affiche 1× par session si une `deletion_requests` active existe pour
   // l'user courant.
   const deletionReminder = usePendingDeletionReminder();
+
+  // Ticket #233 : listener Realtime pour les appels entrants. Quand un autre
+  // user crée un call dans une de mes conversations → push vers l'écran
+  // ringtone (Accept/Decline).
+  const [meId, setMeId] = useState<string | null>(null);
+  useEffect(() => {
+    void (async () => {
+      const { data } = await supabase.auth.getSession();
+      setMeId(data.session?.user.id ?? null);
+    })();
+  }, []);
+  useIncomingCallListener(meId);
 
   // Tab bar dynamique : on remonte la barre de la zone safe area système
   // (gesture navigation Android moderne + home indicator iOS). Sans ça,

--- a/app/call/incoming/[id].tsx
+++ b/app/call/incoming/[id].tsx
@@ -1,0 +1,239 @@
+// IncomingCallScreen — Ticket #233 (E6-C4).
+//
+// Plein écran ringtone. Affiche l'avatar + le nom du caller + Accept (vert)
+// / Decline (rouge). Auto-timeout à 30s → status='missed'.
+//
+// Pour MVP : pas de son ringtone (à ajouter follow-up si gros besoin UX).
+// Vibration nope non plus — éviter de demander une perm de plus pour MVP.
+//
+// Pour générer un token client : on rappelle l'Edge Function create-daily-call
+// ?? NON — la room et le token initiator existent côté serveur, mais le
+// destinataire a besoin de SON propre meeting token. Pour MVP, on rappelle
+// l'Edge Function en passant le conversation_id ET un flag `join_existing`...
+// MAIS simplifié : on génère juste un meeting token à part via une 2e Edge
+// Function `join-daily-call` (TODO follow-up). En attendant, on accepte
+// l'appel en navigant vers /call/[id] avec le roomUrl partagé et un token
+// vide → Daily.co accepte les rooms publiques sans token aussi (selon le
+// niveau de sécu config en serveur).
+//
+// LIMITE MVP : on passe le roomUrl directement (room créée publique côté
+// Edge Function — pas de protection token strict pour le destinataire).
+// À renforcer post-bêta avec Edge Function `join-daily-call`.
+
+import { router, useLocalSearchParams } from 'expo-router';
+import { StatusBar } from 'expo-status-bar';
+import { Phone, PhoneOff, User as UserIcon } from 'lucide-react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { Animated, Easing, Pressable, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+import { useConversationHeader } from '@/features/messaging/hooks/useConversationHeader';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+const RING_TIMEOUT_MS = 30_000;
+
+export default function IncomingCallScreen() {
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{
+    id: string;
+    conversationId: string;
+    callType: 'audio' | 'video';
+    roomUrl: string;
+  }>();
+
+  const callId = typeof params.id === 'string' ? params.id : null;
+  const conversationId = typeof params.conversationId === 'string' ? params.conversationId : null;
+  const callType = params.callType === 'video' ? 'video' : 'audio';
+  const roomUrl = typeof params.roomUrl === 'string' ? params.roomUrl : null;
+
+  // Header du DM pour avatar + display_name
+  const header = useConversationHeader(conversationId).data;
+
+  const [decided, setDecided] = useState(false);
+
+  // Animation pulse simple sur l'avatar pour signaler l'appel
+  const pulse = useState(() => new Animated.Value(1))[0];
+  useEffect(() => {
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, {
+          toValue: 1.15,
+          duration: 700,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulse, {
+          toValue: 1,
+          duration: 700,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [pulse]);
+
+  // Update status d'un call via RPC end_call (réutilise la RPC existante,
+  // qui accepte n'importe quelle valeur de call_status valide).
+  const updateCallStatus = useCallback(
+    async (status: 'rejected' | 'missed' | 'accepted') => {
+      if (!callId) return;
+      try {
+        const { error } = await supabase.rpc('end_call', {
+          p_call_id: callId,
+          p_status: status,
+        });
+        if (error) logger.warn('Incoming call status update failed', { message: error.message });
+      } catch (e) {
+        logger.warn('Incoming call RPC threw', {
+          message: e instanceof Error ? e.message : String(e),
+        });
+      }
+    },
+    [callId]
+  );
+
+  // Auto-timeout 30s → missed
+  useEffect(() => {
+    if (decided) return undefined;
+    const timer = setTimeout(() => {
+      if (decided) return;
+      void updateCallStatus('missed');
+      if (router.canGoBack()) router.back();
+      else router.replace('/(tabs)/messages');
+    }, RING_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [decided, updateCallStatus]);
+
+  const handleAccept = useCallback(() => {
+    if (decided || !roomUrl || !callId) return;
+    setDecided(true);
+    // On marque le call accepted, puis on navigue vers le screen call
+    // standard avec le roomUrl reçu. Note MVP : pas de token destinataire
+    // (room créée sans token strict — limite documentée dans le commentaire
+    // de header). À renforcer post-bêta.
+    void updateCallStatus('accepted');
+    router.replace({
+      pathname: '/call/[id]',
+      params: {
+        id: callId,
+        roomUrl,
+        token: '', // MVP : pas de token destinataire (cf header note)
+        callType,
+        isInitiator: '0',
+      },
+    });
+  }, [callId, callType, decided, roomUrl, updateCallStatus]);
+
+  const handleDecline = useCallback(() => {
+    if (decided) return;
+    setDecided(true);
+    void updateCallStatus('rejected');
+    if (router.canGoBack()) router.back();
+    else router.replace('/(tabs)/messages');
+  }, [decided, updateCallStatus]);
+
+  const displayName = header?.display_name ?? 'Appel entrant';
+  const initial = displayName.charAt(0).toUpperCase() || '?';
+
+  return (
+    <View flex={1} backgroundColor="#000000">
+      <StatusBar style="light" />
+
+      {/* Header texte */}
+      <YStack
+        position="absolute"
+        top={insets.top + 60}
+        left={0}
+        right={0}
+        alignItems="center"
+        gap={6}
+      >
+        <Text color="#A0A0A0" fontSize={14}>
+          {callType === 'video' ? 'Appel vidéo entrant' : 'Appel audio entrant'}
+        </Text>
+        <Text color="#FFFFFF" fontSize={26} fontWeight="800">
+          {displayName}
+        </Text>
+      </YStack>
+
+      {/* Avatar pulsant au centre */}
+      <View flex={1} alignItems="center" justifyContent="center">
+        <Animated.View style={{ transform: [{ scale: pulse }] }}>
+          <YStack
+            width={160}
+            height={160}
+            borderRadius={9999}
+            backgroundColor="#1A1A1A"
+            borderWidth={3}
+            borderColor="#10D970"
+            alignItems="center"
+            justifyContent="center"
+          >
+            {header?.display_avatar_url ? (
+              // expo-image serait mieux mais on garde minimal pour MVP
+              <Text color="#FFFFFF" fontSize={56} fontWeight="800">
+                {initial}
+              </Text>
+            ) : (
+              <UserIcon size={64} color="#A0A0A0" />
+            )}
+          </YStack>
+        </Animated.View>
+      </View>
+
+      {/* Boutons Decline / Accept */}
+      <XStack
+        position="absolute"
+        bottom={insets.bottom + 60}
+        left={0}
+        right={0}
+        justifyContent="space-around"
+        alignItems="center"
+      >
+        <Pressable
+          onPress={handleDecline}
+          disabled={decided}
+          style={styles.declineButton}
+          accessibilityRole="button"
+          accessibilityLabel="Refuser l'appel"
+          accessibilityHint="Tap pour refuser cet appel entrant"
+        >
+          <PhoneOff size={32} color="#FFFFFF" />
+        </Pressable>
+        <Pressable
+          onPress={handleAccept}
+          disabled={decided}
+          style={styles.acceptButton}
+          accessibilityRole="button"
+          accessibilityLabel="Accepter l'appel"
+          accessibilityHint={`Tap pour répondre à l'appel ${callType === 'video' ? 'vidéo' : 'audio'}`}
+        >
+          <Phone size={32} color="#FFFFFF" />
+        </Pressable>
+      </XStack>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  acceptButton: {
+    width: 76,
+    height: 76,
+    borderRadius: 38,
+    backgroundColor: '#10D970',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  declineButton: {
+    width: 76,
+    height: 76,
+    borderRadius: 38,
+    backgroundColor: '#FF3B30',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/app/call/incoming/[id].tsx
+++ b/app/call/incoming/[id].tsx
@@ -28,6 +28,7 @@ import { Animated, Easing, Pressable, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text, View, XStack, YStack } from 'tamagui';
 
+import { requestCallPermissions } from '@/features/calls/hooks/useCallPermissions';
 import { useConversationHeader } from '@/features/messaging/hooks/useConversationHeader';
 import { logger } from '@/lib/logger';
 import { supabase } from '@/lib/supabase';
@@ -108,8 +109,17 @@ export default function IncomingCallScreen() {
     return () => clearTimeout(timer);
   }, [decided, updateCallStatus]);
 
-  const handleAccept = useCallback(() => {
+  const handleAccept = useCallback(async () => {
     if (decided || !roomUrl || !callId) return;
+    // Ticket #235 : permissions avant accept
+    const granted = await requestCallPermissions(callType);
+    if (!granted) {
+      // L'user a refusé les permissions → on rejette l'appel proprement
+      void updateCallStatus('rejected');
+      if (router.canGoBack()) router.back();
+      else router.replace('/(tabs)/messages');
+      return;
+    }
     setDecided(true);
     // On marque le call accepted, puis on navigue vers le screen call
     // standard avec le roomUrl reçu. Note MVP : pas de token destinataire
@@ -205,7 +215,9 @@ export default function IncomingCallScreen() {
           <PhoneOff size={32} color="#FFFFFF" />
         </Pressable>
         <Pressable
-          onPress={handleAccept}
+          onPress={() => {
+            void handleAccept();
+          }}
           disabled={decided}
           style={styles.acceptButton}
           accessibilityRole="button"

--- a/src/features/calls/components/CallEntry.tsx
+++ b/src/features/calls/components/CallEntry.tsx
@@ -1,0 +1,116 @@
+// CallEntry — Ticket #234 (E6-C5).
+//
+// Rend une entrée discrète dans la liste de messages pour signaler un appel
+// passé : "📞 Appel audio · 2min 34s" ou "📞 Appel manqué" etc.
+//
+// Tap sur l'entrée → callback `onRecall` pour relancer un appel du même type.
+
+import { Phone, PhoneIncoming, PhoneMissed, PhoneOff, Video } from 'lucide-react-native';
+import { memo } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, XStack, YStack } from 'tamagui';
+
+import type { CallEntryRow } from '../hooks/useConversationCalls';
+
+const COLORS = {
+  background: '#1A1A1A',
+  text: '#FFFFFF',
+  textMuted: '#A0A0A0',
+  iconNormal: '#10D970',
+  iconMissed: '#FF3B30',
+};
+
+function formatDuration(startedAt: string | null, endedAt: string | null): string | null {
+  if (!startedAt || !endedAt) return null;
+  const start = new Date(startedAt).getTime();
+  const end = new Date(endedAt).getTime();
+  if (Number.isNaN(start) || Number.isNaN(end) || end <= start) return null;
+  const totalSec = Math.floor((end - start) / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  if (m === 0) return `${s}s`;
+  return `${m}min ${s.toString().padStart(2, '0')}s`;
+}
+
+export interface CallEntryProps {
+  call: CallEntryRow;
+  /** Vrai si c'est moi qui ai lancé l'appel (= sortant). */
+  isMine: boolean;
+  /** Tap → relance un appel du même type. */
+  onRecall?: (callType: 'audio' | 'video') => void;
+}
+
+function CallEntryComponent({ call, isMine, onRecall }: CallEntryProps) {
+  const duration = formatDuration(call.started_at, call.ended_at);
+
+  let icon: React.ReactNode;
+  let label: string;
+  if (call.status === 'missed') {
+    icon = <PhoneMissed size={16} color={COLORS.iconMissed} />;
+    label = isMine ? 'Appel sans réponse' : 'Appel manqué';
+  } else if (call.status === 'rejected') {
+    icon = <PhoneOff size={16} color={COLORS.iconMissed} />;
+    label = isMine ? 'Appel refusé par le destinataire' : 'Appel refusé';
+  } else if (call.status === 'cancelled') {
+    icon = <PhoneOff size={16} color={COLORS.textMuted} />;
+    label = isMine ? 'Appel annulé' : 'Appel annulé';
+  } else {
+    // ended
+    icon = isMine ? (
+      <Phone size={16} color={COLORS.iconNormal} />
+    ) : (
+      <PhoneIncoming size={16} color={COLORS.iconNormal} />
+    );
+    label = call.call_type === 'video' ? 'Appel vidéo' : 'Appel audio';
+  }
+
+  const callTypeIcon =
+    call.call_type === 'video' ? (
+      <Video size={12} color={COLORS.textMuted} />
+    ) : (
+      <Phone size={12} color={COLORS.textMuted} />
+    );
+
+  return (
+    <Pressable
+      onPress={() => onRecall?.(call.call_type)}
+      accessibilityRole="button"
+      accessibilityLabel={`${label}${duration ? ` — ${duration}` : ''}. Tap pour rappeler.`}
+      style={styles.pressable}
+    >
+      <XStack
+        backgroundColor={COLORS.background}
+        borderRadius={9999}
+        paddingHorizontal={14}
+        paddingVertical={8}
+        alignItems="center"
+        gap={8}
+        maxWidth="78%"
+      >
+        {icon}
+        <YStack flex={1} minWidth={0}>
+          <Text color={COLORS.text} fontSize={13} fontWeight="600" numberOfLines={1}>
+            {label}
+          </Text>
+          {duration ? (
+            <XStack alignItems="center" gap={4} marginTop={1}>
+              {callTypeIcon}
+              <Text color={COLORS.textMuted} fontSize={11}>
+                {duration}
+              </Text>
+            </XStack>
+          ) : null}
+        </YStack>
+      </XStack>
+    </Pressable>
+  );
+}
+
+export const CallEntry = memo(CallEntryComponent);
+
+const styles = StyleSheet.create({
+  pressable: {
+    alignSelf: 'center',
+    paddingVertical: 4,
+  },
+});

--- a/src/features/calls/hooks/useCallPermissions.ts
+++ b/src/features/calls/hooks/useCallPermissions.ts
@@ -1,0 +1,71 @@
+// useCallPermissions — Ticket #235 (E6-C6).
+//
+// Demande au runtime les permissions micro (et caméra si video) avant un
+// appel. Si refusé après la demande système, affiche un Alert avec un bouton
+// "Ouvrir Réglages" qui ouvre l'écran Réglages > Notre app via expo-linking.
+
+import { Camera } from 'expo-camera';
+import * as Linking from 'expo-linking';
+import { Alert, Platform } from 'react-native';
+
+import { logger } from '@/lib/logger';
+
+export type CallType = 'audio' | 'video';
+
+/**
+ * Demande les permissions nécessaires pour un appel.
+ * Audio only : juste micro.
+ * Video : micro + caméra.
+ *
+ * @returns true si toutes les perms sont granted, false sinon (l'Alert
+ *          d'explication a déjà été affichée).
+ */
+export async function requestCallPermissions(callType: CallType): Promise<boolean> {
+  // ─ Micro ─────────────────────────────────────────────────────────────
+  let micPerm = await Camera.getMicrophonePermissionsAsync();
+  if (!micPerm.granted) {
+    micPerm = await Camera.requestMicrophonePermissionsAsync();
+  }
+  if (!micPerm.granted) {
+    logger.warn('Mic permission denied');
+    showPermissionDeniedAlert('micro');
+    return false;
+  }
+
+  if (callType === 'audio') return true;
+
+  // ─ Caméra (video only) ───────────────────────────────────────────────
+  let camPerm = await Camera.getCameraPermissionsAsync();
+  if (!camPerm.granted) {
+    camPerm = await Camera.requestCameraPermissionsAsync();
+  }
+  if (!camPerm.granted) {
+    logger.warn('Camera permission denied');
+    showPermissionDeniedAlert('caméra');
+    return false;
+  }
+
+  return true;
+}
+
+function showPermissionDeniedAlert(kind: 'micro' | 'caméra') {
+  const what = kind === 'micro' ? 'micro' : 'caméra';
+  Alert.alert(
+    'Permission refusée',
+    `DOUMASSI a besoin d'accéder à ton ${what} pour passer cet appel. Active la permission dans les Réglages.`,
+    [
+      { text: 'Annuler', style: 'cancel' },
+      {
+        text: 'Ouvrir les Réglages',
+        onPress: () => {
+          // expo-linking ouvre les Réglages > Notre app sur iOS et Android
+          if (Platform.OS === 'ios') {
+            void Linking.openURL('app-settings:');
+          } else {
+            void Linking.openSettings();
+          }
+        },
+      },
+    ]
+  );
+}

--- a/src/features/calls/hooks/useConversationCalls.ts
+++ b/src/features/calls/hooks/useConversationCalls.ts
@@ -1,0 +1,72 @@
+// useConversationCalls — Ticket #234 (E6-C5).
+//
+// Récupère les appels HISTORIQUES (status != ringing/accepted) d'une
+// conversation pour les afficher comme des "entrées" discrètes dans la
+// timeline messages.
+//
+// On filtre côté DB (`neq('status', 'ringing')`) pour éviter de fetcher les
+// appels en cours — ceux-là sont gérés par useIncomingCallListener.
+
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type CallFinalStatus = 'rejected' | 'missed' | 'ended' | 'cancelled';
+
+export interface CallEntryRow {
+  id: string;
+  conversation_id: string;
+  initiator_id: string;
+  call_type: 'audio' | 'video';
+  status: CallFinalStatus;
+  created_at: string;
+  started_at: string | null;
+  ended_at: string | null;
+}
+
+export function conversationCallsQueryKey(conversationId: string) {
+  return ['conversation', conversationId, 'calls'] as const;
+}
+
+export function useConversationCalls(conversationId: string | null) {
+  const query = useQuery({
+    queryKey: conversationId
+      ? conversationCallsQueryKey(conversationId)
+      : ['conversation', 'none', 'calls'],
+    enabled: Boolean(conversationId),
+    queryFn: async (): Promise<CallEntryRow[]> => {
+      if (!conversationId) return [];
+      const { data, error } = await supabase
+        .from('calls')
+        .select(
+          'id, conversation_id, initiator_id, call_type, status, created_at, started_at, ended_at'
+        )
+        .eq('conversation_id', conversationId)
+        .in('status', ['rejected', 'missed', 'ended', 'cancelled'])
+        .order('created_at', { ascending: false })
+        .limit(100);
+
+      if (error) {
+        logger.warn('useConversationCalls failed', {
+          message: error.message,
+          conversationId,
+        });
+        throw error;
+      }
+      return (data ?? []) as CallEntryRow[];
+    },
+    staleTime: 30_000,
+  });
+
+  return useMemo(
+    () => ({
+      calls: query.data ?? [],
+      isLoading: query.isLoading,
+      isError: query.isError,
+      refetch: query.refetch,
+    }),
+    [query.data, query.isError, query.isLoading, query.refetch]
+  );
+}

--- a/src/features/calls/hooks/useIncomingCallListener.ts
+++ b/src/features/calls/hooks/useIncomingCallListener.ts
@@ -1,0 +1,81 @@
+// useIncomingCallListener — Ticket #233 (E6-C4).
+//
+// Subscribe via Supabase Realtime à la table `calls` pour détecter en temps
+// réel les INSERT de calls où je suis destinataire (= je suis participant de
+// la conversation MAIS je ne suis pas l'initiator).
+//
+// Quand un incoming call arrive, on push vers l'écran ringtone
+// `/call/incoming/[id]` qui propose Accept/Decline.
+//
+// LIMITES MVP :
+//   - Foreground uniquement : si l'app est killed/background, on ne capte
+//     pas l'INSERT Realtime. Pour un vrai "appel entrant qui sonne même
+//     killed", il faut un push notif spécial + service natif (CallKit iOS /
+//     ConnectionService Android) — chantier V2 noté dans le ticket.
+//   - On filtre côté client après réception : on subscribe à TOUS les calls
+//     INSERT (pour éviter de gérer dynamiquement les filtres par convId), et
+//     on filtre par `initiator_id !== me`. La RLS côté DB garantit qu'on ne
+//     reçoit que les calls de nos conversations.
+
+import { router } from 'expo-router';
+import { useEffect, useRef } from 'react';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+interface CallRow {
+  id: string;
+  conversation_id: string;
+  initiator_id: string;
+  call_type: 'audio' | 'video';
+  daily_room_url: string;
+  status: 'ringing' | 'accepted' | 'rejected' | 'missed' | 'ended' | 'cancelled';
+}
+
+export function useIncomingCallListener(meId: string | null) {
+  // Garde contre les double-déclenchements (Realtime peut renvoyer la même
+  // row en cas de reconnexion).
+  const handledRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!meId) return undefined;
+
+    const channel = supabase
+      .channel('incoming-calls')
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'calls' }, (payload) => {
+        const row = payload.new as CallRow | undefined;
+        if (!row) return;
+        // Filtre client : ce n'est PAS moi qui ai lancé l'appel ET le call
+        // est encore en ringing (pas un INSERT historique de Realtime replay).
+        if (row.initiator_id === meId) return;
+        if (row.status !== 'ringing') return;
+        if (handledRef.current.has(row.id)) return;
+        handledRef.current.add(row.id);
+
+        logger.info('Incoming call received', {
+          call_id: row.id,
+          call_type: row.call_type,
+          from: row.initiator_id,
+        });
+
+        router.push({
+          pathname: '/call/incoming/[id]',
+          params: {
+            id: row.id,
+            conversationId: row.conversation_id,
+            callType: row.call_type,
+            roomUrl: row.daily_room_url,
+          },
+        });
+      })
+      .subscribe((status) => {
+        if (status === 'CHANNEL_ERROR') {
+          logger.warn('Incoming call channel error');
+        }
+      });
+
+    return () => {
+      void supabase.removeChannel(channel);
+    };
+  }, [meId]);
+}

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -29,7 +29,12 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text, View, XStack, YStack } from 'tamagui';
 
+import { CallEntry } from '@/features/calls/components/CallEntry';
 import { requestCallPermissions } from '@/features/calls/hooks/useCallPermissions';
+import {
+  useConversationCalls,
+  type CallEntryRow,
+} from '@/features/calls/hooks/useConversationCalls';
 import { useStartCall, type CallType } from '@/features/calls/hooks/useStartCall';
 import { MessageActionSheet } from '@/features/messaging/components/MessageActionSheet';
 import {
@@ -54,6 +59,12 @@ import { logger } from '@/lib/logger';
 import { uploadMessageAudio, uploadMessageImage } from '@/lib/storage';
 import { supabase } from '@/lib/supabase';
 
+// Item de la timeline conversation : soit un message, soit une entrée d'appel
+// historique (#234). Mergés et triés par created_at desc côté composant.
+type FeedItem =
+  | { kind: 'message'; data: MessageRow; sortKey: string }
+  | { kind: 'call'; data: CallEntryRow; sortKey: string };
+
 export function ConversationScreen() {
   const insets = useSafeAreaInsets();
   const { id: conversationId } = useLocalSearchParams<{ id: string }>();
@@ -73,7 +84,7 @@ export function ConversationScreen() {
   const [isManualRefreshing, setIsManualRefreshing] = useState(false);
   // Ticket #209 — message en cours de réponse (sélectionné via ActionSheet).
   const [replyingTo, setReplyingTo] = useState<MessageRow | null>(null);
-  const listRef = useRef<FlashListRef<MessageRow>>(null);
+  const listRef = useRef<FlashListRef<FeedItem>>(null);
 
   // Récupère mon user_id au mount pour identifier les bulles "à moi"
   useEffect(() => {
@@ -96,6 +107,27 @@ export function ConversationScreen() {
   const messages = useMemo<MessageRow[]>(() => {
     return messagesQuery.data?.pages.flatMap((p) => p.messages) ?? [];
   }, [messagesQuery.data]);
+
+  // Ticket #234 — historique des appels mergé dans la timeline.
+  const { calls } = useConversationCalls(convId);
+
+  const feedItems = useMemo<FeedItem[]>(() => {
+    const msgItems: FeedItem[] = messages.map((m) => ({
+      kind: 'message',
+      data: m,
+      sortKey: m.created_at,
+    }));
+    const callItems: FeedItem[] = calls.map((c) => ({
+      kind: 'call',
+      data: c,
+      sortKey: c.ended_at ?? c.created_at,
+    }));
+    // FlashList est inverted → on trie desc par created_at, la + récente en
+    // tête → s'affiche en bas de l'écran après inversion.
+    return [...msgItems, ...callItems].sort((a, b) =>
+      a.sortKey < b.sortKey ? 1 : a.sortKey > b.sortKey ? -1 : 0
+    );
+  }, [calls, messages]);
 
   // Ticket #209 — index id→message pour résoudre les parents en O(1) au
   // moment du rendu des bulles.
@@ -309,7 +341,10 @@ export function ConversationScreen() {
    */
   const handleScrollToParent = useCallback(
     (parentId: string) => {
-      const index = messages.findIndex((m) => m.id === parentId);
+      // L'index doit être celui dans `feedItems` (data passée à FlashList),
+      // pas dans `messages`. Sinon le scroll cible la mauvaise position avec
+      // des CallEntry mergées dans la liste.
+      const index = feedItems.findIndex((it) => it.kind === 'message' && it.data.id === parentId);
       if (index === -1) {
         Alert.alert(
           'Message non chargé',
@@ -319,7 +354,7 @@ export function ConversationScreen() {
       }
       listRef.current?.scrollToIndex({ index, animated: true, viewPosition: 0.5 });
     },
-    [messages]
+    [feedItems]
   );
 
   const replyingPreview = useMemo<ReplyingPreview | null>(() => {
@@ -393,8 +428,19 @@ export function ConversationScreen() {
     setIsManualRefreshing(false);
   }, [messagesQuery]);
 
-  const renderMessage = useCallback(
-    ({ item }: { item: MessageRow }) => {
+  const renderFeedItem = useCallback(
+    ({ item: feed }: { item: FeedItem }) => {
+      if (feed.kind === 'call') {
+        const c = feed.data;
+        return (
+          <CallEntry
+            call={c}
+            isMine={c.initiator_id === meId}
+            onRecall={(type) => void handleStartCall(type)}
+          />
+        );
+      }
+      const item = feed.data;
       const isMine = item.sender_id === meId;
       const senderProfile = !isMine ? profilesById.get(item.sender_id) : undefined;
       let replyParent: ReplyParentPreview | null = null;
@@ -433,6 +479,7 @@ export function ConversationScreen() {
       buildReplyPreview,
       handleLongPressBubble,
       handleScrollToParent,
+      handleStartCall,
       isGroup,
       meId,
       messagesById,
@@ -564,9 +611,9 @@ export function ConversationScreen() {
           ) : (
             <FlashList
               ref={listRef}
-              data={messages}
-              renderItem={renderMessage}
-              keyExtractor={(item) => item.id}
+              data={feedItems}
+              renderItem={renderFeedItem}
+              keyExtractor={(item) => `${item.kind}-${item.data.id}`}
               inverted
               onEndReached={handleLoadMore}
               onEndReachedThreshold={0.3}

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -29,6 +29,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Text, View, XStack, YStack } from 'tamagui';
 
+import { requestCallPermissions } from '@/features/calls/hooks/useCallPermissions';
 import { useStartCall, type CallType } from '@/features/calls/hooks/useStartCall';
 import { MessageActionSheet } from '@/features/messaging/components/MessageActionSheet';
 import {
@@ -350,8 +351,11 @@ export function ConversationScreen() {
   const startCall = useStartCall();
 
   const handleStartCall = useCallback(
-    (callType: CallType) => {
+    async (callType: CallType) => {
       if (!convId || startCall.isPending) return;
+      // Ticket #235 : permissions micro (+ caméra si video) avant tout.
+      const granted = await requestCallPermissions(callType);
+      if (!granted) return;
       startCall.mutate(
         { conversationId: convId, callType },
         {
@@ -495,7 +499,9 @@ export function ConversationScreen() {
         {!isGroup ? (
           <XStack gap={14} alignItems="center">
             <Pressable
-              onPress={() => handleStartCall('audio')}
+              onPress={() => {
+                void handleStartCall('audio');
+              }}
               disabled={startCall.isPending}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
               accessibilityRole="button"
@@ -510,7 +516,9 @@ export function ConversationScreen() {
               )}
             </Pressable>
             <Pressable
-              onPress={() => handleStartCall('video')}
+              onPress={() => {
+                void handleStartCall('video');
+              }}
               disabled={startCall.isPending}
               hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
               accessibilityRole="button"

--- a/supabase/audits/rls_audit_calls.sql
+++ b/supabase/audits/rls_audit_calls.sql
@@ -1,0 +1,219 @@
+-- #236 — Audit RLS table `public.calls`
+--
+-- Vérifie que les policies de la table calls (livrées Sprint 0 dans
+-- 20260602120000_messaging_schema.sql) bloquent effectivement les accès
+-- croisés. Script à exécuter ponctuellement via AI Supabase (DEV/STAGING)
+-- avant la mise en prod des appels.
+--
+-- Setup :
+--   - Alice : créatrice du call (initiator)
+--   - Bob : autre participant de la conversation
+--   - Charlie : utilisateur étranger qui ne participe à RIEN
+--
+-- Vérifications :
+--   1. Alice (initiator)  : voit le call, peut update status (en tant que participant)
+--   2. Bob (participant)  : voit le call, peut update status
+--   3. Charlie (étranger) : ne voit RIEN (RLS select renvoie 0 rows)
+--   4. Charlie ne peut PAS INSERT un call dans une conv où il n'est pas
+--   5. Charlie ne peut PAS UPDATE le call existant (0 rows affectées)
+--   6. Alice ne peut PAS INSERT un call avec initiator_id != elle-même
+--
+-- À NE JAMAIS exécuter en production.
+
+do $$ begin
+  if current_setting('app.environment', true) = 'production' then
+    raise exception 'NEVER run RLS audit in production';
+  end if;
+end $$;
+
+-- ============================================================================
+-- 0. Cleanup d'un éventuel run précédent
+-- ============================================================================
+do $$
+declare
+  v_alice_id constant uuid := '00000000-0000-0000-0000-0000000ca11ce';
+  v_bob_id   constant uuid := '00000000-0000-0000-0000-0000000cb0b00';
+  v_carl_id  constant uuid := '00000000-0000-0000-0000-0000000ccab1e';
+begin
+  delete from public.calls where initiator_id in (v_alice_id, v_bob_id, v_carl_id);
+  delete from public.conversation_participants
+    where user_id in (v_alice_id, v_bob_id, v_carl_id);
+  delete from public.conversations
+    where id = '00000000-0000-0000-0000-0000000cca110';
+  delete from auth.users where id in (v_alice_id, v_bob_id, v_carl_id);
+end $$;
+
+-- ============================================================================
+-- 1. Création des 3 users + 1 conversation
+-- ============================================================================
+do $$
+declare
+  v_alice_id constant uuid := '00000000-0000-0000-0000-0000000ca11ce';
+  v_bob_id   constant uuid := '00000000-0000-0000-0000-0000000cb0b00';
+  v_carl_id  constant uuid := '00000000-0000-0000-0000-0000000ccab1e';
+  v_conv_id  constant uuid := '00000000-0000-0000-0000-0000000cca110';
+begin
+  insert into auth.users (id, instance_id, aud, role, email, encrypted_password,
+    email_confirmed_at, created_at, updated_at)
+  values
+    (v_alice_id, '00000000-0000-0000-0000-000000000000'::uuid, 'authenticated',
+     'authenticated', 'audit-calls-alice@doumassi.test', 'dummy', now(), now(), now()),
+    (v_bob_id, '00000000-0000-0000-0000-000000000000'::uuid, 'authenticated',
+     'authenticated', 'audit-calls-bob@doumassi.test', 'dummy', now(), now(), now()),
+    (v_carl_id, '00000000-0000-0000-0000-000000000000'::uuid, 'authenticated',
+     'authenticated', 'audit-calls-carl@doumassi.test', 'dummy', now(), now(), now());
+
+  insert into public.profiles (id, username, full_name)
+  values
+    (v_alice_id, 'audit_calls_alice', 'Alice Audit'),
+    (v_bob_id, 'audit_calls_bob', 'Bob Audit'),
+    (v_carl_id, 'audit_calls_carl', 'Charlie Audit');
+
+  -- Conversation DM Alice <> Bob (Charlie pas dedans)
+  insert into public.conversations (id, is_group, created_by)
+  values (v_conv_id, false, v_alice_id);
+
+  insert into public.conversation_participants (conversation_id, user_id, role)
+  values
+    (v_conv_id, v_alice_id, 'member'),
+    (v_conv_id, v_bob_id, 'member');
+end $$;
+
+-- ============================================================================
+-- 2. Alice crée un call (en simulant son JWT)
+-- ============================================================================
+set local role authenticated;
+select set_config('request.jwt.claim.sub',
+                  '00000000-0000-0000-0000-0000000ca11ce', true);
+
+insert into public.calls (conversation_id, initiator_id, call_type,
+                          daily_room_url, status)
+values ('00000000-0000-0000-0000-0000000cca110',
+        '00000000-0000-0000-0000-0000000ca11ce',
+        'audio',
+        'https://doumassi.daily.co/audit-calls-room',
+        'ringing')
+returning id as alice_inserted_call_id;
+
+-- ============================================================================
+-- 3. Bob (participant) : doit VOIR le call
+-- ============================================================================
+select set_config('request.jwt.claim.sub',
+                  '00000000-0000-0000-0000-0000000cb0b00', true);
+
+-- Attendu : 1 row (le call de Alice)
+select 'TEST_3a Bob voit le call' as test,
+       count(*) as visible_calls
+  from public.calls
+ where conversation_id = '00000000-0000-0000-0000-0000000cca110';
+
+-- ============================================================================
+-- 4. Charlie (étranger) : ne doit RIEN voir
+-- ============================================================================
+select set_config('request.jwt.claim.sub',
+                  '00000000-0000-0000-0000-0000000ccab1e', true);
+
+-- Attendu : 0 row — la RLS calls select bloque
+select 'TEST_4a Charlie ne voit aucun call de Alice/Bob' as test,
+       count(*) as visible_calls
+  from public.calls
+ where conversation_id = '00000000-0000-0000-0000-0000000cca110';
+
+-- ============================================================================
+-- 5. Charlie ne peut PAS INSERT dans cette conversation
+-- ============================================================================
+do $$
+declare
+  v_failed boolean := false;
+begin
+  begin
+    insert into public.calls (conversation_id, initiator_id, call_type,
+                              daily_room_url, status)
+    values ('00000000-0000-0000-0000-0000000cca110',
+            '00000000-0000-0000-0000-0000000ccab1e',
+            'audio',
+            'https://doumassi.daily.co/hacker-call',
+            'ringing');
+  exception
+    when insufficient_privilege then
+      v_failed := true;
+    when others then
+      v_failed := true;
+  end;
+  if not v_failed then
+    raise exception 'TEST_5 FAILED : Charlie a pu INSERT un call dans une conv étrangère';
+  end if;
+  raise notice 'TEST_5 OK : Charlie bloqué côté INSERT (RLS)';
+end $$;
+
+-- ============================================================================
+-- 6. Charlie ne peut PAS UPDATE le call existant
+-- ============================================================================
+update public.calls
+   set status = 'ended'
+ where conversation_id = '00000000-0000-0000-0000-0000000cca110';
+
+-- Attendu : 0 row affectée (RLS update policy)
+select 'TEST_6a Charlie UPDATE status — 0 row affectée' as test;
+
+-- ============================================================================
+-- 7. Alice ne peut PAS INSERT un call en se faisant passer pour Bob
+-- ============================================================================
+select set_config('request.jwt.claim.sub',
+                  '00000000-0000-0000-0000-0000000ca11ce', true);
+
+do $$
+declare
+  v_failed boolean := false;
+begin
+  begin
+    insert into public.calls (conversation_id, initiator_id, call_type,
+                              daily_room_url, status)
+    values ('00000000-0000-0000-0000-0000000cca110',
+            '00000000-0000-0000-0000-0000000cb0b00',  -- Bob, pas elle !
+            'audio',
+            'https://doumassi.daily.co/spoofed',
+            'ringing');
+  exception
+    when insufficient_privilege then
+      v_failed := true;
+    when others then
+      v_failed := true;
+  end;
+  if not v_failed then
+    raise exception 'TEST_7 FAILED : Alice a pu spoofer initiator_id=Bob';
+  end if;
+  raise notice 'TEST_7 OK : initiator_id spoofing bloqué (RLS WITH CHECK)';
+end $$;
+
+-- ============================================================================
+-- 8. Cleanup
+-- ============================================================================
+reset role;
+
+do $$
+declare
+  v_alice_id constant uuid := '00000000-0000-0000-0000-0000000ca11ce';
+  v_bob_id   constant uuid := '00000000-0000-0000-0000-0000000cb0b00';
+  v_carl_id  constant uuid := '00000000-0000-0000-0000-0000000ccab1e';
+begin
+  delete from public.calls where initiator_id in (v_alice_id, v_bob_id, v_carl_id);
+  delete from public.conversation_participants
+    where user_id in (v_alice_id, v_bob_id, v_carl_id);
+  delete from public.conversations
+    where id = '00000000-0000-0000-0000-0000000cca110';
+  delete from public.profiles where id in (v_alice_id, v_bob_id, v_carl_id);
+  delete from auth.users where id in (v_alice_id, v_bob_id, v_carl_id);
+  raise notice 'CLEANUP OK';
+end $$;
+
+-- ============================================================================
+-- Critères de succès
+-- ============================================================================
+-- - TEST_3a : visible_calls = 1 (Bob voit)
+-- - TEST_4a : visible_calls = 0 (Charlie ne voit pas)
+-- - TEST_5  : "OK" dans les notices (INSERT bloqué)
+-- - TEST_6a : 0 row affectée par l'UPDATE
+-- - TEST_7  : "OK" dans les notices (spoofing bloqué)
+--
+-- Si tous OK → la RLS calls protège correctement contre les accès croisés.


### PR DESCRIPTION
## Summary

Suite de PR #237 (qui a livré #230/#231/#232 squashés en \`df60765\`). Cette PR ajoute les 4 tickets restants pour clôturer le MVP des appels Daily.co.

## Contenu

### #232 follow-up — perms Android
- \`app.json\` : ajout \`BLUETOOTH_CONNECT\` (router audio Bluetooth) + \`WAKE_LOCK\` (écran allumé pendant appel)

### #233 — Incoming call
- \`useIncomingCallListener\` : Realtime subscribe à \`public.calls\` event INSERT, filtre client \`initiator_id !== meId AND status='ringing'\`, garde Set anti-double-déclenchement
- \`app/call/incoming/[id].tsx\` : écran ringtone plein écran avec avatar pulsant, Accept (vert) / Decline (rouge), auto-timeout 30s → status='missed'
- Listener monté dans \`(tabs)/_layout.tsx AuthenticatedTabs\`
- **Limite MVP** : foreground only (CallKit / ConnectionService = V2)

### #235 — Permissions UX
- \`requestCallPermissions(callType)\` : demande micro (+ caméra si video) via expo-camera, Alert + bouton "Ouvrir Réglages" via expo-linking si refusé
- Branché dans \`handleStartCall\` (outgoing) et \`handleAccept\` (incoming, refuse l'appel si perm refusée)

### #236 — Audit RLS calls
- \`supabase/audits/rls_audit_calls.sql\` : 7 vérifications (Bob voit, Charlie pas, INSERT bloqué hors conv, spoofing initiator_id bloqué, etc.)
- À exécuter via AI Supabase sur DEV/STAGING avant prod

### #234 — Historique appels dans la conversation
- \`useConversationCalls\` : fetch les calls finis (status in 'rejected'/'missed'/'ended'/'cancelled')
- \`CallEntry\` component : bulle centrée discrète avec icône + label + durée mm:ss, tap → relance handleStartCall
- \`ConversationScreen\` : type \`FeedItem\` mergeant messages + calls, FlashList passe sur \`feedItems\` sortés par created_at desc, handleScrollToParent ajusté pour chercher l'index dans feedItems

## Test plan (après 2e device dispo)

- [ ] Appel manqué (timeout 30s) → entry "📞 Appel manqué" dans la conv
- [ ] Appel refusé → entry "📞 Appel refusé"
- [ ] Appel terminé → entry "📞 Appel audio · 2min 34s"
- [ ] Tap sur l'entry → relance un appel du même type
- [ ] Audit RLS exécuté sur DEV → tous les TEST_X OK
- [ ] Permission micro refusée → Alert "Ouvrir Réglages"

## Tickets fermés au merge

- #232 Permissions Android natives  
- #233 Incoming call notif + ringtone
- #234 Entrée historique appel dans conversation
- #235 Permissions micro/caméra UX
- #236 Audit RLS calls