### PR TITLE
feat(cours): bucket Storage resources — #263 (E9-03)

### DIFF
--- a/supabase/migrations/20260702140000_cours_resources_bucket.sql
+++ b/supabase/migrations/20260702140000_cours_resources_bucket.sql
@@ -1,0 +1,105 @@
+-- E9-03 (#263) — Bucket Storage `resources` + policies
+--
+-- Stockage des fichiers de ressources pédagogiques (PDF + images). Pattern
+-- identique au bucket `listings` (marketplace), en format "phrase" pour les
+-- noms de policies (cohérence Sprint 3+, évite les doublons snake_case qu'on
+-- a dû nettoyer sur posts/stories/listings).
+--
+-- Différence avec listings : on autorise application/pdf en plus des images
+-- (un cours est souvent un PDF), et une taille max plus généreuse (20 Mo).
+--
+-- Path attendu côté client : `<user_id>/<uuid>.<ext>` — le 1er segment DOIT
+-- être l'auth.uid() (contrôlé par les policies upload/update/delete).
+--
+-- Idempotent (on conflict + pg_policies check).
+
+-- ---------------------------------------------------------------------------
+-- Bucket
+-- ---------------------------------------------------------------------------
+
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'resources',
+  'resources',
+  true,
+  20971520, -- 20 Mo
+  array['application/pdf', 'image/jpeg', 'image/png', 'image/webp']
+)
+on conflict (id) do update set
+  public             = excluded.public,
+  file_size_limit    = excluded.file_size_limit,
+  allowed_mime_types = excluded.allowed_mime_types;
+
+-- ---------------------------------------------------------------------------
+-- Policies (format "phrase", idempotentes)
+-- ---------------------------------------------------------------------------
+
+do $$
+begin
+  -- INSERT : l'user upload dans SON dossier (1er segment = son uid)
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'resources users upload own folder'
+  ) then
+    create policy "resources users upload own folder"
+      on storage.objects for insert to authenticated
+      with check (
+        bucket_id = 'resources'
+        and (storage.foldername(name))[1] = auth.uid()::text
+      );
+  end if;
+
+  -- UPDATE : idem sur son dossier
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'resources users update own folder'
+  ) then
+    create policy "resources users update own folder"
+      on storage.objects for update to authenticated
+      using (
+        bucket_id = 'resources'
+        and (storage.foldername(name))[1] = auth.uid()::text
+      );
+  end if;
+
+  -- DELETE : idem sur son dossier
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'resources users delete own folder'
+  ) then
+    create policy "resources users delete own folder"
+      on storage.objects for delete to authenticated
+      using (
+        bucket_id = 'resources'
+        and (storage.foldername(name))[1] = auth.uid()::text
+      );
+  end if;
+
+  -- SELECT : lecture publique (bucket public — anon + authenticated)
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'storage' and tablename = 'objects'
+      and policyname = 'resources public read'
+  ) then
+    create policy "resources public read"
+      on storage.objects for select to anon, authenticated
+      using (bucket_id = 'resources');
+  end if;
+end $$;
+
+-- ---------------------------------------------------------------------------
+-- Post-condition attendue (à vérifier après application) :
+--   select policyname, cmd, roles from pg_policies
+--   where schemaname='storage' and tablename='objects'
+--     and policyname ilike '%resources%'
+--   order by policyname;
+--
+--   → exactement 4 policies "phrase" :
+--     - resources users upload own folder   (INSERT, authenticated)
+--     - resources users update own folder   (UPDATE, authenticated)
+--     - resources users delete own folder   (DELETE, authenticated)
+--     - resources public read               (SELECT, {anon, authenticated})
+-- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

E9-03 (#263) — Bucket Storage `resources` pour les fichiers de ressources pédagogiques (PDF + images). Aucune dépendance, applicable indépendamment.

## Contenu

- Bucket `resources` : public, **20 Mo max** (PDF de cours souvent lourds), MIME `application/pdf` + images
- 4 policies **format phrase** idempotentes (pas de doublon snake_case à nettoyer — bucket neuf)
  - `resources users upload own folder` (INSERT, authenticated)
  - `resources users update own folder` (UPDATE, authenticated)
  - `resources users delete own folder` (DELETE, authenticated)
  - `resources public read` (SELECT, anon + authenticated)
- Path client attendu : `<user_id>/<uuid>.<ext>` (1er segment = auth.uid())

## Différence avec le bucket listings

On autorise `application/pdf` en plus des images (un cours est souvent un PDF) + taille max 20 Mo au lieu de 10.

## Pré-requis avant merge

- [ ] Migration appliquée DEV via AI Supabase
- [ ] Migration appliquée STAGING
- [ ] Vérif : `select policyname, cmd, roles from pg_policies where policyname ilike '%resources%'` → 4 policies phrase

## Suite

E9-09 (card Business Hub cliquable) puis E9-04 (grille). L'upload util `uploadResourceFile` sera ajouté dans E9-06 (création ressource), là où il est utilisé.