### PR TITLE
feat(profile): onglet Boutique — branchement fiche produit + CTA création — #246

### DIFF
--- a/src/features/profile/components/ListingCard.tsx
+++ b/src/features/profile/components/ListingCard.tsx
@@ -1,10 +1,19 @@
-// Carte produit (Listing) pour l'onglet Boutique — E3-VENDOR.
-// Affiche l'image principale en ratio 1:1 avec les overlays prix et action.
+// Carte produit (Listing) pour l'onglet Boutique — E3-VENDOR + E7-15 (#246).
+//
+// Tile carré 1:1 sur la grille 3 colonnes de l'onglet boutique du profil.
+// Diffère du ListingCard de la grille marketplace (qui est rectangulaire
+// avec un footer textuel) — ici on reste sur le format vitrine vendeur,
+// fidèle à la maquette Canva.
+//
+// E7-15 (#246) : le bouton "Voir le produit" navigue vers la fiche
+// produit (E7-12 — /shop/[id]) au lieu de l'Alert placeholder.
 
 import { Image } from 'expo-image';
+import { router } from 'expo-router';
 import { Store } from 'lucide-react-native';
-import { Alert, StyleSheet, TouchableOpacity } from 'react-native';
-import { Text, YStack } from 'tamagui';
+import { useCallback } from 'react';
+import { StyleSheet, TouchableOpacity } from 'react-native';
+import { Text, View, YStack } from 'tamagui';
 
 import type { ListingItem } from '@/features/profile/hooks/useListings';
 
@@ -15,14 +24,23 @@ interface ListingCardProps {
   isLastColumn: boolean;
 }
 
-export function ListingCard({ item, size, gap, isLastColumn }: ListingCardProps) {
-  // Placeholder MVP : la page produit n'existe pas encore (vertical Marketplace
-  // au Sprint 5). On affiche un message d'attente plutôt que de naviguer.
-  const handleViewProduct = () => {
-    Alert.alert('Bientôt disponible', 'La page produit arrive prochainement.');
-  };
+const BADGE_LABEL: Record<string, string> = {
+  offre_speciale: 'Promo',
+  nouveaute: 'Nouveau',
+  recommandation: 'Reco',
+};
 
-  // Conversion cents -> unité principale
+const BADGE_COLORS: Record<string, { bg: string; text: string }> = {
+  offre_speciale: { bg: '#E53935', text: '#FFFFFF' },
+  nouveaute: { bg: '#10D970', text: '#000000' },
+  recommandation: { bg: '#10D970', text: '#000000' },
+};
+
+export function ListingCard({ item, size, gap, isLastColumn }: ListingCardProps) {
+  const handleViewProduct = useCallback(() => {
+    router.push(`/shop/${item.id}`);
+  }, [item.id]);
+
   const price = item.price_cents / 100;
   const formattedPrice = new Intl.NumberFormat('fr-FR', {
     style: 'currency',
@@ -32,57 +50,109 @@ export function ListingCard({ item, size, gap, isLastColumn }: ListingCardProps)
   }).format(price);
 
   const mainImage = item.images && item.images.length > 0 ? item.images[0] : null;
+  const badgeData = item.badge ? BADGE_COLORS[item.badge] : null;
+  const badgeText = item.badge ? BADGE_LABEL[item.badge] : null;
 
   return (
-    <YStack
-      width={size}
-      height={size}
-      marginRight={isLastColumn ? 0 : gap}
-      marginBottom={gap}
-      position="relative"
-    >
-      {/* Image 1:1 */}
-      {mainImage ? (
-        <Image
-          source={{ uri: mainImage }}
-          style={styles.image}
-          contentFit="cover"
-          transition={200}
-        />
-      ) : (
-        <YStack
-          flex={1}
-          backgroundColor="$surface"
-          alignItems="center"
-          justifyContent="center"
-          borderRadius={8}
-        >
-          <Store size={32} color="#A0A0A0" />
-        </YStack>
-      )}
-
-      {/* Overlay Prix — bas à droite */}
+    <TouchableOpacity onPress={handleViewProduct} activeOpacity={0.85} style={{ borderRadius: 8 }}>
       <YStack
-        position="absolute"
-        bottom={8}
-        right={8}
-        backgroundColor="rgba(0, 0, 0, 0.7)"
-        paddingHorizontal={8}
-        paddingVertical={4}
-        borderRadius={6}
+        width={size}
+        height={size}
+        marginRight={isLastColumn ? 0 : gap}
+        marginBottom={gap}
+        position="relative"
+        accessibilityRole="button"
+        accessibilityLabel={`Voir le produit ${item.title}, ${formattedPrice}`}
       >
-        <Text fontSize={13} fontWeight="700" color="#FFFFFF">
-          {formattedPrice}
-        </Text>
-      </YStack>
+        {/* Image 1:1 */}
+        {mainImage ? (
+          <Image
+            source={{ uri: mainImage }}
+            style={styles.image}
+            contentFit="cover"
+            transition={200}
+          />
+        ) : (
+          <YStack
+            flex={1}
+            backgroundColor="$surface"
+            alignItems="center"
+            justifyContent="center"
+            borderRadius={8}
+          >
+            <Store size={32} color="#A0A0A0" />
+          </YStack>
+        )}
 
-      {/* Overlay Bouton — bas à gauche */}
-      <TouchableOpacity onPress={handleViewProduct} activeOpacity={0.8} style={styles.viewButton}>
-        <Text fontSize={11} fontWeight="600" color="#000000">
-          Voir le produit
-        </Text>
-      </TouchableOpacity>
-    </YStack>
+        {/* Badge promo overlay top-left */}
+        {badgeData && badgeText ? (
+          <View
+            position="absolute"
+            top={6}
+            left={6}
+            backgroundColor={badgeData.bg}
+            paddingHorizontal={6}
+            paddingVertical={2}
+            borderRadius={9999}
+            pointerEvents="none"
+          >
+            <Text fontSize={9} fontWeight="700" color={badgeData.text}>
+              {badgeText}
+            </Text>
+          </View>
+        ) : null}
+
+        {/* Badge discount overlay top-right si pas de badge */}
+        {!badgeData && item.discount_percent && item.discount_percent > 0 ? (
+          <View
+            position="absolute"
+            top={6}
+            right={6}
+            backgroundColor="#E53935"
+            paddingHorizontal={6}
+            paddingVertical={2}
+            borderRadius={6}
+            pointerEvents="none"
+          >
+            <Text fontSize={9} fontWeight="700" color="#FFFFFF">
+              -{item.discount_percent}%
+            </Text>
+          </View>
+        ) : null}
+
+        {/* Overlay Prix — bas à droite */}
+        <YStack
+          position="absolute"
+          bottom={8}
+          right={8}
+          backgroundColor="rgba(0, 0, 0, 0.7)"
+          paddingHorizontal={8}
+          paddingVertical={4}
+          borderRadius={6}
+          pointerEvents="none"
+        >
+          <Text fontSize={13} fontWeight="700" color="#FFFFFF">
+            {formattedPrice}
+          </Text>
+        </YStack>
+
+        {/* Overlay Bouton — bas à gauche */}
+        <View
+          position="absolute"
+          bottom={8}
+          left={8}
+          backgroundColor="#FFFFFF"
+          paddingHorizontal={10}
+          paddingVertical={5}
+          borderRadius={6}
+          pointerEvents="none"
+        >
+          <Text fontSize={11} fontWeight="600" color="#000000">
+            Voir le produit
+          </Text>
+        </View>
+      </YStack>
+    </TouchableOpacity>
   );
 }
 
@@ -91,14 +161,5 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
     borderRadius: 8,
-  },
-  viewButton: {
-    position: 'absolute',
-    bottom: 8,
-    left: 8,
-    backgroundColor: '#FFFFFF',
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 6,
   },
 });

--- a/src/features/profile/components/ShopEmptyState.tsx
+++ b/src/features/profile/components/ShopEmptyState.tsx
@@ -1,10 +1,21 @@
-// Empty state de l'onglet Boutique — E3-VENDOR.
+// Empty state de l'onglet Boutique — E3-VENDOR + E7-15 (#246).
 // Partagé entre Mon profil et Profil d'un autre utilisateur.
+//
+// E7-15 : si on est sur Mon profil, on injecte un CTA "Publier ta première
+// annonce" qui ouvre l'écran de création (E7-14 — /shop/create). Sur le
+// profil d'un autre user, on garde le message neutre.
 
-import { Store } from 'lucide-react-native';
-import { Text, YStack } from 'tamagui';
+import { Plus, Store } from 'lucide-react-native';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, View, XStack, YStack } from 'tamagui';
 
-export function ShopEmptyState() {
+export interface ShopEmptyStateProps {
+  /** Si défini, affiche un CTA "Publier ta première annonce" qui appelle cette fonction. */
+  onCreatePress?: () => void;
+}
+
+export function ShopEmptyState({ onCreatePress }: ShopEmptyStateProps = {}) {
+  const isMine = typeof onCreatePress === 'function';
   return (
     <YStack alignItems="center" justifyContent="center" paddingVertical={80} gap="$3">
       <YStack
@@ -19,8 +30,34 @@ export function ShopEmptyState() {
         <Store size={32} color="#A0A0A0" />
       </YStack>
       <Text fontSize={15} color="$textSecondary" textAlign="center" fontWeight="500">
-        Aucun produit en vente
+        {isMine ? 'Aucune annonce pour l’instant' : 'Aucun produit en vente'}
       </Text>
+      {isMine ? (
+        <Pressable
+          onPress={onCreatePress}
+          accessibilityRole="button"
+          accessibilityLabel="Publier ta première annonce"
+          style={styles.cta}
+        >
+          <XStack alignItems="center" gap={6}>
+            <View>
+              <Plus size={16} color="#000000" strokeWidth={2.6} />
+            </View>
+            <Text fontSize={14} fontWeight="800" color="#000000">
+              Publier ta première annonce
+            </Text>
+          </XStack>
+        </Pressable>
+      ) : null}
     </YStack>
   );
 }
+
+const styles = StyleSheet.create({
+  cta: {
+    backgroundColor: '#10D970',
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 9999,
+  },
+});

--- a/src/features/profile/screens/ProfileScreen.tsx
+++ b/src/features/profile/screens/ProfileScreen.tsx
@@ -174,7 +174,7 @@ export function ProfileScreen() {
           keyExtractor={keyExtractor}
           numColumns={NUM_COLUMNS}
           ListHeaderComponent={ListHeader}
-          ListEmptyComponent={ShopEmptyState}
+          ListEmptyComponent={<ShopEmptyState onCreatePress={() => router.push('/shop/create')} />}
           showsVerticalScrollIndicator={false}
           onRefresh={refetch}
           refreshing={false}


### PR DESCRIPTION
## Summary

**E7-15 (#246)** finalisation. Audit a révélé que l'infra était déjà là (depuis E3-VENDOR) — il manquait juste 2 wirings : tap sur une card → fiche produit, et CTA empty state → écran création.

Aucune migration DB nécessaire.

## Constat d'audit (avant patch)

L'onglet "shop" du profile existait déjà :
- ✅ \`ProfileTabs\` avec 4 onglets (Grid/Reels/Tagged/Shop)
- ✅ \`useListings(userId)\` qui fetch les listings actives par seller_id
- ✅ \`ProfileScreen\` (mon profil) ET \`[id]/index.tsx\` (profil autre) branchés sur \`isShopTab\`
- ✅ \`ListingCard\` (image carrée + prix overlay)
- ✅ \`ShopEmptyState\`

**MAIS** :
- ❌ Le bouton "Voir le produit" ouvrait une **Alert "Bientôt disponible"** (placeholder MVP — la fiche n'existait pas au moment du codage initial)
- ❌ Pas de chemin pour qu'un nouvel user publie sa première annonce depuis l'empty state

## Patch

### \`ListingCard.tsx\` (profile)
- **Tap → \`router.push(\`/shop/\${item.id}\`)\`** (E7-12 livre la fiche)
- Toute la tile est cliquable maintenant (au lieu du seul bouton "Voir le produit")
- Badge promo overlay top-left si \`item.badge\` (offre_speciale rouge / nouveaute/recommandation vert)
- Badge \`-X%\` discount overlay top-right en fallback si \`discount_percent\` sans badge serveur
- \`accessibilityLabel\` composite : "Voir le produit X, prix"

### \`ShopEmptyState.tsx\`
- Nouvelle prop \`onCreatePress\` optionnelle
- Si fournie (Mon profil) → CTA vert "Publier ta première annonce" → \`/shop/create\` (E7-14)
- Si absente (profil autre user) → message neutre "Aucun produit en vente" (comportement inchangé)

### \`ProfileScreen.tsx\` (mon profil)
- Branche le CTA empty state vers \`/shop/create\`

### \`[id]/index.tsx\` (profil autre)
- Volontairement **non modifié** : on ne veut pas du CTA "Publier" sur le profil de quelqu'un d'autre

## Test plan

- [ ] Profile autre user avec annonces → tap card → ouvre la fiche \`/shop/[id]\`
- [ ] Mon profil onglet Boutique avec 0 annonce → empty state + CTA "Publier ta première annonce" → ouvre \`/shop/create\`
- [ ] Mon profil onglet Boutique avec annonces → tap card → ouvre la fiche, retour atterrit sur le profile (pas sur la grille marketplace)
- [ ] Profile autre user avec 0 annonce → empty state SANS CTA (juste le message)
- [ ] Card avec \`badge='offre_speciale'\` → pastille rouge "Promo" top-left
- [ ] Card avec \`discount_percent=20\` sans badge → pastille rouge "-20%" top-right

## Suite

Avec cette PR mergée, **marketplace L0 ≈ 87% livré**. Reste **1 ticket** :
- **E7-11 (#242)** Modale filtres avancés (slider prix, état, tri par popularité/distance) — \`handleOpenAdvanced\` est en stub no-op dans la grille E7-10

Après E7-11 → scope L0 complet, prêt pour bug bash + démo interne.