### PR TITLE
feat(notifs): brancher Firebase Android pour push notifs (FCM)

### DIFF
--- a/app.json
+++ b/app.json
@@ -18,6 +18,7 @@
       "associatedDomains": ["applinks:doumassi.app"]
     },
     "android": {
+      "googleServicesFile": "./google-services.json",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#000000"

--- a/google-services.json
+++ b/google-services.json
@@ -1,0 +1,29 @@
+{
+  "project_info": {
+    "project_number": "683730166597",
+    "project_id": "doumassi-app01",
+    "storage_bucket": "doumassi-app01.firebasestorage.app"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:683730166597:android:7a2389ef86e66f8585d42c",
+        "android_client_info": {
+          "package_name": "com.doumassi.app"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyD8VMMJZPNzs3-znKEEzxKTxwzLYTgK-SY"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
## Summary

Complète le fix silencieux de PR #258 en branchant vraiment Firebase FCM pour les push notifications Android. Sans ce chantier, les push notifs Android ne fonctionnent pas quand l'app est fermée.

## Setup Firebase Console (déjà fait par CTO)

- Projet Firebase créé : **DOUMASSI**
- `project_id`: \`doumassi-app01\`
- `project_number`: \`683730166597\`
- Plan **Spark** (gratuit — suffit pour FCM)
- App Android ajoutée : package \`com.doumassi.app\`
- SHA-1 signing cert : non fourni (pas nécessaire pour push simples)

## Contenu de cette PR

### \`google-services.json\` (racine du repo)
Fichier de config Firebase Android. **Non gitignoré** — c'est un fichier PUBLIC bundled dans l'APK final. La sécurité vient des règles Firebase Console + du SHA-1 du signing cert de l'app, pas du fait de garder ce fichier secret.

### \`app.json\`
Ajout d'\`android.googleServicesFile\` :

\`\`\`json
\"android\": {
  \"googleServicesFile\": \"./google-services.json\",
  ...
}
\`\`\`

Le plugin \`expo-notifications\` détecte ce champ pendant Expo Prebuild et copie automatiquement le fichier dans \`android/app/google-services.json\` + active FCM au niveau Gradle.

## Ce qui se passera au prochain rebuild EAS Android

1. Expo Prebuild injecte \`google-services.json\` au bon endroit
2. Le plugin FCM est activé automatiquement (config Gradle)
3. Au runtime, \`FirebaseApp.initializeApp()\` s'exécute au démarrage
4. \`Notifications.getExpoPushTokenAsync()\` récupère un token FCM valide
5. Le token est enregistré dans \`profiles.push_token\` via \`usePushToken\`
6. Le try/catch silencieux de PR #258 ne se déclenche plus

## ⚠️ Rebuild EAS obligatoire

Fast refresh insuffisant — c'est une config **native**. Commande :

\`\`\`bash
pnpm build:dev:android
\`\`\`

Durée : ~30-45 min en background. Une fois le build fini, installe le nouvel APK sur ton device pour tester.

## Test plan (après nouveau Dev Build installé)

- [ ] Ouvrir l'app → plus d'erreur \`register_push_token_unexpec…\` ni de log \`push_token_skipped_firebase_not_configured\` en Sentry
- [ ] Vérifier en DB : \`select push_token from profiles where id = auth.uid();\` → contient un token Expo (format \`ExponentPushToken[...]\`)
- [ ] Faire une action qui déclenche une push notif (like d'un post, follow, message) → la notif arrive **même app fermée**
- [ ] Tap sur la notif → ouvre le bon écran (navigation deep link)

## Suite

Rien de plus côté code pour les push notifs Android. Pour iOS, EAS Credentials gère APNs automatiquement à la 1ère build iOS (Sprint 5-6 quand on montera iOS).