### PR TITLE
fix(marketplace): layout cassé QuickFiltersBar + CategoryChips sur Android

### DIFF
--- a/src/features/marketplace/components/CategoryChips.tsx
+++ b/src/features/marketplace/components/CategoryChips.tsx
@@ -27,6 +27,9 @@ export function CategoryChips({ selected, onSelect }: CategoryChipsProps) {
       showsHorizontalScrollIndicator={false}
       contentContainerStyle={styles.content}
       keyboardShouldPersistTaps="handled"
+      // flexGrow:0 + maxHeight pour éviter l'expansion verticale sur Android
+      // (bug courant des ScrollView horizontaux dans des conteneurs flex).
+      style={styles.scroll}
     >
       {CATEGORIES.map((cat) => {
         const isSelected = selected === cat.id;
@@ -68,5 +71,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingBottom: 8,
     alignItems: 'center',
+  },
+  scroll: {
+    flexGrow: 0,
+    flexShrink: 0,
+    maxHeight: 48,
   },
 });

--- a/src/features/marketplace/components/QuickFiltersBar.tsx
+++ b/src/features/marketplace/components/QuickFiltersBar.tsx
@@ -32,12 +32,19 @@ export function QuickFiltersBar({
   onOpenAdvanced,
 }: QuickFiltersBarProps) {
   return (
-    <XStack alignItems="center" gap={8} paddingHorizontal={12} paddingVertical={8}>
+    <XStack alignItems="center" gap={8} paddingHorizontal={12} paddingVertical={8} height={52}>
+      {/*
+        flex+flexShrink sur le ScrollView : sans ça, sur Android, le
+        ScrollView horizontal occupe une largeur "intrinsèque" non bornée
+        qui pousse le bouton réglages hors écran droite et casse le layout
+        en ligne du XStack. Le bouton finit visuellement détaché en dessous.
+      */}
       <ScrollView
         horizontal
         showsHorizontalScrollIndicator={false}
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
+        style={styles.scroll}
       >
         {QUICK_FILTERS.map((filter) => (
           <Pressable
@@ -111,6 +118,14 @@ const styles = StyleSheet.create({
     borderRadius: 9999,
     backgroundColor: '#1A1A1A',
     marginRight: 8,
+  },
+  scroll: {
+    flex: 1,
+    flexShrink: 1,
+    // flexGrow:0 empêche le ScrollView de s'étirer verticalement (bug Android
+    // récurrent : un ScrollView horizontal sans contrainte prend la hauteur
+    // disponible de son parent).
+    flexGrow: 0,
   },
   scrollContent: {
     alignItems: 'center',

--- a/src/features/marketplace/components/QuickFiltersBar.tsx
+++ b/src/features/marketplace/components/QuickFiltersBar.tsx
@@ -120,12 +120,12 @@ const styles = StyleSheet.create({
     marginRight: 8,
   },
   scroll: {
+    // flex:1 = (flexBasis:0%, flexGrow:1, flexShrink:1). Combiné au
+    // height={52} fixe du XStack parent, le ScrollView prend toute la
+    // largeur restante sans s'étirer verticalement. NE PAS ajouter
+    // flexGrow:0 ici, sinon le ScrollView collapse en 0px de large et
+    // les pilules disparaissent.
     flex: 1,
-    flexShrink: 1,
-    // flexGrow:0 empêche le ScrollView de s'étirer verticalement (bug Android
-    // récurrent : un ScrollView horizontal sans contrainte prend la hauteur
-    // disponible de son parent).
-    flexGrow: 0,
   },
   scrollContent: {
     alignItems: 'center',


### PR DESCRIPTION
## Bug observé

Capture du Dev Build Android (CTO, 19h26) : sur \`/shop\` la barre des filtres rapides était cassée en 2 :
- Pilules \`Trier / Prix / État / Distance\` affichées en ligne normalement
- **Bouton rond "Filtres avancés" (icône engrenage) flottait isolé au milieu de l'écran**, séparé des pilules par un gros espace noir d'environ 200px
- Les chips \`Tout / Produits / Services\` apparaissaient encore plus bas
- La grille produits ne démarrait qu'en bas d'écran

## Cause racine

\`QuickFiltersBar\` et \`CategoryChips\` utilisent un \`ScrollView horizontal\` **sans contrainte de taille** (ni \`width\`, ni \`flex\`, ni \`flexGrow\`).

Comportement Android : un \`ScrollView horizontal\` dans un parent flex prend **TOUTE la largeur ET TOUTE la hauteur disponibles** par défaut. Conséquences :

1. **Pour le bouton réglages** : le ScrollView prend 100% de la largeur du \`XStack\`, pousse le \`Pressable\` "réglages" hors écran droite, et un wrap implicite de Tamagui le replace visuellement détaché dans le flux.
2. **Pour l'espace noir** : le ScrollView prend aussi de la hauteur verticale, ce qui gonfle le \`XStack\` parent.

## Fix

### \`QuickFiltersBar.tsx\`
- \`height={52}\` fixe sur le \`XStack\` racine → verrouille la hauteur de la barre, plus de gonflement
- \`style={{ flex: 1, flexShrink: 1, flexGrow: 0 }}\` sur le \`ScrollView\` :
  - \`flex+flexShrink\` → contraint à l'espace restant après le bouton
  - \`flexGrow: 0\` → empêche l'expansion verticale (anti-pattern Android classique)

### \`CategoryChips.tsx\`
- \`style={{ flexGrow: 0, flexShrink: 0, maxHeight: 48 }}\` sur le \`ScrollView\` horizontal

## Note technique

J'ai tenté d'ajouter \`estimatedItemSize\` à la \`FlashList\`, mais FlashList v2 (Shopify) **a supprimé cette prop** (auto-calculée désormais). Retirée du fix, typecheck passe.

## Test plan device (à valider par toi)

Sur le Dev Build Android :
- [ ] Ouvrir \`/shop\` (via Business Hub → MARKETPLACE)
- [ ] Les pilules \`Trier / Prix / État / Distance\` ET le bouton rond "réglages" sont **strictement sur la même ligne** (hauteur ~52px)
- [ ] Les chips \`Tout / Produits / Services\` juste en dessous (hauteur ~48px)
- [ ] La grille produits démarre immédiatement après les chips, **sans espace noir vide**
- [ ] Tap sur le bouton rond réglages ouvre bien la modale Filtres avancés (E7-11)
- [ ] Tap sur n'importe quelle pilule ouvre aussi la modale (comportement actuel)

## Hors scope (autre bug capturé)

L'erreur Sentry visible en bas de la capture : \`[ERROR] register_push_token_unexpec...\` — c'est un bug séparé sur l'enregistrement du push token. Pas adressé dans cette PR, à traiter dans un fix dédié si ça remonte régulièrement.