### PR TITLE
fix: 2 crashs Dev Build (Realtime channel + FCM) — bug bash

### DIFF
--- a/src/features/auth/hooks/usePushToken.ts
+++ b/src/features/auth/hooks/usePushToken.ts
@@ -58,8 +58,24 @@ async function registerPushToken(userId: string): Promise<void> {
   }
 
   // Récupérer le token. Expo génère un token stable par installation.
-  const tokenResponse = await Notifications.getExpoPushTokenAsync({ projectId: PROJECT_ID });
-  const token = tokenResponse.data;
+  // Sur Android, échoue si Firebase (google-services.json + FCM) n'est pas
+  // configuré côté natif — on log en info silencieux plutôt que error car
+  // c'est un pré-requis config, pas un bug runtime. La feature push notifs
+  // sera juste inactive sur ce device tant que Firebase n'est pas branché.
+  let token: string;
+  try {
+    const tokenResponse = await Notifications.getExpoPushTokenAsync({ projectId: PROJECT_ID });
+    token = tokenResponse.data;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (Platform.OS === 'android' && (message.includes('FirebaseApp') || message.includes('FCM'))) {
+      logger.info('push_token_skipped_firebase_not_configured', { platform: 'android' });
+      return;
+    }
+    // Autre erreur (iOS, permissions, réseau) — reste en warn pour investigation.
+    logger.warn('push_token_fetch_failed', { message });
+    return;
+  }
 
   // Idempotent : on lit d'abord pour éviter un UPDATE inutile si rien n'a changé.
   const { data: profile } = await supabase

--- a/src/features/calls/hooks/useIncomingCallListener.ts
+++ b/src/features/calls/hooks/useIncomingCallListener.ts
@@ -40,8 +40,24 @@ export function useIncomingCallListener(meId: string | null) {
   useEffect(() => {
     if (!meId) return undefined;
 
+    const channelName = 'incoming-calls';
+
+    // Defensive cleanup — Supabase Realtime v2 réutilise les channels par
+    // nom. Si un channel avec ce nom existe déjà (cleanup pas encore
+    // propagé, React StrictMode double-mount, meId qui change vite),
+    // .channel(name) retourne l'instance existante DÉJÀ subscribed. Le
+    // .on() qui suit throw alors : "cannot add postgres_changes callbacks
+    // after subscribe()". On force le remove synchrone des instances
+    // existantes AVANT de recréer.
+    supabase
+      .getChannels()
+      .filter((c) => c.topic === `realtime:${channelName}`)
+      .forEach((c) => {
+        void supabase.removeChannel(c);
+      });
+
     const channel = supabase
-      .channel('incoming-calls')
+      .channel(channelName)
       .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'calls' }, (payload) => {
         const row = payload.new as CallRow | undefined;
         if (!row) return;


### PR DESCRIPTION
## Summary

2 erreurs bloquantes remontées au bug bash Marketplace L0 du 2026-07-01, aucune liée à la marketplace elle-même. Ce sont des dettes techniques du Sprint 6 (calls + push notifs).

## Bug 1 — Render Error bloquant (useIncomingCallListener)

**Symptôme** : \`cannot add postgres_changes callbacks for realtime:incoming-calls after subscribe()\` au montage de \`AuthenticatedTabs\`. Bloque toute l'app.

**Cause** : Supabase Realtime v2 met en cache les channels par nom. Si \`.channel('incoming-calls')\` est appelé pendant qu'une instance précédente n'a pas fini son cleanup (React StrictMode double-mount, ou \`meId\` qui change vite avant que \`removeChannel()\` ne se propage), \`.channel()\` retourne l'instance EXISTANTE déjà subscribed. Le \`.on()\` qui suit throw.

**Fix** : avant de créer le channel, on force un \`removeChannel\` synchrone de toutes les instances existantes qui matchent le topic \`realtime:incoming-calls\`. Idempotent — si aucune instance en cache, c'est un no-op.

## Bug 2 — Console Error au démarrage (usePushToken)

**Symptôme** : \`register_push_token_unexpected: Default FirebaseApp is not initialized in this process com.doumassi.app\`

**Cause** : \`Notifications.getExpoPushTokenAsync()\` nécessite Firebase (google-services.json + FCM) sur Android. Le Dev Build actuel n'a pas la config Firebase → l'appel throw.

**Fix** : wrap l'appel dans un try/catch et détection spécifique des erreurs \`FirebaseApp\`/\`FCM\` sur Android. Dans ce cas → log info silencieux (\`push_token_skipped_firebase_not_configured\`) au lieu de remonter comme error. La feature push notifs est juste inactive tant que Firebase n'est pas branché.

Les autres erreurs (iOS, permissions, réseau) restent en warn pour ne pas masquer de vrais bugs.

## Ce qui n'est PAS fix ici

- La configuration Firebase elle-même (google-services.json + app.json). C'est un chantier séparé (E1-14 monitoring push notifs ou dédié) — quand tu voudras que les push notifs Android fonctionnent vraiment, il faudra :
  1. Créer un projet Firebase pour DOUMASSI
  2. Télécharger \`google-services.json\`
  3. L'ajouter au repo + brancher dans \`app.json\` :
     \`\`\`json
     \"android\": { \"googleServicesFile\": \"./google-services.json\" }
     \`\`\`
  4. Rebuild EAS Android

## Test plan

Après merge + reload Metro :
- [ ] L'app démarre sans écran d'erreur rouge \"Render Error\" (bug 1)
- [ ] Pas de toast \"[ERROR] register_push_token_unexpec…\" au démarrage (bug 2)
- [ ] Le parcours calls continue de fonctionner : Alice appelle Bob → Bob reçoit un ringtone → accept OK
- [ ] Sentry ne remonte plus \`register_push_token_unexpected\` (juste \`push_token_skipped_firebase_not_configured\` en info)