### PR TITLE
feat(marketplace): fiche produit + CTA Contacter vendeur — #243, #244

### DIFF
--- a/app/shop/[id].tsx
+++ b/app/shop/[id].tsx
@@ -1,0 +1,480 @@
+// Écran Fiche produit — E7-12 + intégration CTA Contacter vendeur (E7-13)
+//
+// Layout (cf brief Marketplace L0 + maquette CEO) :
+//   - Header retour + bookmark toggle (top-right)
+//   - Carousel images (E7-12 — ListingImageCarousel)
+//   - Badge promo conditionnel au-dessus du titre
+//   - Titre + prix actuel + prix barré si discount + état + localisation +
+//     date relative + compteur de vues
+//   - Description complète
+//   - Carte vendeur cliquable → /profile/[id]
+//   - Section "Annonces similaires" (SimilarListingsRow)
+//   - CTA sticky bottom plein largeur "Contacter le vendeur" → useGetOrCreateDm
+//     puis router.push vers la conversation avec un message pré-rempli
+//
+// Garde-fou : si je suis le vendeur de l'annonce → on désactive le CTA et on
+// affiche "C'est votre annonce" pour éviter la création d'un DM avec soi-même
+// (que la RPC get_or_create_dm rejette de toute façon côté DB, mais autant
+// éviter l'aller-retour).
+
+import { router, Stack, useLocalSearchParams } from 'expo-router';
+import { ArrowLeft, Bookmark, Eye, MapPin } from 'lucide-react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Text, View, XStack, YStack } from 'tamagui';
+
+import { ListingImageCarousel } from '@/features/marketplace/components/ListingImageCarousel';
+import { SellerCard } from '@/features/marketplace/components/SellerCard';
+import { SimilarListingsRow } from '@/features/marketplace/components/SimilarListingsRow';
+import {
+  useListingDetail,
+  useSimilarListings,
+} from '@/features/marketplace/hooks/useListingDetail';
+import { useToggleListingBookmark } from '@/features/marketplace/hooks/useListings';
+import { useGetOrCreateDm } from '@/features/messaging/hooks/useGetOrCreateDm';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+const CONDITION_LABEL: Record<string, string> = {
+  neuf: 'Neuf',
+  tres_bon_etat: 'Très bon état',
+  bon_etat: 'Bon état',
+  occasion: 'Occasion',
+};
+
+const BADGE_LABEL: Record<string, string> = {
+  offre_speciale: 'Offre spéciale',
+  nouveaute: 'Nouveauté',
+  recommandation: 'Recommandation',
+};
+
+const BADGE_COLORS: Record<string, { bg: string; text: string }> = {
+  offre_speciale: { bg: '#E53935', text: '#FFFFFF' },
+  nouveaute: { bg: '#10D970', text: '#000000' },
+  recommandation: { bg: '#10D970', text: '#000000' },
+};
+
+function formatPrice(cents: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('fr-FR', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(cents / 100);
+  } catch {
+    return `${(cents / 100).toFixed(2)} ${currency}`;
+  }
+}
+
+function computeOriginalPrice(currentCents: number, discountPercent: number): number {
+  if (discountPercent <= 0 || discountPercent >= 100) return currentCents;
+  return Math.round(currentCents / (1 - discountPercent / 100));
+}
+
+function formatRelativeFr(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const elapsedMs = Math.max(0, Date.now() - date.getTime());
+  const minutes = Math.floor(elapsedMs / 60_000);
+  if (minutes < 1) return "à l'instant";
+  if (minutes < 60) return `il y a ${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `il y a ${hours} h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `il y a ${days} j`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `il y a ${weeks} sem`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `il y a ${months} mois`;
+  return `il y a ${Math.floor(days / 365)} an`;
+}
+
+export default function ListingDetailScreen() {
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ id: string }>();
+  const listingId = typeof params.id === 'string' ? params.id : null;
+
+  const { data: listing, isLoading, isError } = useListingDetail(listingId);
+  const { listings: similar } = useSimilarListings(listingId);
+  const toggleBookmark = useToggleListingBookmark();
+  const getOrCreateDm = useGetOrCreateDm();
+
+  const [meId, setMeId] = useState<string | null>(null);
+  useEffect(() => {
+    void (async () => {
+      const { data } = await supabase.auth.getSession();
+      setMeId(data.session?.user.id ?? null);
+    })();
+  }, []);
+
+  const isMyListing = meId !== null && listing != null && listing.seller_id === meId;
+
+  // Recompute du prix original côté client (cohérent avec ListingCard)
+  const priceCurrent = useMemo(
+    () =>
+      listing?.price_cents != null ? formatPrice(listing.price_cents, listing.currency) : null,
+    [listing?.price_cents, listing?.currency]
+  );
+
+  const priceOriginal = useMemo(() => {
+    if (
+      !listing ||
+      listing.price_cents == null ||
+      !listing.discount_percent ||
+      listing.discount_percent <= 0
+    ) {
+      return null;
+    }
+    return formatPrice(
+      computeOriginalPrice(listing.price_cents, listing.discount_percent),
+      listing.currency
+    );
+  }, [listing]);
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/shop');
+  }, []);
+
+  const handleToggleBookmark = useCallback(() => {
+    if (!listingId) return;
+    toggleBookmark.mutate({ listingId });
+  }, [listingId, toggleBookmark]);
+
+  const handleOpenSeller = useCallback(() => {
+    if (!listing) return;
+    router.push(`/profile/${listing.seller_id}`);
+  }, [listing]);
+
+  const handlePressSimilar = useCallback((otherId: string) => {
+    // Replace plutôt que push pour éviter d'empiler des fiches produit en
+    // boucle (sinon le back stack peut grossir indéfiniment quand on navigue
+    // d'une annonce similaire à une autre).
+    router.replace(`/shop/${otherId}`);
+  }, []);
+
+  // E7-13 — CTA Contacter vendeur
+  const handleContactSeller = useCallback(() => {
+    if (!listing) return;
+    if (isMyListing) return; // garde-fou
+    const prefill = `Bonjour, je suis intéressé(e) par votre annonce '${listing.title}'.`;
+    getOrCreateDm.mutate(listing.seller_id, {
+      onSuccess: (conversationId) => {
+        // L'écran de conversation lira `prefill` au mount et pré-remplira le
+        // composer SANS auto-envoyer. L'user édite puis envoie quand il veut.
+        router.push({
+          pathname: '/messages/[id]',
+          params: { id: conversationId, prefill },
+        });
+      },
+      onError: (err) => {
+        logger.warn('Contact seller failed', { message: err.message });
+        Alert.alert(
+          'Impossible de contacter ce vendeur',
+          err.message || 'Réessaie dans un instant.'
+        );
+      },
+    });
+  }, [getOrCreateDm, isMyListing, listing]);
+
+  // Header (toujours rendu pour permettre le retour même en erreur/loading)
+  const renderHeader = (
+    <XStack
+      position="absolute"
+      top={insets.top + 8}
+      left={0}
+      right={0}
+      paddingHorizontal={12}
+      justifyContent="space-between"
+      zIndex={10}
+      pointerEvents="box-none"
+    >
+      <Pressable
+        onPress={handleBack}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityRole="button"
+        accessibilityLabel="Retour"
+        style={styles.headerButton}
+      >
+        <ArrowLeft size={22} color="#FFFFFF" />
+      </Pressable>
+      {listing ? (
+        <Pressable
+          onPress={handleToggleBookmark}
+          disabled={toggleBookmark.isPending}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          accessibilityRole="button"
+          accessibilityLabel={
+            listing.bookmarked_by_me ? 'Retirer des favoris' : 'Ajouter aux favoris'
+          }
+          accessibilityState={{ selected: listing.bookmarked_by_me }}
+          style={styles.headerButton}
+        >
+          <Bookmark
+            size={22}
+            color={listing.bookmarked_by_me ? '#10D970' : '#FFFFFF'}
+            fill={listing.bookmarked_by_me ? '#10D970' : 'transparent'}
+            strokeWidth={2.2}
+          />
+        </Pressable>
+      ) : null}
+    </XStack>
+  );
+
+  if (isLoading) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View flex={1} backgroundColor="$background">
+          {renderHeader}
+          <YStack flex={1} alignItems="center" justifyContent="center">
+            <ActivityIndicator color="#FFFFFF" />
+          </YStack>
+        </View>
+      </>
+    );
+  }
+
+  if (isError || !listing) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <View flex={1} backgroundColor="$background" paddingTop={insets.top}>
+          {renderHeader}
+          <YStack
+            flex={1}
+            alignItems="center"
+            justifyContent="center"
+            paddingHorizontal={24}
+            gap={8}
+          >
+            <Text fontSize={16} fontWeight="700" color="$color">
+              Annonce introuvable
+            </Text>
+            <Text fontSize={13} color="$textSecondary" textAlign="center">
+              Cette annonce a peut-être été supprimée ou désactivée.
+            </Text>
+            <Button
+              marginTop={12}
+              backgroundColor="$accentNeon"
+              color="#000000"
+              fontWeight="700"
+              borderRadius="$10"
+              onPress={handleBack}
+            >
+              Retour
+            </Button>
+          </YStack>
+        </View>
+      </>
+    );
+  }
+
+  const conditionLabel = listing.condition ? CONDITION_LABEL[listing.condition] : null;
+  const badgeLabel = listing.badge ? BADGE_LABEL[listing.badge] : null;
+  const badgeColors = listing.badge ? BADGE_COLORS[listing.badge] : null;
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <View flex={1} backgroundColor="$background">
+        {renderHeader}
+
+        <ScrollView
+          contentContainerStyle={{ paddingBottom: 120 + insets.bottom }}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* Carousel */}
+          <ListingImageCarousel
+            images={listing.images}
+            accessibilityLabelBase={`Image de l'annonce ${listing.title}`}
+          />
+
+          <YStack paddingHorizontal={16} paddingTop={16} gap={12}>
+            {/* Badge promo */}
+            {badgeLabel && badgeColors ? (
+              <View alignSelf="flex-start">
+                <View
+                  backgroundColor={badgeColors.bg}
+                  paddingHorizontal={10}
+                  paddingVertical={4}
+                  borderRadius={9999}
+                >
+                  <Text fontSize={11} fontWeight="700" color={badgeColors.text}>
+                    {badgeLabel}
+                  </Text>
+                </View>
+              </View>
+            ) : null}
+
+            {/* Titre */}
+            <Text fontSize={22} fontWeight="800" color="$color">
+              {listing.title}
+            </Text>
+
+            {/* Prix actuel + prix barré */}
+            <XStack alignItems="baseline" gap={10} flexWrap="wrap">
+              {priceCurrent ? (
+                <Text fontSize={26} fontWeight="900" color="$accentNeon">
+                  {priceCurrent}
+                </Text>
+              ) : null}
+              {priceOriginal ? (
+                <Text fontSize={16} color="$textSecondary" textDecorationLine="line-through">
+                  {priceOriginal}
+                </Text>
+              ) : null}
+              {listing.discount_percent ? (
+                <View
+                  backgroundColor="#E53935"
+                  paddingHorizontal={8}
+                  paddingVertical={3}
+                  borderRadius={6}
+                >
+                  <Text fontSize={12} fontWeight="700" color="#FFFFFF">
+                    -{listing.discount_percent}%
+                  </Text>
+                </View>
+              ) : null}
+            </XStack>
+
+            {/* État + localisation + date + vues */}
+            <XStack flexWrap="wrap" gap={8} alignItems="center">
+              {conditionLabel ? (
+                <View
+                  backgroundColor="$surface"
+                  paddingHorizontal={10}
+                  paddingVertical={4}
+                  borderRadius={6}
+                >
+                  <Text fontSize={12} fontWeight="600" color="$color">
+                    {conditionLabel}
+                  </Text>
+                </View>
+              ) : null}
+              {listing.location ? (
+                <XStack alignItems="center" gap={4}>
+                  <MapPin size={14} color="#A0A0A0" />
+                  <Text fontSize={12} color="$textSecondary" numberOfLines={1}>
+                    {listing.location}
+                  </Text>
+                </XStack>
+              ) : null}
+              <Text fontSize={12} color="$textSecondary">
+                {formatRelativeFr(listing.created_at)}
+              </Text>
+              <XStack alignItems="center" gap={4}>
+                <Eye size={12} color="#A0A0A0" />
+                <Text fontSize={12} color="$textSecondary">
+                  {listing.view_count} vue{listing.view_count > 1 ? 's' : ''}
+                </Text>
+              </XStack>
+            </XStack>
+
+            {/* Description */}
+            {listing.description ? (
+              <YStack gap={6} paddingTop={4}>
+                <Text fontSize={13} color="$textSecondary" fontWeight="700">
+                  Description
+                </Text>
+                <Text fontSize={14} color="$color" lineHeight={20}>
+                  {listing.description}
+                </Text>
+              </YStack>
+            ) : null}
+
+            {/* Carte vendeur */}
+            <YStack gap={8} paddingTop={4}>
+              <Text fontSize={13} color="$textSecondary" fontWeight="700">
+                Vendeur
+              </Text>
+              <SellerCard
+                seller={{
+                  id: listing.seller_id,
+                  username: listing.seller_username,
+                  full_name: listing.seller_full_name,
+                  avatar_url: listing.seller_avatar_url,
+                  is_verified: listing.seller_is_verified,
+                }}
+                onPress={handleOpenSeller}
+              />
+            </YStack>
+          </YStack>
+
+          {/* Annonces similaires */}
+          {similar.length > 0 ? (
+            <YStack paddingTop={20}>
+              <SimilarListingsRow listings={similar} onPressItem={handlePressSimilar} />
+            </YStack>
+          ) : null}
+        </ScrollView>
+
+        {/* CTA sticky bottom — E7-13 */}
+        <YStack
+          position="absolute"
+          bottom={0}
+          left={0}
+          right={0}
+          paddingHorizontal={16}
+          paddingTop={12}
+          paddingBottom={insets.bottom + 12}
+          backgroundColor="$background"
+          borderTopWidth={StyleSheet.hairlineWidth}
+          borderTopColor="$borderColor"
+        >
+          {isMyListing ? (
+            <View
+              backgroundColor="$surface"
+              borderRadius={9999}
+              paddingVertical={14}
+              alignItems="center"
+            >
+              <Text fontSize={14} fontWeight="700" color="$textSecondary">
+                {`C'est votre annonce`}
+              </Text>
+            </View>
+          ) : (
+            <Pressable
+              onPress={handleContactSeller}
+              disabled={getOrCreateDm.isPending}
+              accessibilityRole="button"
+              accessibilityLabel={`Contacter ${listing.seller_username}`}
+              accessibilityHint="Ouvre une conversation avec le vendeur, message pré-rempli"
+              accessibilityState={{ disabled: getOrCreateDm.isPending }}
+              style={[
+                styles.cta,
+                { backgroundColor: getOrCreateDm.isPending ? '#1A1A1A' : '#10D970' },
+              ]}
+            >
+              {getOrCreateDm.isPending ? (
+                <ActivityIndicator color="#10D970" />
+              ) : (
+                <Text fontSize={15} fontWeight="800" color="#000000">
+                  Contacter le vendeur
+                </Text>
+              )}
+            </Pressable>
+          )}
+        </YStack>
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  cta: {
+    borderRadius: 9999,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  headerButton: {
+    width: 40,
+    height: 40,
+    borderRadius: 20,
+    backgroundColor: 'rgba(0,0,0,0.55)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/features/marketplace/components/ListingImageCarousel.tsx
+++ b/src/features/marketplace/components/ListingImageCarousel.tsx
@@ -1,0 +1,119 @@
+// ListingImageCarousel — E7-12
+//
+// Carousel horizontal des images d'une annonce. Si une seule image,
+// affichage simple sans pagination. Si plusieurs, dots de pagination en bas.
+//
+// Implémentation FlatList pagingEnabled + suivi de l'index actif via
+// onMomentumScrollEnd. Pas de lib externe pour rester léger.
+
+import { Image } from 'expo-image';
+import { useCallback, useState } from 'react';
+import {
+  Dimensions,
+  FlatList,
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  StyleSheet,
+  View,
+} from 'react-native';
+import { XStack, YStack } from 'tamagui';
+
+const SCREEN_WIDTH = Dimensions.get('window').width;
+
+export interface ListingImageCarouselProps {
+  images: string[];
+  /** Hauteur de l'image (la largeur prend toute la largeur écran). */
+  height?: number;
+  /** Label a11y de l'annonce, propagé aux images individuelles. */
+  accessibilityLabelBase?: string;
+}
+
+export function ListingImageCarousel({
+  images,
+  height = 320,
+  accessibilityLabelBase,
+}: ListingImageCarouselProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const handleMomentumScrollEnd = useCallback(
+    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const offsetX = e.nativeEvent.contentOffset.x;
+      const next = Math.round(offsetX / SCREEN_WIDTH);
+      if (next !== activeIndex) setActiveIndex(next);
+    },
+    [activeIndex]
+  );
+
+  if (images.length === 0) {
+    return (
+      <YStack
+        width={SCREEN_WIDTH}
+        height={height}
+        backgroundColor="$surface"
+        accessibilityLabel="Aucune image"
+      />
+    );
+  }
+
+  if (images.length === 1) {
+    return (
+      <Image
+        source={{ uri: images[0] }}
+        style={{ width: SCREEN_WIDTH, height }}
+        contentFit="cover"
+        transition={150}
+        accessibilityLabel={accessibilityLabelBase ?? 'Image de l’annonce'}
+      />
+    );
+  }
+
+  return (
+    <YStack>
+      <FlatList
+        data={images}
+        keyExtractor={(item, i) => `${item}-${i}`}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={handleMomentumScrollEnd}
+        renderItem={({ item, index }) => (
+          <Image
+            source={{ uri: item }}
+            style={{ width: SCREEN_WIDTH, height }}
+            contentFit="cover"
+            transition={150}
+            accessibilityLabel={`${accessibilityLabelBase ?? 'Image'} — ${index + 1} sur ${images.length}`}
+          />
+        )}
+      />
+      {/* Dots */}
+      <XStack
+        position="absolute"
+        bottom={12}
+        left={0}
+        right={0}
+        justifyContent="center"
+        alignItems="center"
+        gap={6}
+        pointerEvents="none"
+      >
+        {images.map((_, i) => (
+          <View key={i} style={[styles.dot, i === activeIndex ? styles.dotActive : null]} />
+        ))}
+      </XStack>
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: 'rgba(255,255,255,0.45)',
+  },
+  dotActive: {
+    width: 18,
+    backgroundColor: '#FFFFFF',
+  },
+});

--- a/src/features/marketplace/components/SellerCard.tsx
+++ b/src/features/marketplace/components/SellerCard.tsx
@@ -1,0 +1,100 @@
+// SellerCard — E7-12 — Carte vendeur cliquable dans la fiche produit.
+//
+// Affiche avatar + username + badge vérifié. Tap → router.push profil
+// du vendeur (réutilise la route existante /profile/[id]).
+
+import { Image } from 'expo-image';
+import { ChevronRight, User as UserIcon } from 'lucide-react-native';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, XStack, YStack } from 'tamagui';
+
+import { VerifiedBadge } from '@/features/profile/components/VerifiedBadge';
+
+export interface SellerCardProps {
+  seller: {
+    id: string;
+    username: string;
+    full_name: string | null;
+    avatar_url: string | null;
+    is_verified: boolean;
+  };
+  onPress: () => void;
+}
+
+export function SellerCard({ seller, onPress }: SellerCardProps) {
+  const initial = (seller.username || '?').charAt(0).toUpperCase();
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={`Voir le profil de ${seller.username}`}
+      accessibilityHint="Tap pour ouvrir le profil du vendeur"
+      style={styles.container}
+    >
+      <XStack
+        backgroundColor="$surface"
+        borderRadius={12}
+        padding={12}
+        alignItems="center"
+        gap={12}
+      >
+        <YStack
+          width={48}
+          height={48}
+          borderRadius={9999}
+          backgroundColor="$surfaceElevated"
+          overflow="hidden"
+          alignItems="center"
+          justifyContent="center"
+        >
+          {seller.avatar_url ? (
+            <Image
+              source={{ uri: seller.avatar_url }}
+              style={styles.avatar}
+              contentFit="cover"
+              transition={150}
+            />
+          ) : (
+            <Text fontSize={18} fontWeight="700" color="$color">
+              {initial}
+            </Text>
+          )}
+        </YStack>
+
+        <YStack flex={1} minWidth={0} gap={2}>
+          <XStack alignItems="center" gap={4}>
+            <Text
+              fontSize={15}
+              fontWeight="700"
+              color="$color"
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
+              @{seller.username}
+            </Text>
+            <VerifiedBadge isVerified={seller.is_verified} />
+          </XStack>
+          {seller.full_name ? (
+            <Text fontSize={12} color="$textSecondary" numberOfLines={1}>
+              {seller.full_name}
+            </Text>
+          ) : null}
+        </YStack>
+
+        <UserIcon size={16} color="#A0A0A0" />
+        <ChevronRight size={16} color="#A0A0A0" />
+      </XStack>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  avatar: {
+    width: '100%',
+    height: '100%',
+  },
+  container: {
+    width: '100%',
+  },
+});

--- a/src/features/marketplace/components/SimilarListingsRow.tsx
+++ b/src/features/marketplace/components/SimilarListingsRow.tsx
@@ -1,0 +1,109 @@
+// SimilarListingsRow — E7-12
+//
+// Carousel horizontal des annonces similaires (même catégorie, triées par
+// popularité côté DB via get_similar_listings).
+//
+// Mini-cards plus compactes que ListingCard : image + titre + prix. Tap →
+// fiche produit de l'annonce similaire (router.push remplace l'écran courant
+// pour éviter l'empilement infini quand on navigue d'annonce en annonce —
+// d'où router.replace plutôt que router.push).
+
+import { Image } from 'expo-image';
+import { Pressable, ScrollView, StyleSheet } from 'react-native';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+import type { SimilarListing } from '../hooks/useListingDetail';
+
+const CARD_WIDTH = 140;
+
+function formatPrice(cents: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('fr-FR', {
+      style: 'currency',
+      currency,
+      maximumFractionDigits: 2,
+    }).format(cents / 100);
+  } catch {
+    return `${(cents / 100).toFixed(2)} ${currency}`;
+  }
+}
+
+export interface SimilarListingsRowProps {
+  listings: SimilarListing[];
+  onPressItem: (listingId: string) => void;
+}
+
+export function SimilarListingsRow({ listings, onPressItem }: SimilarListingsRowProps) {
+  if (listings.length === 0) return null;
+
+  return (
+    <YStack gap={10} paddingHorizontal={16}>
+      <Text fontSize={16} fontWeight="700" color="$color">
+        Annonces similaires
+      </Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContent}
+      >
+        {listings.map((listing) => {
+          const firstImage = listing.images[0];
+          const priceLabel =
+            listing.price_cents != null ? formatPrice(listing.price_cents, listing.currency) : null;
+          return (
+            <Pressable
+              key={listing.id}
+              onPress={() => onPressItem(listing.id)}
+              accessibilityRole="button"
+              accessibilityLabel={`${listing.title}${priceLabel ? `, ${priceLabel}` : ''}`}
+              style={styles.card}
+            >
+              <View
+                width={CARD_WIDTH}
+                height={CARD_WIDTH}
+                borderRadius={12}
+                overflow="hidden"
+                backgroundColor="$surface"
+              >
+                {firstImage ? (
+                  <Image
+                    source={{ uri: firstImage }}
+                    style={styles.image}
+                    contentFit="cover"
+                    transition={150}
+                  />
+                ) : null}
+              </View>
+              <YStack marginTop={6} gap={2}>
+                <Text fontSize={12} fontWeight="600" color="$color" numberOfLines={1}>
+                  {listing.title}
+                </Text>
+                {priceLabel ? (
+                  <XStack alignItems="center" gap={4}>
+                    <Text fontSize={13} fontWeight="800" color="$accentNeon">
+                      {priceLabel}
+                    </Text>
+                  </XStack>
+                ) : null}
+              </YStack>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    width: CARD_WIDTH,
+    marginRight: 12,
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+  },
+  scrollContent: {
+    paddingRight: 16,
+  },
+});

--- a/src/features/marketplace/hooks/useListingDetail.ts
+++ b/src/features/marketplace/hooks/useListingDetail.ts
@@ -1,0 +1,162 @@
+// useListingDetail + useSimilarListings — E7-12 (Fiche produit + similaires)
+//
+// La RPC get_listing_detail incrémente le view_count à chaque appel côté DB.
+// Pour éviter de spammer le compteur en cas de re-render ou de refetch
+// agressif, on garde un staleTime modéré (60s) et on désactive le
+// refetchOnWindowFocus / refetchOnMount.
+
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+import type { ListingBadge, ListingCategory, ListingCondition } from './useListings';
+
+export interface ListingDetail {
+  id: string;
+  seller_id: string;
+  seller_username: string;
+  seller_full_name: string | null;
+  seller_avatar_url: string | null;
+  seller_is_verified: boolean;
+  category: ListingCategory;
+  title: string;
+  description: string | null;
+  price_cents: number | null;
+  currency: string;
+  images: string[];
+  location: string | null;
+  condition: ListingCondition | null;
+  badge: ListingBadge | null;
+  discount_percent: number | null;
+  view_count: number;
+  created_at: string;
+  bookmarked_by_me: boolean;
+}
+
+export interface SimilarListing {
+  id: string;
+  title: string;
+  price_cents: number | null;
+  currency: string;
+  images: string[];
+  badge: ListingBadge | null;
+  discount_percent: number | null;
+}
+
+type RpcRow = Record<string, unknown>;
+
+function isCategory(value: unknown): value is ListingCategory {
+  return value === 'product' || value === 'service';
+}
+
+function isCondition(value: unknown): value is ListingCondition {
+  return (
+    value === 'neuf' || value === 'tres_bon_etat' || value === 'bon_etat' || value === 'occasion'
+  );
+}
+
+function isBadge(value: unknown): value is ListingBadge {
+  return value === 'offre_speciale' || value === 'nouveaute' || value === 'recommandation';
+}
+
+function mapDetail(row: RpcRow): ListingDetail {
+  return {
+    id: String(row.id ?? ''),
+    seller_id: String(row.seller_id ?? ''),
+    seller_username: String(row.seller_username ?? ''),
+    seller_full_name: (row.seller_full_name as string | null) ?? null,
+    seller_avatar_url: (row.seller_avatar_url as string | null) ?? null,
+    seller_is_verified: Boolean(row.seller_is_verified ?? false),
+    category: isCategory(row.category) ? row.category : 'product',
+    title: String(row.title ?? ''),
+    description: (row.description as string | null) ?? null,
+    price_cents: typeof row.price_cents === 'number' ? row.price_cents : null,
+    currency: String(row.currency ?? 'EUR'),
+    images: Array.isArray(row.images) ? (row.images as string[]) : [],
+    location: (row.location as string | null) ?? null,
+    condition: isCondition(row.condition) ? row.condition : null,
+    badge: isBadge(row.badge) ? row.badge : null,
+    discount_percent: typeof row.discount_percent === 'number' ? row.discount_percent : null,
+    view_count: typeof row.view_count === 'number' ? row.view_count : 0,
+    created_at: String(row.created_at ?? ''),
+    bookmarked_by_me: Boolean(row.bookmarked_by_me ?? false),
+  };
+}
+
+export function listingDetailQueryKey(listingId: string) {
+  return ['marketplace', 'detail', listingId] as const;
+}
+
+export function useListingDetail(listingId: string | null) {
+  return useQuery({
+    queryKey: listingId ? listingDetailQueryKey(listingId) : ['marketplace', 'detail', 'none'],
+    enabled: Boolean(listingId),
+    queryFn: async (): Promise<ListingDetail | null> => {
+      if (!listingId) return null;
+      const { data, error } = await supabase.rpc('get_listing_detail', {
+        p_listing_id: listingId,
+      });
+      if (error) {
+        logger.warn('get_listing_detail failed', { message: error.message, listingId });
+        throw error;
+      }
+      // La RPC retourne TABLE (set), Supabase enveloppe en array. On prend la
+      // 1ère row, ou null si l'annonce est inactive/inexistante.
+      const rows = (data ?? []) as RpcRow[];
+      const first = rows[0];
+      return first ? mapDetail(first) : null;
+    },
+    // 60s : on évite que view_count se re-incrémente trop souvent.
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+}
+
+function mapSimilar(row: RpcRow): SimilarListing {
+  return {
+    id: String(row.id ?? ''),
+    title: String(row.title ?? ''),
+    price_cents: typeof row.price_cents === 'number' ? row.price_cents : null,
+    currency: String(row.currency ?? 'EUR'),
+    images: Array.isArray(row.images) ? (row.images as string[]) : [],
+    badge: isBadge(row.badge) ? row.badge : null,
+    discount_percent: typeof row.discount_percent === 'number' ? row.discount_percent : null,
+  };
+}
+
+export function useSimilarListings(listingId: string | null, limit = 4) {
+  const query = useQuery({
+    queryKey: listingId
+      ? ['marketplace', 'similar', listingId, limit]
+      : ['marketplace', 'similar', 'none'],
+    enabled: Boolean(listingId),
+    queryFn: async (): Promise<SimilarListing[]> => {
+      if (!listingId) return [];
+      const { data, error } = await supabase.rpc('get_similar_listings', {
+        p_listing_id: listingId,
+        p_limit: limit,
+      });
+      if (error) {
+        logger.warn('get_similar_listings failed', {
+          message: error.message,
+          listingId,
+        });
+        throw error;
+      }
+      return ((data ?? []) as RpcRow[]).map(mapSimilar);
+    },
+    staleTime: 5 * 60_000,
+  });
+
+  return useMemo(
+    () => ({
+      listings: query.data ?? [],
+      isLoading: query.isLoading,
+      isError: query.isError,
+    }),
+    [query.data, query.isError, query.isLoading]
+  );
+}

--- a/src/features/messaging/components/MessageInput.tsx
+++ b/src/features/messaging/components/MessageInput.tsx
@@ -49,6 +49,14 @@ export interface MessageInputProps {
   replyingTo?: ReplyingPreview | null;
   /** Appelé quand l'utilisateur tape sur la croix de l'encart de réponse. */
   onCancelReply?: () => void;
+  /**
+   * Ticket #244 (E7-13) — message pré-rempli dans le composer à l'ouverture
+   * de la conversation (typiquement depuis le CTA "Contacter le vendeur"
+   * d'une fiche marketplace). Appliqué une seule fois au mount via une key
+   * sentinelle pour ne pas écraser le texte que l'utilisateur a déjà
+   * commencé à éditer.
+   */
+  initialContent?: string;
   disabled?: boolean;
   placeholder?: string;
 }
@@ -73,11 +81,19 @@ export function MessageInput({
   isSendingVoice = false,
   replyingTo,
   onCancelReply,
+  initialContent,
   disabled = false,
   placeholder = 'Écrire un message…',
 }: MessageInputProps) {
-  const [content, setContent] = useState('');
-  const [selection, setSelection] = useState({ start: 0, end: 0 });
+  // initialContent appliqué une seule fois au tout premier mount du composant.
+  // On utilise useState lazy initializer pour éviter qu'un changement futur
+  // de la prop initialContent n'écrase ce que l'utilisateur est en train de
+  // taper.
+  const [content, setContent] = useState(() => initialContent ?? '');
+  const [selection, setSelection] = useState(() => {
+    const init = initialContent ?? '';
+    return { start: init.length, end: init.length };
+  });
 
   const { activeQuery, suggestions, isLoading, replaceMention } = useMentionSuggestions(
     content,

--- a/src/features/messaging/screens/ConversationScreen.tsx
+++ b/src/features/messaging/screens/ConversationScreen.tsx
@@ -67,8 +67,16 @@ type FeedItem =
 
 export function ConversationScreen() {
   const insets = useSafeAreaInsets();
-  const { id: conversationId } = useLocalSearchParams<{ id: string }>();
+  // E7-13 — `prefill` est passé en query param quand on arrive depuis le CTA
+  // "Contacter le vendeur" d'une fiche marketplace. Il pré-remplit le
+  // composer (sans auto-envoyer) au tout premier mount.
+  const { id: conversationId, prefill } = useLocalSearchParams<{
+    id: string;
+    prefill?: string;
+  }>();
   const convId = typeof conversationId === 'string' ? conversationId : null;
+  const initialMessageContent =
+    typeof prefill === 'string' && prefill.length > 0 ? prefill : undefined;
 
   const headerQuery = useConversationHeader(convId);
   const messagesQuery = useConversationMessages(convId);
@@ -652,6 +660,7 @@ export function ConversationScreen() {
           isSendingVoice={isSendingVoice}
           replyingTo={replyingPreview}
           onCancelReply={handleCancelReply}
+          initialContent={initialMessageContent}
           disabled={sendMessage.isPending || isAttaching || isSendingVoice}
         />
         <View style={{ height: insets.bottom }} backgroundColor="$surface" />


### PR DESCRIPTION
## Summary

Fin du parcours **visiteur** marketplace : grille (PR #248 mergée) → fiche produit → conversation avec le vendeur. Deux tickets bundle ici parce que **E7-13 est juste le CTA bas de la fiche** — le découpler aurait été du churn.

- **E7-12 (#243)** : fiche produit complète avec carousel, prix/promo, vendeur, similaires
- **E7-13 (#244)** : CTA "Contacter le vendeur" → DM avec message pré-rempli

## Contenu code

### Hooks
- \`useListingDetail\` — \`useQuery\` sur \`get_listing_detail\`. **staleTime 60s + refetchOnWindowFocus/Mount désactivés** pour éviter de spammer view_count (la RPC l'incrémente à chaque appel).
- \`useSimilarListings\` — \`useQuery\` sur \`get_similar_listings\` (staleTime 5min).

### Composants
- \`ListingImageCarousel\` — FlatList \`pagingEnabled\` horizontal + dots de pagination. Fallback 1 image / 0 image.
- \`SellerCard\` — avatar + @username + VerifiedBadge + nom complet, tap → \`/profile/[seller_id]\`.
- \`SimilarListingsRow\` — carousel horizontal de mini-cards. Tap utilise \`router.replace\` (pas \`push\`) pour éviter d'empiler des fiches produit en boucle.

### Écran \`app/shop/[id].tsx\`
- Header overlay : retour + bookmark dans des ronds noirs semi-transparents par-dessus le carousel
- Badge promo conditionnel + titre + prix actuel/barré + dot rouge \`-X%\`
- Métadonnées chip : état + 📍 localisation + date relative FR + 👁 vues
- Description + carte vendeur + similaires
- **4 états distincts** : loading / error / not-found / found (mine vs not-mine)

### CTA E7-13
- Sticky bottom plein largeur, \`accessibilityHint\` explicite
- Garde-fou : si l'user est le seller → remplacé par "C'est votre annonce" (évite création de DM avec soi-même)
- Tap → \`useGetOrCreateDm\` puis \`router.push\` vers \`/messages/[id]\` avec query param \`prefill\`
- \`MessageInput\` : nouvelle prop \`initialContent\` appliquée **uniquement au mount** via \`useState\` lazy initializer (pas d'écrasement si l'user édite ensuite)
- Cursor positionné en bout de texte pour permettre l'édition immédiate
- **AUCUN auto-send** — l'utilisateur valide manuellement (cf brief)
- Erreur DM → Alert FR

### Wiring \`ConversationScreen\`
- Lit \`prefill\` via \`useLocalSearchParams\`, le propage à \`MessageInput\`
- Compatible avec les flows existants (no-op si \`prefill\` absent)

## Test plan

- [ ] Lancer Dev Build, ouvrir la grille \`/shop\`, taper une card
- [ ] Carousel : swipe entre images + dots qui suivent
- [ ] Bookmark toggle dans la fiche : visuel update + persiste après refresh
- [ ] Carte vendeur → \`/profile/[id]\` ouvre le bon profil
- [ ] Annonces similaires : taper une → la fiche se remplace (back retourne à la grille, pas à la fiche précédente)
- [ ] Tap "Contacter le vendeur" → conversation ouverte avec message pré-rempli
- [ ] Le message pré-rempli est ÉDITABLE et N'EST PAS auto-envoyé
- [ ] Sur ma propre annonce → CTA remplacé par "C'est votre annonce"
- [ ] view_count s'incrémente à l'ouverture (vérifier en DB après 1 fetch)
- [ ] view_count ne s'incrémente PAS plusieurs fois sur re-render (60s staleTime)

## Prochaines étapes

- **E7-14 (#245)** Création d'annonce — utilise le bucket Storage E7-09
- **E7-15 (#246)** Onglet boutique sur profile (réutilise \`ListingCard\`)
- **E7-16 (#247)** Écran favoris (route \`/shop/bookmarks\` déjà branchée)
- **E7-11 (#242)** Modale filtres avancés (\`handleOpenAdvanced\` toujours stub)

Après merge → parcours visiteur complet. Reste le parcours vendeur.