### PR TITLE
fix(marketplace): tracking migration — get_listing_detail id ambigu

### DIFF
--- a/supabase/migrations/20260701120000_fix_get_listing_detail_ambiguous_id.sql
+++ b/supabase/migrations/20260701120000_fix_get_listing_detail_ambiguous_id.sql
@@ -1,0 +1,83 @@
+-- Fix — get_listing_detail : conflit de noms "id" ambigu dans le UPDATE
+--
+-- Contexte : bug remonté au bug bash Marketplace L0 du 2026-07-01. Sur le
+-- Dev Build, taper sur une card produit affichait "Annonce introuvable"
+-- au lieu de la fiche. Même symptôme après création d'annonce
+-- (router.replace('/shop/[newId]') → 404). Le compteur de vues ne
+-- s'incrémentait pas non plus.
+--
+-- Cause racine : dans la version précédente de la RPC (migration
+-- 20260629180000_listings_add_condition_and_rpcs.sql, lignes 122-125) :
+--
+--   returns table (id uuid, ...)
+--   ...
+--   update public.listings set view_count = view_count + 1
+--   where id = p_listing_id and is_active = true;
+--
+-- La clause RETURNS TABLE déclare `id` comme OUT parameter, ce qui masque
+-- `listings.id` dans le corps PL/pgSQL. Le UPDATE ne match plus aucune
+-- ligne → view_count reste inchangé + le SELECT retourne 0 rows →
+-- "Annonce introuvable" côté client.
+--
+-- Fix : qualifier explicitement `listings.id` et `listings.view_count`
+-- dans le UPDATE. Le SELECT en dessous utilise déjà l'alias `l.` donc
+-- pas affecté.
+--
+-- Diagnostiqué + appliqué en direct sur DEV + STAGING via AI Supabase.
+-- Vérifié : `select * from get_listing_detail(<uuid>)` retourne 1 ligne
+-- et incrémente view_count.
+--
+-- Idempotent (create or replace), rejouable.
+
+create or replace function public.get_listing_detail(p_listing_id uuid)
+returns table (
+  id uuid,
+  seller_id uuid,
+  seller_username text,
+  seller_full_name text,
+  seller_avatar_url text,
+  seller_is_verified boolean,
+  category text,
+  title text,
+  description text,
+  price_cents int,
+  currency text,
+  images text[],
+  location text,
+  condition text,
+  badge text,
+  discount_percent int,
+  view_count int,
+  created_at timestamptz,
+  bookmarked_by_me boolean
+)
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- Qualification explicite `listings.` pour éviter le conflit de nom
+  -- avec la colonne `id` du RETURNS TABLE.
+  update public.listings
+    set view_count = public.listings.view_count + 1
+  where public.listings.id = p_listing_id
+    and public.listings.is_active = true;
+
+  return query
+  select
+    l.id, l.seller_id, pr.username, pr.full_name, pr.avatar_url,
+    coalesce(pr.is_verified, false),
+    l.category::text, l.title, l.description, l.price_cents, l.currency,
+    l.images, l.location, l.condition, l.badge, l.discount_percent,
+    l.view_count, l.created_at,
+    exists (
+      select 1 from public.listing_bookmarks b
+      where b.listing_id = l.id and b.user_id = auth.uid()
+    )
+  from public.listings l
+  join public.profiles pr on pr.id = l.seller_id
+  where l.id = p_listing_id and l.is_active = true;
+end;
+$$;
+
+grant execute on function public.get_listing_detail(uuid) to authenticated, anon;


### PR DESCRIPTION
## Summary

**Migration de tracking** du fix appliqué en direct par le CTO sur DEV + STAGING pendant le bug bash Marketplace du 2026-07-01. Aucun code applicatif à changer.

## Bug capturé

Bug bash sur Dev Build → 3 symptômes convergents :
- Tap sur une card produit → \"Annonce introuvable\"
- Après création annonce, \`router.replace('/shop/[newId]')\` → même écran 404
- \`view_count\` ne s'incrémentait jamais

## Diagnostic (par CTO via AI Supabase)

Bug SQL classique : dans \`RETURNS TABLE (id uuid, ...)\`, la colonne \`id\` déclarée comme OUT parameter **masque \`listings.id\`** dans le corps PL/pgSQL. Le \`UPDATE\` de la RPC devenait :

\`\`\`sql
update public.listings set view_count = view_count + 1
where id = p_listing_id and is_active = true;
--    ^^ ambigu : id = OUT param, pas listings.id
\`\`\`

→ 0 ligne matchée par le UPDATE → \`view_count\` inchangé
→ le \`return query\` en dessous retourne 0 rows → \"Annonce introuvable\"

## Fix (déjà appliqué en direct)

Qualifier explicitement \`public.listings.id\` et \`public.listings.view_count\` dans le UPDATE. Le SELECT en dessous utilisait déjà l'alias \`l.\` donc pas affecté.

## Test de non-régression (déjà validé par le CTO)

\`\`\`sql
select * from public.get_listing_detail('ae3f6321-...'::uuid);
-- ✅ 1 ligne retournée
-- ✅ view_count passe de 0 à 1
\`\`\`

## Pourquoi cette PR existe (alors que c'est déjà déployé)

Pour éviter la **4e occurrence** du pattern \"SQL appliqué en direct sans commit\" :
1. \`adapt_notifications_for_sprint3\` (dette Sprint 3)
2. \`posts_storage_bucket\` doublons (nettoyé Sprint 5)
3. \`listings_storage_bucket\` doublons (nettoyé Sprint 7 via PR #248)
4. **Celle-ci** — trackée maintenant

Sans le fichier commité, la BDD devient la seule source de vérité et le fix ne se rejoue pas sur prod.

## Test plan

- [ ] Migration idempotente, sans effet sur DEV/STAGING (déjà appliquée)
- [ ] Après merge → si on crée un nouveau projet Supabase (prod), la migration se joue et applique le fix