### PR TITLE
feat(marketplace): création d'annonce — #245

### DIFF
--- a/app/shop/create.tsx
+++ b/app/shop/create.tsx
@@ -1,0 +1,498 @@
+// Écran Création d'annonce — E7-14 (#245)
+//
+// Stack : React Hook Form + Zod (cf CLAUDE.md). On valide le formulaire avant
+// d'uploader la moindre image — pas de réseau gaspillé si l'user envoie un
+// titre vide.
+//
+// Submit pipeline :
+//   1. Validation Zod (échec → erreurs inline)
+//   2. Upload séquentiel des images vers le bucket `listings/<user_id>/...`
+//      (échec d'une image → on stoppe et on alert ; l'user peut retry)
+//   3. RPC create_listing(...) avec les URLs publiques
+//   4. router.replace vers /shop/[newId] pour atterrir sur la fiche fraîche
+//
+// Note : on n'upload pas en background pendant que l'user remplit le titre —
+// le bénéfice (gain de quelques secondes) ne vaut pas la complexité (gérer
+// l'annulation, le nettoyage des orphans en cas d'abandon).
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { router, Stack } from 'expo-router';
+import { ArrowLeft } from 'lucide-react-native';
+import { useCallback, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Input, Text, TextArea, View, XStack, YStack } from 'tamagui';
+import { z } from 'zod';
+
+import { ListingImagePicker } from '@/features/marketplace/components/ListingImagePicker';
+import { SegmentedChoice } from '@/features/marketplace/components/SegmentedChoice';
+import { useCreateListing } from '@/features/marketplace/hooks/useCreateListing';
+import { logger } from '@/lib/logger';
+import { uploadListingImage } from '@/lib/storage';
+
+const MAX_TITLE = 80;
+const MAX_DESCRIPTION = 2000;
+const MAX_IMAGES = 4;
+const MAX_PRICE_EUR = 999_999;
+
+const CategoryEnum = z.enum(['product', 'service']);
+const ConditionEnum = z.enum(['neuf', 'tres_bon_etat', 'bon_etat', 'occasion']);
+
+const ListingSchema = z
+  .object({
+    category: CategoryEnum,
+    title: z
+      .string()
+      .trim()
+      .min(3, 'Le titre doit faire au moins 3 caractères.')
+      .max(MAX_TITLE, `Maximum ${MAX_TITLE} caractères.`),
+    description: z
+      .string()
+      .trim()
+      .min(10, 'Décris ton annonce en au moins 10 caractères.')
+      .max(MAX_DESCRIPTION, `Maximum ${MAX_DESCRIPTION} caractères.`),
+    // Le user tape un montant en euros, on convertit en cents au submit.
+    priceEuros: z
+      .string()
+      .trim()
+      .min(1, 'Indique un prix.')
+      .refine((v) => /^\d+([.,]\d{1,2})?$/.test(v), 'Format invalide (ex: 12,50)')
+      .refine((v) => {
+        const num = Number.parseFloat(v.replace(',', '.'));
+        return Number.isFinite(num) && num > 0 && num <= MAX_PRICE_EUR;
+      }, `Prix entre 0,01 € et ${MAX_PRICE_EUR} €.`),
+    location: z.string().trim().max(120).optional(),
+    condition: ConditionEnum.nullable().optional(),
+  })
+  .refine((data) => data.category === 'product' || data.condition == null, {
+    message: "L'état ne s'applique qu'aux produits.",
+    path: ['condition'],
+  });
+
+type FormValues = z.infer<typeof ListingSchema>;
+
+const CATEGORY_OPTIONS = [
+  { value: 'product' as const, label: 'Produit' },
+  { value: 'service' as const, label: 'Service' },
+];
+
+const CONDITION_OPTIONS = [
+  { value: 'neuf' as const, label: 'Neuf' },
+  { value: 'tres_bon_etat' as const, label: 'Très bon état' },
+  { value: 'bon_etat' as const, label: 'Bon état' },
+  { value: 'occasion' as const, label: 'Occasion' },
+];
+
+export default function CreateListingScreen() {
+  const insets = useSafeAreaInsets();
+  const createListing = useCreateListing();
+
+  const [images, setImages] = useState<string[]>([]);
+  const [imagesError, setImagesError] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<{ done: number; total: number } | null>(
+    null
+  );
+
+  const {
+    control,
+    handleSubmit,
+    watch,
+    setValue,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(ListingSchema),
+    defaultValues: {
+      category: 'product',
+      title: '',
+      description: '',
+      priceEuros: '',
+      location: '',
+      condition: null,
+    },
+    mode: 'onSubmit',
+  });
+
+  const category = watch('category');
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/shop');
+  }, []);
+
+  const handleClose = useCallback(() => {
+    Alert.alert('Abandonner cette annonce ?', 'Tu perdras ce que tu as saisi.', [
+      { text: 'Continuer la saisie', style: 'cancel' },
+      { text: 'Abandonner', style: 'destructive', onPress: handleBack },
+    ]);
+  }, [handleBack]);
+
+  const onSubmit = useCallback(
+    async (values: FormValues) => {
+      // Garde-fou côté formulaire : au moins 1 image.
+      if (images.length === 0) {
+        setImagesError('Ajoute au moins 1 photo.');
+        return;
+      }
+      setImagesError(null);
+
+      // Conversion euros → cents (la regex Zod garantit le format).
+      const euros = Number.parseFloat(values.priceEuros.replace(',', '.'));
+      const priceCents = Math.round(euros * 100);
+
+      // Upload séquentiel — un échec stoppe et l'user retry (on garde la
+      // saisie). On pourrait paralléliser mais pour 1-4 images, ça n'apporte
+      // pas grand chose et l'erreur est plus lisible séquentiellement.
+      try {
+        setUploadProgress({ done: 0, total: images.length });
+        const publicUrls: string[] = [];
+        for (let i = 0; i < images.length; i++) {
+          const uri = images[i];
+          if (!uri) continue;
+          const result = await uploadListingImage(uri);
+          publicUrls.push(result.publicUrl);
+          setUploadProgress({ done: i + 1, total: images.length });
+        }
+        setUploadProgress(null);
+
+        const newId = await createListing.mutateAsync({
+          category: values.category,
+          title: values.title.trim(),
+          description: values.description.trim(),
+          price_cents: priceCents,
+          currency: 'EUR',
+          images: publicUrls,
+          location: values.location?.trim() || null,
+          condition: values.category === 'product' ? (values.condition ?? null) : null,
+        });
+
+        // Replace pour que le back de la fiche atterrisse sur la grille
+        // (et pas sur le formulaire vide).
+        router.replace(`/shop/${newId}`);
+      } catch (err) {
+        setUploadProgress(null);
+        const message = err instanceof Error ? err.message : 'Une erreur est survenue, réessaie.';
+        logger.warn('create_listing submit failed', { message });
+        Alert.alert('Publication impossible', message);
+      }
+    },
+    [createListing, images]
+  );
+
+  const isBusy = isSubmitting || createListing.isPending || uploadProgress !== null;
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={styles.flex}
+      >
+        <View flex={1} backgroundColor="$background" paddingTop={insets.top}>
+          {/* Header */}
+          <XStack
+            height={56}
+            paddingHorizontal={12}
+            alignItems="center"
+            gap={12}
+            borderBottomWidth={StyleSheet.hairlineWidth}
+            borderBottomColor="$borderColor"
+          >
+            <Pressable
+              onPress={handleClose}
+              disabled={isBusy}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              accessibilityRole="button"
+              accessibilityLabel="Annuler"
+            >
+              <ArrowLeft size={24} color="#FFFFFF" />
+            </Pressable>
+            <Text flex={1} color="$color" fontSize={18} fontWeight="700">
+              Nouvelle annonce
+            </Text>
+          </XStack>
+
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            {/* Section Photos */}
+            <Section title="Photos" required>
+              <ListingImagePicker
+                images={images}
+                onChange={(next) => {
+                  setImages(next);
+                  if (next.length > 0) setImagesError(null);
+                }}
+                maxImages={MAX_IMAGES}
+                disabled={isBusy}
+              />
+              {imagesError ? <ErrorText>{imagesError}</ErrorText> : null}
+            </Section>
+
+            {/* Section Catégorie */}
+            <Section title="Catégorie" required>
+              <Controller
+                control={control}
+                name="category"
+                render={({ field: { value, onChange } }) => (
+                  <SegmentedChoice
+                    options={CATEGORY_OPTIONS}
+                    value={value}
+                    onChange={(next) => {
+                      onChange(next);
+                      // Reset condition si on bascule sur service
+                      if (next === 'service') setValue('condition', null);
+                    }}
+                    disabled={isBusy}
+                  />
+                )}
+              />
+            </Section>
+
+            {/* Section Titre */}
+            <Section title="Titre" required>
+              <Controller
+                control={control}
+                name="title"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <Input
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Ex : Casque audio sans fil"
+                    placeholderTextColor="$placeholderColor"
+                    maxLength={MAX_TITLE}
+                    editable={!isBusy}
+                    color="$color"
+                    backgroundColor="$surface"
+                    borderWidth={0}
+                    borderRadius="$md"
+                    height={48}
+                    paddingHorizontal={14}
+                    accessibilityLabel="Titre de l'annonce"
+                  />
+                )}
+              />
+              {errors.title ? <ErrorText>{errors.title.message}</ErrorText> : null}
+            </Section>
+
+            {/* Section Description */}
+            <Section title="Description" required>
+              <Controller
+                control={control}
+                name="description"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextArea
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Décris ton article : état, accessoires inclus, raison de la vente…"
+                    placeholderTextColor="$placeholderColor"
+                    maxLength={MAX_DESCRIPTION}
+                    editable={!isBusy}
+                    color="$color"
+                    backgroundColor="$surface"
+                    borderWidth={0}
+                    borderRadius="$md"
+                    minHeight={120}
+                    paddingHorizontal={14}
+                    paddingTop={12}
+                    textAlignVertical="top"
+                    accessibilityLabel="Description de l'annonce"
+                  />
+                )}
+              />
+              {errors.description ? <ErrorText>{errors.description.message}</ErrorText> : null}
+            </Section>
+
+            {/* Section Prix */}
+            <Section title="Prix" required>
+              <Controller
+                control={control}
+                name="priceEuros"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <XStack
+                    alignItems="center"
+                    gap={8}
+                    backgroundColor="$surface"
+                    borderRadius="$md"
+                    paddingHorizontal={14}
+                    height={48}
+                  >
+                    <Input
+                      flex={1}
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      placeholder="0,00"
+                      placeholderTextColor="$placeholderColor"
+                      keyboardType="decimal-pad"
+                      editable={!isBusy}
+                      color="$color"
+                      backgroundColor="transparent"
+                      borderWidth={0}
+                      paddingHorizontal={0}
+                      height={48}
+                      accessibilityLabel="Prix en euros"
+                    />
+                    <Text color="$textSecondary" fontSize={16} fontWeight="600">
+                      €
+                    </Text>
+                  </XStack>
+                )}
+              />
+              {errors.priceEuros ? <ErrorText>{errors.priceEuros.message}</ErrorText> : null}
+            </Section>
+
+            {/* Section État (uniquement si product) */}
+            {category === 'product' ? (
+              <Section title="État" subtitle="Optionnel">
+                <Controller
+                  control={control}
+                  name="condition"
+                  render={({ field: { value, onChange } }) => (
+                    <SegmentedChoice
+                      options={CONDITION_OPTIONS}
+                      value={value ?? null}
+                      onChange={onChange}
+                      allowDeselect
+                      onDeselect={() => onChange(null)}
+                      disabled={isBusy}
+                    />
+                  )}
+                />
+              </Section>
+            ) : null}
+
+            {/* Section Localisation */}
+            <Section title="Localisation" subtitle="Optionnel">
+              <Controller
+                control={control}
+                name="location"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <Input
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Ex : Paris 11ème"
+                    placeholderTextColor="$placeholderColor"
+                    maxLength={120}
+                    editable={!isBusy}
+                    color="$color"
+                    backgroundColor="$surface"
+                    borderWidth={0}
+                    borderRadius="$md"
+                    height={48}
+                    paddingHorizontal={14}
+                    accessibilityLabel="Localisation"
+                  />
+                )}
+              />
+            </Section>
+
+            {uploadProgress ? (
+              <Text fontSize={12} color="$textSecondary" textAlign="center" marginTop={8}>
+                Upload des photos {uploadProgress.done}/{uploadProgress.total}…
+              </Text>
+            ) : null}
+          </ScrollView>
+
+          {/* CTA sticky bottom */}
+          <YStack
+            paddingHorizontal={16}
+            paddingTop={12}
+            paddingBottom={insets.bottom + 12}
+            backgroundColor="$background"
+            borderTopWidth={StyleSheet.hairlineWidth}
+            borderTopColor="$borderColor"
+          >
+            <Pressable
+              onPress={handleSubmit(onSubmit)}
+              disabled={isBusy}
+              accessibilityRole="button"
+              accessibilityLabel="Publier l'annonce"
+              accessibilityState={{ disabled: isBusy }}
+              style={[styles.cta, { backgroundColor: isBusy ? '#1A1A1A' : '#10D970' }]}
+            >
+              {isBusy ? (
+                <ActivityIndicator color="#10D970" />
+              ) : (
+                <Text fontSize={15} fontWeight="800" color="#000000">
+                  Publier
+                </Text>
+              )}
+            </Pressable>
+          </YStack>
+        </View>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+function Section({
+  title,
+  subtitle,
+  required,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <YStack gap={10} marginTop={20}>
+      <XStack alignItems="baseline" gap={6}>
+        <Text fontSize={14} fontWeight="700" color="$color">
+          {title}
+        </Text>
+        {required ? (
+          <Text fontSize={12} color="#10D970" fontWeight="700">
+            *
+          </Text>
+        ) : null}
+        {subtitle ? (
+          <Text fontSize={11} color="$textSecondary">
+            · {subtitle}
+          </Text>
+        ) : null}
+      </XStack>
+      {children}
+    </YStack>
+  );
+}
+
+function ErrorText({ children }: { children: string | undefined }) {
+  if (!children) return null;
+  return (
+    <Text fontSize={12} color="#FF6B6B" marginTop={4}>
+      {children}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  cta: {
+    borderRadius: 9999,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 24,
+  },
+});

--- a/app/shop/index.tsx
+++ b/app/shop/index.tsx
@@ -10,7 +10,7 @@
 
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { router, Stack } from 'expo-router';
-import { ArrowLeft, Bookmark, Search, X } from 'lucide-react-native';
+import { ArrowLeft, Bookmark, Plus, Search, X } from 'lucide-react-native';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
@@ -84,6 +84,10 @@ export default function MarketplaceGridScreen() {
   const handleOpenBookmarks = useCallback(() => {
     // E7-16 livrera l'écran /shop/bookmarks
     router.push('/shop/bookmarks');
+  }, []);
+
+  const handleOpenCreate = useCallback(() => {
+    router.push('/shop/create');
   }, []);
 
   const handleOpenAdvanced = useCallback(() => {
@@ -170,6 +174,16 @@ export default function MarketplaceGridScreen() {
             accessibilityHint="Tap pour voir les annonces que tu as sauvegardées"
           >
             <Bookmark size={22} color="#FFFFFF" strokeWidth={2.2} />
+          </Pressable>
+          <Pressable
+            onPress={handleOpenCreate}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Publier une annonce"
+            accessibilityHint="Tap pour créer une nouvelle annonce"
+            style={styles.createButton}
+          >
+            <Plus size={20} color="#000000" strokeWidth={2.6} />
           </Pressable>
         </XStack>
 
@@ -291,6 +305,14 @@ export default function MarketplaceGridScreen() {
 }
 
 const styles = StyleSheet.create({
+  createButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#10D970',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   gridContent: {
     paddingTop: 8,
     paddingBottom: 24,

--- a/src/features/marketplace/components/ListingImagePicker.tsx
+++ b/src/features/marketplace/components/ListingImagePicker.tsx
@@ -1,0 +1,183 @@
+// ListingImagePicker — E7-14 (#245)
+//
+// Grid des images sélectionnées + bouton "Ajouter une photo". Limite à
+// MAX_IMAGES (4) — au-delà, le bouton disparaît.
+//
+// L'upload réel se fait au moment du submit du formulaire (cf
+// app/shop/create.tsx) pour ne pas uploader des images qu'on jettera si
+// l'user annule.
+
+import { Image } from 'expo-image';
+import * as ImagePicker from 'expo-image-picker';
+import { Camera, ImagePlus, X } from 'lucide-react-native';
+import { useCallback } from 'react';
+import { Alert, Pressable, StyleSheet } from 'react-native';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+export interface ListingImagePickerProps {
+  /** URIs locales (avant upload) ou URLs distantes (édition future). */
+  images: string[];
+  onChange: (next: string[]) => void;
+  maxImages?: number;
+  disabled?: boolean;
+}
+
+const DEFAULT_MAX = 4;
+const TILE_SIZE = 80;
+
+export function ListingImagePicker({
+  images,
+  onChange,
+  maxImages = DEFAULT_MAX,
+  disabled = false,
+}: ListingImagePickerProps) {
+  const canAdd = images.length < maxImages && !disabled;
+
+  const pickFromGallery = useCallback(async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      allowsMultipleSelection: true,
+      selectionLimit: Math.max(1, maxImages - images.length),
+      quality: 1,
+    });
+    if (result.canceled) return;
+    const picked = result.assets.map((a) => a.uri).slice(0, maxImages - images.length);
+    onChange([...images, ...picked]);
+  }, [images, maxImages, onChange]);
+
+  const pickFromCamera = useCallback(async () => {
+    const perm = await ImagePicker.requestCameraPermissionsAsync();
+    if (!perm.granted) {
+      Alert.alert(
+        'Caméra non autorisée',
+        'Active la caméra dans les réglages pour prendre une photo.'
+      );
+      return;
+    }
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 1,
+    });
+    if (result.canceled) return;
+    const uri = result.assets[0]?.uri;
+    if (uri) onChange([...images, uri]);
+  }, [images, onChange]);
+
+  const handleAdd = useCallback(() => {
+    if (!canAdd) return;
+    Alert.alert(
+      'Ajouter une photo',
+      `Tu peux ajouter encore ${maxImages - images.length} photo${maxImages - images.length > 1 ? 's' : ''}.`,
+      [
+        { text: 'Galerie', onPress: () => void pickFromGallery() },
+        { text: 'Caméra', onPress: () => void pickFromCamera() },
+        { text: 'Annuler', style: 'cancel' },
+      ]
+    );
+  }, [canAdd, images.length, maxImages, pickFromCamera, pickFromGallery]);
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      onChange(images.filter((_, i) => i !== index));
+    },
+    [images, onChange]
+  );
+
+  return (
+    <YStack gap={8}>
+      <XStack gap={8} flexWrap="wrap">
+        {images.map((uri, i) => (
+          <View key={`${uri}-${i}`} style={styles.tile}>
+            <Image source={{ uri }} style={styles.tileImage} contentFit="cover" />
+            <Pressable
+              onPress={() => handleRemove(i)}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel={`Supprimer la photo ${i + 1}`}
+              style={styles.removeBadge}
+            >
+              <X size={12} color="#FFFFFF" strokeWidth={3} />
+            </Pressable>
+            {i === 0 ? (
+              <View style={styles.coverBadge}>
+                <Text fontSize={9} fontWeight="700" color="#000000">
+                  COUVERTURE
+                </Text>
+              </View>
+            ) : null}
+          </View>
+        ))}
+
+        {canAdd ? (
+          <Pressable
+            onPress={handleAdd}
+            accessibilityRole="button"
+            accessibilityLabel={
+              images.length === 0
+                ? 'Ajouter une photo'
+                : `Ajouter une photo (${images.length}/${maxImages})`
+            }
+            style={styles.addTile}
+          >
+            {images.length === 0 ? (
+              <Camera size={26} color="#FFFFFF" strokeWidth={1.8} />
+            ) : (
+              <ImagePlus size={22} color="#FFFFFF" strokeWidth={1.8} />
+            )}
+            <Text fontSize={10} color="#A0A0A0" marginTop={4}>
+              {images.length}/{maxImages}
+            </Text>
+          </Pressable>
+        ) : null}
+      </XStack>
+      <Text fontSize={11} color="$textSecondary">
+        La 1ère photo sera utilisée comme couverture. Glisse pour réorganiser bientôt.
+      </Text>
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  addTile: {
+    width: TILE_SIZE,
+    height: TILE_SIZE,
+    borderRadius: 10,
+    backgroundColor: '#1A1A1A',
+    borderWidth: 1,
+    borderColor: '#333',
+    borderStyle: 'dashed',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  coverBadge: {
+    position: 'absolute',
+    bottom: 4,
+    left: 4,
+    backgroundColor: '#10D970',
+    paddingHorizontal: 5,
+    paddingVertical: 2,
+    borderRadius: 4,
+  },
+  removeBadge: {
+    position: 'absolute',
+    top: 4,
+    right: 4,
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  tile: {
+    width: TILE_SIZE,
+    height: TILE_SIZE,
+    borderRadius: 10,
+    overflow: 'hidden',
+    backgroundColor: '#1A1A1A',
+  },
+  tileImage: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/src/features/marketplace/components/SegmentedChoice.tsx
+++ b/src/features/marketplace/components/SegmentedChoice.tsx
@@ -1,0 +1,78 @@
+// SegmentedChoice — E7-14 (#245)
+//
+// Composant générique de choix segmenté (boutons exclusifs alignés
+// horizontalement). Utilisé pour Catégorie (product/service) et État
+// (4 valeurs). Pattern volontairement minimaliste : pas d'icône — texte FR
+// suffit pour l'usage MVP.
+
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, XStack } from 'tamagui';
+
+export interface SegmentedOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+export interface SegmentedChoiceProps<T extends string> {
+  options: SegmentedOption<T>[];
+  value: T | null;
+  onChange: (next: T) => void;
+  /** Permet la désélection (tap sur la valeur active la repasse à null). */
+  allowDeselect?: boolean;
+  onDeselect?: () => void;
+  disabled?: boolean;
+}
+
+export function SegmentedChoice<T extends string>({
+  options,
+  value,
+  onChange,
+  allowDeselect = false,
+  onDeselect,
+  disabled = false,
+}: SegmentedChoiceProps<T>) {
+  return (
+    <XStack flexWrap="wrap" gap={8}>
+      {options.map((opt) => {
+        const isActive = value === opt.value;
+        return (
+          <Pressable
+            key={opt.value}
+            onPress={() => {
+              if (disabled) return;
+              if (isActive && allowDeselect) {
+                onDeselect?.();
+              } else {
+                onChange(opt.value);
+              }
+            }}
+            accessibilityRole="radio"
+            accessibilityLabel={opt.label}
+            accessibilityState={{ selected: isActive, disabled }}
+            style={[styles.chip, isActive ? styles.chipActive : null]}
+          >
+            <Text
+              fontSize={13}
+              fontWeight={isActive ? '700' : '500'}
+              color={isActive ? '#000000' : '#FFFFFF'}
+            >
+              {opt.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </XStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderRadius: 9999,
+    backgroundColor: '#1A1A1A',
+  },
+  chipActive: {
+    backgroundColor: '#FFFFFF',
+  },
+});

--- a/src/features/marketplace/hooks/useCreateListing.ts
+++ b/src/features/marketplace/hooks/useCreateListing.ts
@@ -1,0 +1,57 @@
+// useCreateListing — E7-14 (#245) — Création d'annonce
+//
+// Wrappe la RPC create_listing (security definer, seller_id forcé à
+// auth.uid() côté DB → impossible de créer une annonce pour un autre user).
+//
+// Hors-scope création utilisateur : badge et discount_percent ne sont pas
+// dans la signature de la RPC — réservés à une éventuelle interface admin.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+import type { ListingCategory, ListingCondition } from './useListings';
+
+export interface CreateListingInput {
+  category: ListingCategory;
+  title: string;
+  description: string;
+  price_cents: number;
+  currency?: string;
+  images?: string[];
+  location?: string | null;
+  condition?: ListingCondition | null;
+}
+
+export function useCreateListing() {
+  const queryClient = useQueryClient();
+
+  return useMutation<string, Error, CreateListingInput>({
+    mutationFn: async (input): Promise<string> => {
+      const { data, error } = await supabase.rpc('create_listing', {
+        p_category: input.category,
+        p_title: input.title,
+        p_description: input.description,
+        p_price_cents: input.price_cents,
+        p_currency: input.currency ?? 'EUR',
+        p_images: input.images ?? [],
+        p_location: input.location ?? null,
+        p_condition: input.condition ?? null,
+      });
+      if (error) {
+        logger.warn('create_listing failed', {
+          message: error.message,
+          category: input.category,
+        });
+        throw error;
+      }
+      // La RPC retourne directement l'UUID en scalaire.
+      return String(data);
+    },
+    onSuccess: () => {
+      // Toutes les queries marketplace (grille + bookmarks) sont périmées.
+      void queryClient.invalidateQueries({ queryKey: ['marketplace'] });
+    },
+  });
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -467,6 +467,54 @@ export interface UploadStoryMediaResult {
  * Images : même pipeline de compression que uploadPostImage.
  * Vidéos  : upload direct (expo-camera livre déjà du mp4, pas de recompression).
  */
+// ---------------------------------------------------------------------------
+// Marketplace upload (#245 — E7-14 — création d'annonce)
+// ---------------------------------------------------------------------------
+
+const LISTINGS_BUCKET = 'listings';
+
+export interface UploadListingImageResult {
+  publicUrl: string;
+  path: string;
+}
+
+/**
+ * Compresse + upload une image dans le bucket `listings`. Même pipeline que
+ * uploadPostImage (quality 0.8, resize 1920px max). Path :
+ * `{user_id}/{uuid}.jpg` (les policies du bucket exigent que le 1er segment
+ * soit l'auth.uid()).
+ */
+export async function uploadListingImage(
+  uri: string,
+  options?: { signal?: AbortSignal; onProgress?: (p: number) => void; quality?: number }
+): Promise<UploadListingImageResult> {
+  const quality = clamp01(options?.quality ?? DEFAULT_QUALITY);
+  const signal = options?.signal;
+  const onProgress = options?.onProgress;
+
+  try {
+    if (signal?.aborted) throw abortedError();
+    const session = await getFreshSession();
+    const compressedUri = await compressImage(uri, quality);
+    const path = `${session.user.id}/${uuidv4()}.jpg`;
+    try {
+      await uploadToStorage(compressedUri, path, LISTINGS_BUCKET, 'image/jpeg', {
+        onProgress,
+        signal,
+      });
+    } finally {
+      await cleanupTempFiles([compressedUri]);
+    }
+    const { data } = supabase.storage.from(LISTINGS_BUCKET).getPublicUrl(path);
+    return { publicUrl: data.publicUrl, path };
+  } catch (error) {
+    const uploadError = error instanceof UploadError ? error : new UploadError('upload', error);
+    if (signal?.aborted) logger.debug('upload_listing_image_cancelled');
+    else logger.error('upload_listing_image_failed', uploadError);
+    throw uploadError;
+  }
+}
+
 export async function uploadStoryMedia(
   uri: string,
   mediaType: 'image' | 'video',


### PR DESCRIPTION
## Summary

Parcours **vendeur** débuté : l'utilisateur peut maintenant publier une annonce depuis la grille. Avec ça, on a un cycle complet visiteur ⇄ vendeur testable end-to-end en interne.

## Contenu

### \`src/lib/storage.ts\` — \`uploadListingImage\`
Reproduit strictement le pattern \`uploadPostImage\` / \`uploadMessageImage\` (compress quality 0.8, resize 1920px max). Path \`<user_id>/<uuid>.jpg\` conforme aux policies du bucket \`listings\` (1er segment = \`auth.uid()::text\`). Mêmes garanties d'erreur + AbortSignal + cleanup temp.

### \`useCreateListing\`
Mutation wrappant la RPC \`create_listing\` (security definer, seller_id forcé à \`auth.uid()\` côté DB). Invalidation \`['marketplace']\` à success → grille + bookmarks rafraîchis. \`discount_percent\` et \`badge\` volontairement hors signature (admin-only, pas exposés au user).

### Composants
- **\`ListingImagePicker\`** — grid 80px, max 4, badge \`COUVERTURE\` sur la 1ère, X pour supprimer. Tap "Ajouter" → Alert Galerie/Caméra (permission caméra demandée à l'usage seulement).
- **\`SegmentedChoice<T>\`** — composant générique réutilisé pour Catégorie ET État. \`allowDeselect\` optionnel. \`accessibilityRole="radio"\` + \`accessibilityState.selected\`.

### Écran \`app/shop/create.tsx\`
- **RHF + Zod** (stack figée CLAUDE.md), \`mode: 'onSubmit'\`
- Validation : titre 3-80, description 10-2000, prix \`decimal-pad\` avec regex strict (0,01 € à 999 999 €), location max 120
- **Refine cross-field** : "L'état ne s'applique qu'aux produits" si user a sélectionné une condition puis switché en service
- Conversion euros → cents au submit (\`Math.round\` car float imprécis)
- **Confirmation avant abandon** (Alert FR) — évite la perte de saisie accidentelle
- Tracking upload progress (X/Y) affiché pendant l'upload
- \`isBusy\` bloque tout pendant upload + RPC
- \`router.replace\` final → back depuis la fiche atterrit sur la grille, pas sur un formulaire vide

### \`app/shop/index.tsx\` — bouton "+" dans le header
Petit bouton rond vert à côté du bookmark, ouvre l'écran de création.

## Pipeline submit (raisonnement)

1. **Validation Zod** — échec → erreurs inline, aucun réseau gaspillé
2. **Upload séquentiel** des images vers \`listings/<user_id>/<uuid>.jpg\` — un échec stoppe et l'user retry sans perdre la saisie. Pourquoi séquentiel vs parallèle : pour 1-4 images, gain marginal et erreur plus lisible.
3. **RPC \`create_listing\`** avec les URLs publiques
4. **\`router.replace\`** vers \`/shop/<newId>\` pour atterrir sur la fiche fraîche

**Pas de pré-upload en background** pendant la saisie : le gain (quelques secondes) ne vaut pas la complexité (annulation, nettoyage des orphans en cas d'abandon).

## Test plan

- [ ] Lancer Dev Build, depuis la grille → tap "+" → écran création
- [ ] Submit sans image → erreur "Ajoute au moins 1 photo"
- [ ] Submit avec titre vide → erreur "au moins 3 caractères"
- [ ] Tap "Ajouter une photo" → Alert Galerie/Caméra
- [ ] Choisir 2-3 photos depuis la galerie → tuiles affichées avec badge COUVERTURE sur la 1ère
- [ ] Tap X sur une tuile → supprimée + le compteur n/4 se met à jour
- [ ] Sélectionner "Service" → la section État disparaît
- [ ] Retour avec saisie en cours → Alert "Abandonner cette annonce ?"
- [ ] Submit complet → upload progress (X/Y) → atterrissage sur fiche fraîche avec view_count=1
- [ ] Revenir sur la grille → la nouvelle annonce apparaît en tête

## Prochaines étapes (après merge)

- **E7-15 (#246)** Onglet boutique sur profile (réutilise \`ListingCard\`)
- **E7-16 (#247)** Écran favoris (route \`/shop/bookmarks\` déjà branchée)
- **E7-11 (#242)** Modale filtres avancés (\`handleOpenAdvanced\` stub)

Après ces 3 tickets → **marketplace L0 = scope complet** prêt pour bug bash + démo interne.