### PR TITLE
feat(marketplace): modale filtres avancés — #242

### DIFF
--- a/app/shop/index.tsx
+++ b/app/shop/index.tsx
@@ -22,6 +22,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Input, Text, View, XStack, YStack } from 'tamagui';
 
+import { AdvancedFiltersSheet } from '@/features/marketplace/components/AdvancedFiltersSheet';
 import { CategoryChips } from '@/features/marketplace/components/CategoryChips';
 import { ListingCard } from '@/features/marketplace/components/ListingCard';
 import { QuickFiltersBar } from '@/features/marketplace/components/QuickFiltersBar';
@@ -30,6 +31,8 @@ import {
   useToggleListingBookmark,
   type ListingCard as ListingCardData,
   type ListingCategory,
+  type ListingCondition,
+  type ListingSort,
   type ListingsFilters,
 } from '@/features/marketplace/hooks/useListings';
 
@@ -46,16 +49,28 @@ export default function MarketplaceGridScreen() {
   const [searchQuery, setSearchQuery] = useState('');
   const [isManualRefreshing, setIsManualRefreshing] = useState(false);
 
+  // E7-11 — filtres avancés (modale)
+  const [sort, setSort] = useState<ListingSort>('recent');
+  const [condition, setCondition] = useState<ListingCondition | null>(null);
+  const [minPriceCents, setMinPriceCents] = useState<number | null>(null);
+  const [maxPriceCents, setMaxPriceCents] = useState<number | null>(null);
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+
   const filters = useMemo<ListingsFilters>(
     () => ({
       category,
-      // Sort/condition/prix arriveront via la modale d'avancés E7-11 (état stocké
-      // ici localement pour MVP — passera en Zustand si besoin de partage entre
-      // écrans).
-      sort: 'recent',
+      sort,
+      condition,
+      minPriceCents,
+      maxPriceCents,
     }),
-    [category]
+    [category, sort, condition, minPriceCents, maxPriceCents]
   );
+
+  // Pour le badge "filtres actifs" du bouton réglages : on considère qu'un
+  // filtre est "avancé" dès qu'il sort de la config par défaut.
+  const hasActiveAdvancedFilters =
+    sort !== 'recent' || condition != null || minPriceCents != null || maxPriceCents != null;
 
   const listingsQuery = useListings(filters);
   const toggleBookmark = useToggleListingBookmark();
@@ -91,10 +106,18 @@ export default function MarketplaceGridScreen() {
   }, []);
 
   const handleOpenAdvanced = useCallback(() => {
-    // E7-11 livrera la modale. Pour l'instant pas de no-op visible (l'utilisateur
-    // ne sait pas que c'est désactivé), donc on log silencieux.
-    // TODO E7-11 : ouvrir AdvancedFiltersSheet
+    setIsFiltersOpen(true);
   }, []);
+
+  const handleApplyAdvancedFilters = useCallback(
+    (next: Pick<ListingsFilters, 'sort' | 'condition' | 'minPriceCents' | 'maxPriceCents'>) => {
+      setSort(next.sort ?? 'recent');
+      setCondition(next.condition ?? null);
+      setMinPriceCents(next.minPriceCents ?? null);
+      setMaxPriceCents(next.maxPriceCents ?? null);
+    },
+    []
+  );
 
   const handleCardPress = useCallback((listingId: string) => {
     // E7-12 livrera la fiche produit
@@ -228,7 +251,10 @@ export default function MarketplaceGridScreen() {
         </YStack>
 
         {/* Filtres rapides */}
-        <QuickFiltersBar onOpenAdvanced={handleOpenAdvanced} />
+        <QuickFiltersBar
+          onOpenAdvanced={handleOpenAdvanced}
+          hasActiveAdvancedFilters={hasActiveAdvancedFilters}
+        />
 
         {/* Chips catégorie */}
         <CategoryChips selected={category} onSelect={setCategory} />
@@ -300,6 +326,14 @@ export default function MarketplaceGridScreen() {
           )}
         </View>
       </YStack>
+
+      <AdvancedFiltersSheet
+        open={isFiltersOpen}
+        onOpenChange={setIsFiltersOpen}
+        current={filters}
+        activeCategory={category}
+        onApply={handleApplyAdvancedFilters}
+      />
     </>
   );
 }

--- a/src/features/marketplace/components/AdvancedFiltersSheet.tsx
+++ b/src/features/marketplace/components/AdvancedFiltersSheet.tsx
@@ -1,0 +1,299 @@
+// AdvancedFiltersSheet — E7-11 (#242)
+//
+// Modale bottom-sheet pour les filtres avancés Marketplace : tri, fourchette
+// de prix, état (si product). La distance est laissée hors-scope MVP
+// (nécessite geo + index spatial, à reprendre quand on ajoutera la
+// localisation user).
+//
+// State pattern :
+//   - L'écran parent (grille) garde la source de vérité des filtres
+//   - Cette modale reçoit les filtres courants + 2 callbacks (apply / reset)
+//   - State local pendant l'édition → on n'apply que sur tap explicite
+//   - Reset → on remet les valeurs par défaut mais on n'apply que si l'user
+//     tape ensuite Appliquer (pattern Leboncoin)
+//
+// Pas de slider double : on utilise 2 inputs numériques (pattern marketplace
+// standard, évite d'ajouter une lib + accessibilité plus simple).
+
+import { useEffect, useState } from 'react';
+import { StyleSheet } from 'react-native';
+import { Input, Sheet, Text, View, XStack, YStack } from 'tamagui';
+
+import type {
+  ListingCategory,
+  ListingCondition,
+  ListingSort,
+  ListingsFilters,
+} from '../hooks/useListings';
+
+import { SegmentedChoice } from './SegmentedChoice';
+
+const SORT_OPTIONS: { value: ListingSort; label: string }[] = [
+  { value: 'recent', label: 'Récent' },
+  { value: 'price_asc', label: 'Prix ↑' },
+  { value: 'price_desc', label: 'Prix ↓' },
+  { value: 'popular', label: 'Populaire' },
+];
+
+const CONDITION_OPTIONS: { value: ListingCondition; label: string }[] = [
+  { value: 'neuf', label: 'Neuf' },
+  { value: 'tres_bon_etat', label: 'Très bon état' },
+  { value: 'bon_etat', label: 'Bon état' },
+  { value: 'occasion', label: 'Occasion' },
+];
+
+export interface AdvancedFiltersSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Filtres actuellement appliqués (initial state de la modale). */
+  current: ListingsFilters;
+  /** Catégorie active sur la grille (pour masquer la section État si Service). */
+  activeCategory: ListingCategory | null;
+  /** Appelé avec les nouveaux filtres au tap Appliquer (ferme aussi la sheet). */
+  onApply: (
+    next: Pick<ListingsFilters, 'sort' | 'minPriceCents' | 'maxPriceCents' | 'condition'>
+  ) => void;
+}
+
+function centsToEuroString(cents: number | null | undefined): string {
+  if (cents == null || !Number.isFinite(cents)) return '';
+  const euros = cents / 100;
+  // Affichage sans .00 inutile
+  return Number.isInteger(euros) ? String(euros) : euros.toFixed(2).replace('.', ',');
+}
+
+function parsePriceInput(input: string): number | null {
+  const trimmed = input.trim();
+  if (trimmed.length === 0) return null;
+  // Accepte virgule ou point comme séparateur décimal (saisie FR).
+  const normalized = trimmed.replace(',', '.');
+  const num = Number.parseFloat(normalized);
+  if (!Number.isFinite(num) || num < 0) return null;
+  return Math.round(num * 100);
+}
+
+export function AdvancedFiltersSheet({
+  open,
+  onOpenChange,
+  current,
+  activeCategory,
+  onApply,
+}: AdvancedFiltersSheetProps) {
+  const [sort, setSort] = useState<ListingSort>(current.sort ?? 'recent');
+  const [condition, setCondition] = useState<ListingCondition | null>(current.condition ?? null);
+  const [minPrice, setMinPrice] = useState<string>(centsToEuroString(current.minPriceCents));
+  const [maxPrice, setMaxPrice] = useState<string>(centsToEuroString(current.maxPriceCents));
+  const [priceError, setPriceError] = useState<string | null>(null);
+
+  // Reset le state local quand la sheet (re)s'ouvre : on resynchronise avec
+  // les filtres courants pour ne pas afficher des valeurs périmées d'une
+  // session précédente.
+  useEffect(() => {
+    if (open) {
+      setSort(current.sort ?? 'recent');
+      setCondition(current.condition ?? null);
+      setMinPrice(centsToEuroString(current.minPriceCents));
+      setMaxPrice(centsToEuroString(current.maxPriceCents));
+      setPriceError(null);
+    }
+  }, [open, current.sort, current.condition, current.minPriceCents, current.maxPriceCents]);
+
+  const handleReset = () => {
+    setSort('recent');
+    setCondition(null);
+    setMinPrice('');
+    setMaxPrice('');
+    setPriceError(null);
+  };
+
+  const handleApply = () => {
+    const minCents = parsePriceInput(minPrice);
+    const maxCents = parsePriceInput(maxPrice);
+
+    // Validation : si les 2 sont définis, min doit être <= max.
+    if (minCents != null && maxCents != null && minCents > maxCents) {
+      setPriceError('Le prix min doit être inférieur au prix max.');
+      return;
+    }
+    setPriceError(null);
+
+    onApply({
+      sort,
+      // Section État masquée si la catégorie active est "service" : on force
+      // condition à null pour éviter de propager une valeur fantôme depuis
+      // une session précédente.
+      condition: activeCategory === 'service' ? null : condition,
+      minPriceCents: minCents,
+      maxPriceCents: maxCents,
+    });
+    onOpenChange(false);
+  };
+
+  const showConditionSection = activeCategory !== 'service';
+
+  return (
+    <Sheet modal open={open} onOpenChange={onOpenChange} snapPoints={[72]} dismissOnSnapToBottom>
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="rgba(0,0,0,0.55)"
+      />
+      <Sheet.Handle />
+      <Sheet.Frame
+        backgroundColor="$background"
+        borderTopLeftRadius={20}
+        borderTopRightRadius={20}
+        paddingHorizontal={20}
+        paddingTop={16}
+        paddingBottom={28}
+      >
+        <YStack gap={20} flex={1}>
+          <XStack alignItems="center" justifyContent="space-between">
+            <Text fontSize={18} fontWeight="800" color="$color">
+              Filtres
+            </Text>
+            <Text
+              fontSize={13}
+              fontWeight="700"
+              color="$accentNeon"
+              onPress={handleReset}
+              accessibilityRole="button"
+              accessibilityLabel="Réinitialiser les filtres"
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            >
+              Réinitialiser
+            </Text>
+          </XStack>
+
+          {/* Trier par */}
+          <YStack gap={10}>
+            <Text fontSize={14} fontWeight="700" color="$color">
+              Trier par
+            </Text>
+            <SegmentedChoice<ListingSort> options={SORT_OPTIONS} value={sort} onChange={setSort} />
+          </YStack>
+
+          {/* Fourchette de prix */}
+          <YStack gap={10}>
+            <Text fontSize={14} fontWeight="700" color="$color">
+              Prix
+            </Text>
+            <XStack alignItems="center" gap={10}>
+              <XStack
+                flex={1}
+                alignItems="center"
+                backgroundColor="$surface"
+                borderRadius="$md"
+                paddingHorizontal={12}
+                height={44}
+              >
+                <Input
+                  flex={1}
+                  value={minPrice}
+                  onChangeText={(v) => {
+                    setMinPrice(v);
+                    setPriceError(null);
+                  }}
+                  placeholder="Min"
+                  placeholderTextColor="$placeholderColor"
+                  keyboardType="decimal-pad"
+                  color="$color"
+                  backgroundColor="transparent"
+                  borderWidth={0}
+                  paddingHorizontal={0}
+                  height={44}
+                  fontSize={15}
+                  accessibilityLabel="Prix minimum en euros"
+                />
+                <Text fontSize={14} color="$textSecondary" fontWeight="600">
+                  €
+                </Text>
+              </XStack>
+              <Text fontSize={14} color="$textSecondary">
+                à
+              </Text>
+              <XStack
+                flex={1}
+                alignItems="center"
+                backgroundColor="$surface"
+                borderRadius="$md"
+                paddingHorizontal={12}
+                height={44}
+              >
+                <Input
+                  flex={1}
+                  value={maxPrice}
+                  onChangeText={(v) => {
+                    setMaxPrice(v);
+                    setPriceError(null);
+                  }}
+                  placeholder="Max"
+                  placeholderTextColor="$placeholderColor"
+                  keyboardType="decimal-pad"
+                  color="$color"
+                  backgroundColor="transparent"
+                  borderWidth={0}
+                  paddingHorizontal={0}
+                  height={44}
+                  fontSize={15}
+                  accessibilityLabel="Prix maximum en euros"
+                />
+                <Text fontSize={14} color="$textSecondary" fontWeight="600">
+                  €
+                </Text>
+              </XStack>
+            </XStack>
+            {priceError ? (
+              <Text fontSize={12} color="#FF6B6B">
+                {priceError}
+              </Text>
+            ) : null}
+          </YStack>
+
+          {/* État (masqué si Service actif) */}
+          {showConditionSection ? (
+            <YStack gap={10}>
+              <Text fontSize={14} fontWeight="700" color="$color">
+                État
+              </Text>
+              <SegmentedChoice<ListingCondition>
+                options={CONDITION_OPTIONS}
+                value={condition}
+                onChange={setCondition}
+                allowDeselect
+                onDeselect={() => setCondition(null)}
+              />
+            </YStack>
+          ) : null}
+
+          {/* Spacer */}
+          <View flex={1} />
+
+          {/* CTA Appliquer */}
+          <Text
+            fontSize={15}
+            fontWeight="800"
+            color="#000000"
+            backgroundColor="#10D970"
+            paddingVertical={14}
+            textAlign="center"
+            borderRadius={9999}
+            accessibilityRole="button"
+            accessibilityLabel="Appliquer les filtres"
+            onPress={handleApply}
+            style={styles.cta}
+          >
+            Appliquer
+          </Text>
+        </YStack>
+      </Sheet.Frame>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  cta: {
+    overflow: 'hidden',
+  },
+});


### PR DESCRIPTION
## Summary

**E7-11 (#242)** — Dernier ticket marketplace L0. Avec ça, le **scope L0 est COMPLET**.

Modale bottom-sheet Tamagui ouverte depuis la barre QuickFilters de la grille (\`handleOpenAdvanced\` était stub no-op jusque-là). 3 sections : tri / prix / état. Pas de migration DB nécessaire — le hook \`useListings\` accepte déjà tous ces paramètres depuis E7-10.

## Contenu

### \`AdvancedFiltersSheet.tsx\`
- Bottom-sheet 72% de l'écran
- **Tri** : Récent / Prix↑ / Prix↓ / Populaire (réutilise \`SegmentedChoice\`)
- **Prix** : 2 inputs \`decimal-pad\` Min / Max (pattern marketplace standard Leboncoin/Vinted — plus simple et accessible qu'un slider double, évite d'ajouter une lib)
- **État** : 4 chips Neuf/TBE/BE/Occasion, \`allowDeselect\` (cliquer sur la valeur active la désélectionne)
- **Section État masquée** si la catégorie active sur la grille = Service
- **Header** : titre "Filtres" + lien "Réinitialiser" (remet les valeurs par défaut sans apply automatique)
- **CTA** : "Appliquer" en bas, vert
- Validation : si min ET max définis, min doit être ≤ max → erreur inline FR sinon

### State pattern (raisonnement)
- La grille reste **source de vérité** des filtres (state local)
- La sheet maintient son propre state **pendant l'édition** (apply uniquement sur tap explicite)
- À chaque (ré)ouverture de la sheet → resync sur les filtres courants pour éviter de montrer des valeurs périmées d'une session précédente
- Garde-fou : si catégorie = Service, on force \`condition=null\` au submit même si l'user avait sélectionné une valeur avant de basculer

### \`app/shop/index.tsx\`
- 4 nouveaux states : \`sort\` / \`condition\` / \`minPriceCents\` / \`maxPriceCents\` + \`isFiltersOpen\`
- \`hasActiveAdvancedFilters\` calculé : vrai dès qu'un filtre sort de la config par défaut
- Passé à \`QuickFiltersBar\` → bouton réglages devient vert plein + dot indicateur
- Sheet montée en frère de la grille

## Hors-scope MVP
- **Distance** : nécessite geo de l'user + index spatial, à reprendre quand on ajoutera la localisation
- **Persistance des filtres entre sessions** : pas dans le brief

## Test plan

- [ ] Lancer Dev Build, ouvrir \`/shop\` → tap bouton "Filtres avancés" (rond à droite des chips) → la sheet s'ouvre depuis le bas
- [ ] Sélectionner "Prix↓" + saisir Min=10, Max=100 + sélectionner "Neuf" → tap Appliquer → grille refetch avec les filtres
- [ ] Bouton "Filtres avancés" devient vert plein avec un dot indicateur
- [ ] Rouvrir la sheet → les valeurs sont resynchronisées (pas vide)
- [ ] Tap "Réinitialiser" → valeurs remises à zéro DANS la sheet uniquement (pas d'apply auto)
- [ ] Tap Appliquer après reset → grille revient à la config par défaut
- [ ] Si je passe la catégorie active à "Services" → rouvrir la sheet → la section État disparaît
- [ ] Saisir Min=100, Max=50 → tap Appliquer → erreur "Le prix min doit être inférieur au prix max" + pas de submit

## État global Marketplace L0

| # | Ticket | Status |
|---|---|---|
| E7-09 | Bucket Storage | ✅ |
| E7-10 | Grille | ✅ |
| E7-11 | **Filtres avancés** | 🟡 **CETTE PR** |
| E7-12 | Fiche produit | ✅ |
| E7-13 | Contacter vendeur | ✅ |
| E7-14 | Création annonce | ✅ |
| E7-15 | Onglet boutique profile | ✅ |
| E7-16 | Favoris | ✅ |

**Après merge → scope L0 complet, prêt pour bug bash + démo interne.**