### PR TITLE
chore(notifs): breadcrumbs push_token pour diagnostiquer le flow

### DIFF
--- a/src/features/auth/hooks/usePushToken.ts
+++ b/src/features/auth/hooks/usePushToken.ts
@@ -24,12 +24,20 @@ import { supabase } from '@/lib/supabase';
 const PROJECT_ID = Constants.expoConfig?.extra?.eas?.projectId as string | undefined;
 
 async function registerPushToken(userId: string): Promise<void> {
+  // Breadcrumbs pour tracer exactement où le flow s'interrompt (bug bash
+  // 2026-07-01 : 0 push_token en DB, cause inconnue). Chaque étape log
+  // un `info` avec un contexte minimal.
+  logger.info('push_token_flow_start', { userId, platform: Platform.OS });
+
   // Les push notifs ne fonctionnent pas en simulateur — skip silencieusement
   // (pas de log d'erreur, c'est attendu en dev sur émulateur).
-  if (!Device.isDevice) return;
+  if (!Device.isDevice) {
+    logger.info('push_token_skipped_simulator');
+    return;
+  }
 
   if (!PROJECT_ID) {
-    logger.warn('No EAS projectId in app.json — cannot register push token');
+    logger.warn('push_token_no_eas_project_id');
     return;
   }
 
@@ -51,9 +59,10 @@ async function registerPushToken(userId: string): Promise<void> {
     const response = await Notifications.requestPermissionsAsync();
     status = response.status;
   }
+  logger.info('push_token_permission_status', { status });
 
   if (status !== 'granted') {
-    logger.info('push_permission_denied', { userId });
+    logger.info('push_token_permission_denied', { userId });
     return;
   }
 
@@ -66,6 +75,13 @@ async function registerPushToken(userId: string): Promise<void> {
   try {
     const tokenResponse = await Notifications.getExpoPushTokenAsync({ projectId: PROJECT_ID });
     token = tokenResponse.data;
+    // Log un préfixe du token pour vérifier qu'il ressemble à un ExpoPushToken
+    // valide (format : ExponentPushToken[XXXXXXXX...]). On tronque à 30 char
+    // pour ne pas polluer les logs.
+    logger.info('push_token_fetched', {
+      preview: token.slice(0, 30),
+      length: token.length,
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (Platform.OS === 'android' && (message.includes('FirebaseApp') || message.includes('FCM'))) {
@@ -78,18 +94,30 @@ async function registerPushToken(userId: string): Promise<void> {
   }
 
   // Idempotent : on lit d'abord pour éviter un UPDATE inutile si rien n'a changé.
-  const { data: profile } = await supabase
+  const { data: profile, error: selectError } = await supabase
     .from('profiles')
     .select('push_token')
     .eq('id', userId)
     .single();
 
-  if (profile?.push_token === token) return;
+  if (selectError) {
+    logger.warn('push_token_select_failed', { message: selectError.message });
+    // On tente quand même l'update — un select bloqué par RLS n'implique pas
+    // forcément un update bloqué (policies peuvent différer).
+  }
 
+  if (profile?.push_token === token) {
+    logger.info('push_token_unchanged_skip');
+    return;
+  }
+
+  logger.info('push_token_db_update_attempt', { userId });
   const { error } = await supabase.from('profiles').update({ push_token: token }).eq('id', userId);
   if (error) {
-    logger.error('register_push_token_failed', error);
+    logger.error('push_token_db_update_failed', error);
+    return;
   }
+  logger.info('push_token_db_update_success', { userId });
 }
 
 /**


### PR DESCRIPTION
## Summary

**Observabilité uniquement — aucun changement de comportement.**

Diagnostic AI Supabase (CTO, 2026-07-01) : 0 profils avec \`push_token\` en DB, alors que \`usePushToken\` est censé enregistrer le token au mount de \`AuthenticatedTabs\`. Cause probable côté client (return silencieux quelque part) mais **aucun log ne permet de trancher**.

Cette PR ajoute des \`logger.info\` à chaque étape du flow pour identifier au prochain lancement où ça s'interrompt.

## Événements ajoutés

Tous préfixés \`push_token_\` pour filtre facile Sentry/PostHog :

| Événement | Quand | Level |
|---|---|---|
| \`push_token_flow_start\` | Entrée dans le hook | info |
| \`push_token_skipped_simulator\` | Simulateur détecté | info |
| \`push_token_no_eas_project_id\` | \`app.json\` mal configuré | warn |
| \`push_token_permission_status\` | Après check permission | info |
| \`push_token_permission_denied\` | User a refusé | info |
| \`push_token_fetched\` | Token récupéré (preview + length) | info |
| \`push_token_skipped_firebase_not_configured\` | Android sans FCM | info |
| \`push_token_fetch_failed\` | Autre erreur Expo | warn |
| \`push_token_select_failed\` | Read DB bloqué | warn |
| \`push_token_unchanged_skip\` | Idempotence (même token en DB) | info |
| \`push_token_db_update_attempt\` | Juste avant l'update | info |
| \`push_token_db_update_failed\` | Update rejeté | error |
| \`push_token_db_update_success\` | Update OK | info |

## Comment lire les logs

Au prochain lancement (Metro reload suffit), regarde les logs dans l'ordre :

- Tu vois \`push_token_flow_start\` puis rien d'autre → le hook n'est pas mount
- Tu vois \`_flow_start\` + \`_skipped_firebase_not_configured\` → Firebase pas init (rebuild EAS pas encore fait ou APK pas installé)
- Tu vois \`_permission_denied\` → user a refusé la permission notifs, à re-prompter manuellement
- Tu vois \`_fetched\` + \`_db_update_attempt\` + \`_db_update_failed\` → RLS bloque l'update (regarder l'erreur détaillée)
- Tu vois \`_fetched\` + \`_db_update_attempt\` + \`_db_update_success\` → tout va bien, le token est en DB

## Test plan

- [ ] Reload Metro (pas besoin de rebuild EAS pour cette PR — JS only)
- [ ] Ouvrir l'app / passer sous le guard auth
- [ ] Regarder les logs Metro (ou Sentry si tu as la breadcrumb capture activée)
- [ ] Copier la séquence \`push_token_*\` que tu vois — envoie-la moi si tu ne peux pas trancher

## Suite

Une fois qu'on sait à quelle étape ça s'arrête, on fix. Probables corrections :
- Firebase pas encore prêt sur le device → rebuild + install APK
- RLS bloque → corriger la policy UPDATE sur \`profiles\`
- Permission refusée → ouvrir un dialog pour re-demander