### PR TITLE
feat(marketplace): écran liste favoris — #247

### DIFF
--- a/app/shop/bookmarks.tsx
+++ b/app/shop/bookmarks.tsx
@@ -1,0 +1,221 @@
+// Écran Favoris Marketplace — E7-16 (#247)
+//
+// Liste paginée des annonces que l'user a mises en favori. Réutilise
+// ListingCard (donc même UX que la grille principale, à un seul détail
+// près : ici TOUS les items ont bookmarked_by_me=true par construction).
+//
+// Pull to refresh + infinite scroll + empty state quand l'user n'a encore
+// rien sauvegardé.
+
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
+import { router, Stack } from 'expo-router';
+import { ArrowLeft, BookmarkX } from 'lucide-react-native';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Pressable,
+  RefreshControl,
+  StyleSheet,
+  useWindowDimensions,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+import { ListingCard } from '@/features/marketplace/components/ListingCard';
+import { useBookmarkedListings } from '@/features/marketplace/hooks/useBookmarkedListings';
+import {
+  useToggleListingBookmark,
+  type ListingCard as ListingCardData,
+} from '@/features/marketplace/hooks/useListings';
+
+const GRID_GAP = 8;
+const NUM_COLUMNS = 2;
+const GUTTER = 12;
+
+export default function BookmarksScreen() {
+  const insets = useSafeAreaInsets();
+  const { width: screenWidth } = useWindowDimensions();
+  const listRef = useRef<FlashListRef<ListingCardData>>(null);
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+
+  const bookmarksQuery = useBookmarkedListings();
+  const toggleBookmark = useToggleListingBookmark();
+
+  const allListings = useMemo<ListingCardData[]>(
+    () => bookmarksQuery.data?.pages.flatMap((p) => p.listings) ?? [],
+    [bookmarksQuery.data]
+  );
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/shop');
+  }, []);
+
+  const handleCardPress = useCallback((listingId: string) => {
+    router.push(`/shop/${listingId}`);
+  }, []);
+
+  const handleToggleBookmark = useCallback(
+    (listingId: string) => {
+      // L'optimistic update du hook flip bookmarked_by_me partout, donc
+      // l'item disparaitra de cette liste au prochain refetch. On déclenche
+      // manuellement le refetch pour que l'effet soit immédiat à l'écran
+      // (sinon l'user voit un item "non-bookmarked" pendant 1-2 sec).
+      toggleBookmark.mutate({ listingId }, { onSettled: () => void bookmarksQuery.refetch() });
+    },
+    [bookmarksQuery, toggleBookmark]
+  );
+
+  const handleLoadMore = useCallback(() => {
+    if (bookmarksQuery.hasNextPage && !bookmarksQuery.isFetchingNextPage) {
+      void bookmarksQuery.fetchNextPage();
+    }
+  }, [bookmarksQuery]);
+
+  const handlePullToRefresh = useCallback(async () => {
+    setIsManualRefreshing(true);
+    await bookmarksQuery.refetch();
+    setIsManualRefreshing(false);
+  }, [bookmarksQuery]);
+
+  const cardWidth = useMemo(
+    () => (screenWidth - GUTTER * 2 - GRID_GAP * (NUM_COLUMNS - 1)) / NUM_COLUMNS,
+    [screenWidth]
+  );
+
+  const renderItem = useCallback(
+    ({ item, index }: { item: ListingCardData; index: number }) => {
+      const isLeftColumn = index % NUM_COLUMNS === 0;
+      return (
+        <View width={cardWidth} marginRight={isLeftColumn ? GRID_GAP : 0} marginBottom={GRID_GAP}>
+          <ListingCard
+            listing={item}
+            onPress={() => handleCardPress(item.id)}
+            onToggleBookmark={() => handleToggleBookmark(item.id)}
+            isBookmarkPending={toggleBookmark.isPending}
+          />
+        </View>
+      );
+    },
+    [cardWidth, handleCardPress, handleToggleBookmark, toggleBookmark.isPending]
+  );
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+        {/* Header */}
+        <XStack
+          height={56}
+          paddingHorizontal={12}
+          alignItems="center"
+          gap={12}
+          borderBottomWidth={StyleSheet.hairlineWidth}
+          borderBottomColor="$borderColor"
+        >
+          <Pressable
+            onPress={handleBack}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Retour"
+          >
+            <ArrowLeft size={24} color="#FFFFFF" />
+          </Pressable>
+          <Text flex={1} color="$color" fontSize={18} fontWeight="700">
+            Mes favoris
+          </Text>
+        </XStack>
+
+        {/* Grid */}
+        <View flex={1} paddingHorizontal={GUTTER}>
+          {bookmarksQuery.isLoading ? (
+            <YStack flex={1} alignItems="center" justifyContent="center">
+              <ActivityIndicator color="#FFFFFF" />
+            </YStack>
+          ) : bookmarksQuery.isError ? (
+            <YStack
+              flex={1}
+              alignItems="center"
+              justifyContent="center"
+              paddingHorizontal={24}
+              gap={8}
+            >
+              <Text fontSize={16} fontWeight="700" color="$color">
+                Impossible de charger tes favoris
+              </Text>
+              <Text fontSize={13} color="$textSecondary" textAlign="center">
+                Tire vers le bas pour réessayer.
+              </Text>
+            </YStack>
+          ) : allListings.length === 0 ? (
+            <YStack
+              flex={1}
+              alignItems="center"
+              justifyContent="center"
+              paddingHorizontal={24}
+              gap={12}
+            >
+              <BookmarkX size={48} color="#666" strokeWidth={1.5} />
+              <Text fontSize={16} fontWeight="700" color="$color" textAlign="center">
+                Aucun favori pour l&apos;instant
+              </Text>
+              <Text fontSize={13} color="$textSecondary" textAlign="center">
+                Touche l&apos;icône signet sur une annonce pour la retrouver ici.
+              </Text>
+              <Pressable
+                onPress={() => router.replace('/shop')}
+                accessibilityRole="button"
+                accessibilityLabel="Découvrir la boutique"
+                style={styles.cta}
+              >
+                <Text fontSize={14} fontWeight="800" color="#000000">
+                  Découvrir la boutique
+                </Text>
+              </Pressable>
+            </YStack>
+          ) : (
+            <FlashList
+              ref={listRef}
+              data={allListings}
+              renderItem={renderItem}
+              keyExtractor={(item) => item.id}
+              numColumns={NUM_COLUMNS}
+              onEndReached={handleLoadMore}
+              onEndReachedThreshold={0.4}
+              contentContainerStyle={styles.gridContent}
+              refreshControl={
+                <RefreshControl
+                  refreshing={isManualRefreshing}
+                  onRefresh={() => void handlePullToRefresh()}
+                  tintColor="#10D970"
+                  colors={['#10D970']}
+                />
+              }
+              ListFooterComponent={
+                bookmarksQuery.isFetchingNextPage ? (
+                  <YStack paddingVertical={16} alignItems="center">
+                    <ActivityIndicator color="#FFFFFF" />
+                  </YStack>
+                ) : null
+              }
+            />
+          )}
+        </View>
+      </YStack>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  cta: {
+    marginTop: 8,
+    backgroundColor: '#10D970',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 9999,
+  },
+  gridContent: {
+    paddingTop: 8,
+    paddingBottom: 24,
+  },
+});

--- a/src/features/marketplace/hooks/useBookmarkedListings.ts
+++ b/src/features/marketplace/hooks/useBookmarkedListings.ts
@@ -1,0 +1,86 @@
+// useBookmarkedListings — E7-16 (#247)
+//
+// Pattern useInfiniteQuery sur la RPC get_my_bookmarked_listings. La RPC
+// retourne déjà bookmarked_by_me=true sur toutes les rows ; on garde le
+// flag pour que ListingCard affiche le bookmark plein.
+//
+// QueryKey distincte de la grille : ['marketplace', 'bookmarks'] — c'est
+// celle invalidée par useToggleListingBookmark.onSettled. Si l'user
+// retire un favori depuis la grille, cet écran refetch.
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+import type { ListingCard } from './useListings';
+
+const PAGE_SIZE = 20;
+
+type RpcRow = Record<string, unknown>;
+
+function isCategory(value: unknown): value is ListingCard['category'] {
+  return value === 'product' || value === 'service';
+}
+
+function isCondition(value: unknown): value is NonNullable<ListingCard['condition']> {
+  return (
+    value === 'neuf' || value === 'tres_bon_etat' || value === 'bon_etat' || value === 'occasion'
+  );
+}
+
+function isBadge(value: unknown): value is NonNullable<ListingCard['badge']> {
+  return value === 'offre_speciale' || value === 'nouveaute' || value === 'recommandation';
+}
+
+function mapRow(row: RpcRow): ListingCard {
+  return {
+    id: String(row.id ?? ''),
+    seller_id: String(row.seller_id ?? ''),
+    seller_username: String(row.seller_username ?? ''),
+    seller_avatar_url: (row.seller_avatar_url as string | null) ?? null,
+    seller_is_verified: Boolean(row.seller_is_verified ?? false),
+    category: isCategory(row.category) ? row.category : 'product',
+    title: String(row.title ?? ''),
+    description: (row.description as string | null) ?? null,
+    price_cents: typeof row.price_cents === 'number' ? row.price_cents : null,
+    currency: String(row.currency ?? 'EUR'),
+    images: Array.isArray(row.images) ? (row.images as string[]) : [],
+    location: (row.location as string | null) ?? null,
+    condition: isCondition(row.condition) ? row.condition : null,
+    badge: isBadge(row.badge) ? row.badge : null,
+    discount_percent: typeof row.discount_percent === 'number' ? row.discount_percent : null,
+    view_count: typeof row.view_count === 'number' ? row.view_count : 0,
+    created_at: String(row.created_at ?? ''),
+    bookmarked_by_me: true,
+  };
+}
+
+async function fetchBookmarksPage(cursor: string | null) {
+  const { data, error } = await supabase.rpc('get_my_bookmarked_listings', {
+    p_cursor: cursor,
+    p_limit: PAGE_SIZE,
+  });
+  if (error) {
+    logger.warn('get_my_bookmarked_listings failed', { message: error.message });
+    throw error;
+  }
+  const rows = (data ?? []) as RpcRow[];
+  const listings = rows.map(mapRow);
+  // Cursor = bookmarked_at de la DERNIÈRE row (la RPC trie par lb.created_at
+  // desc — exposé en `bookmarked_at`). Cohérent avec le ORDER BY côté DB.
+  const lastBookmarkedAt = rows[rows.length - 1]?.bookmarked_at;
+  const nextCursor =
+    listings.length === PAGE_SIZE && typeof lastBookmarkedAt === 'string' ? lastBookmarkedAt : null;
+  return { listings, nextCursor };
+}
+
+export function useBookmarkedListings() {
+  return useInfiniteQuery({
+    queryKey: ['marketplace', 'bookmarks'],
+    queryFn: ({ pageParam }) => fetchBookmarksPage(pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    staleTime: 30_000,
+  });
+}

--- a/supabase/migrations/20260630120000_get_my_bookmarked_listings.sql
+++ b/supabase/migrations/20260630120000_get_my_bookmarked_listings.sql
@@ -1,0 +1,79 @@
+-- E7-16 (#247) — RPC liste des annonces favorites de l'user courant
+--
+-- Trie par date de bookmark (plus récent d'abord), pas par date de l'annonce.
+-- C'est plus intuitif côté UX : ce qu'on vient de sauvegarder remonte en tête.
+-- Cursor sur `lb.created_at` pour pagination cohérente.
+--
+-- Authentication requise (revoke anon/public) — la liste de favoris est
+-- forcément liée à un user authentifié.
+--
+-- Sécurité : security definer + filtre dur `lb.user_id = auth.uid()`. Le
+-- caller ne peut jamais voir les favoris d'un autre user.
+--
+-- Idempotent (`create or replace`), rejouable.
+
+create or replace function public.get_my_bookmarked_listings(
+  p_cursor timestamptz default null,
+  p_limit int default 20
+)
+returns table (
+  id uuid,
+  seller_id uuid,
+  seller_username text,
+  seller_avatar_url text,
+  seller_is_verified boolean,
+  category text,
+  title text,
+  description text,
+  price_cents int,
+  currency text,
+  images text[],
+  location text,
+  condition text,
+  badge text,
+  discount_percent int,
+  view_count int,
+  created_at timestamptz,
+  bookmarked_at timestamptz,
+  bookmarked_by_me boolean
+)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select
+    l.id,
+    l.seller_id,
+    p.username      as seller_username,
+    p.avatar_url    as seller_avatar_url,
+    p.is_verified   as seller_is_verified,
+    l.category::text,
+    l.title,
+    l.description,
+    l.price_cents,
+    l.currency,
+    l.images,
+    l.location,
+    l.condition,
+    l.badge,
+    l.discount_percent,
+    l.view_count,
+    l.created_at,
+    lb.created_at   as bookmarked_at,
+    true            as bookmarked_by_me
+  from public.listing_bookmarks lb
+  join public.listings l on l.id = lb.listing_id
+  join public.profiles p on p.id = l.seller_id
+  where lb.user_id = auth.uid()
+    and l.is_active = true
+    and (p_cursor is null or lb.created_at < p_cursor)
+  order by lb.created_at desc
+  limit p_limit;
+$$;
+
+grant execute on function public.get_my_bookmarked_listings(timestamptz, int) to authenticated;
+revoke execute on function public.get_my_bookmarked_listings(timestamptz, int) from anon, public;
+
+comment on function public.get_my_bookmarked_listings(timestamptz, int) is
+  'E7-16 (#247) — Liste paginée des annonces actives en favori de l''user courant. Cursor sur listing_bookmarks.created_at desc.';


### PR DESCRIPTION
## Summary

E7-16 (#247) — Écran liste des annonces favorites. Complète le parcours visiteur (l'icône bookmark en haut de la grille mène enfin quelque part).

⚠️ **1 migration DB à appliquer avant merge** (cf section Pré-requis).

## Contenu

### Migration \`20260630120000_get_my_bookmarked_listings.sql\`
- RPC \`get_my_bookmarked_listings(p_cursor, p_limit)\`
- \`security definer\` + \`stable\` + \`set search_path = public\`
- Filtre dur \`lb.user_id = auth.uid()\` → impossible de voir les favoris d'un autre user
- Trie par \`lb.created_at desc\` (UX intuitive : le dernier ajouté remonte)
- **Expose \`bookmarked_at\`** en plus des champs ListingCard pour permettre la pagination cohérente côté client. Sans ça, le curseur serait sur \`l.created_at\` désaligné du \`ORDER BY\` → pagination qui oscille
- Grant \`authenticated\` uniquement, revoke \`anon\`/\`public\`
- Idempotent (\`create or replace\`)

### \`useBookmarkedListings\`
- \`useInfiniteQuery\` pattern aligné sur \`useListings\`
- \`queryKey: ['marketplace', 'bookmarks']\` → c'est celle qu'invalide \`useToggleListingBookmark.onSettled\`. Conséquence : flip d'un favori depuis la grille ou la fiche → refresh automatique de cet écran.
- \`bookmarked_by_me=true\` forcé en mapping (garanti par la RPC)

### Écran \`app/shop/bookmarks.tsx\`
- Réutilise \`ListingCard\` (cohérence UX avec la grille principale)
- Pull to refresh + infinite scroll
- **Empty state spécifique** : icône \`BookmarkX\` + message FR + CTA "Découvrir la boutique" → \`/shop\`
- \`handleToggleBookmark\` déclenche manuellement \`refetch()\` \`onSettled\` — sans ça l'item resterait visible avec bookmark vide pendant 1-2 sec après un unbookmark (le temps que le rollback optimistic se propage)

## Pré-requis avant merge

- [ ] Migration appliquée sur **DEV** via AI Supabase
- [ ] Migration appliquée sur **STAGING** via AI Supabase
- [ ] Vérification : \`select proname from pg_proc where proname = 'get_my_bookmarked_listings';\` retourne 1 ligne sur les 2 environnements

## Test plan

- [ ] Lancer Dev Build, depuis la grille → tap icône bookmark dans le header
- [ ] Avec 0 favoris → empty state + CTA fonctionne
- [ ] Ajouter une annonce en favori depuis la grille → revenir sur l'écran favoris → elle apparait en tête
- [ ] Retirer un favori depuis l'écran favoris → l'item disparait sans flicker
- [ ] Avec >20 favoris → scroll infini déclenché à 40% du bas
- [ ] Pull to refresh fonctionne

## Suite

Après merge, marketplace L0 ≈ 75% livré. Reste :
- **E7-15 (#246)** Onglet boutique sur profile (~petit, réutilise \`ListingCard\`)
- **E7-11 (#242)** Modale filtres avancés (~moyen)

Avec ces 2 derniers tickets → **scope marketplace L0 complet** prêt pour bug bash + démo interne.