### PR TITLE
feat(cours): écran Apprendre — grille ressources — #264 (E9-04)

### DIFF
--- a/app/cours/index.tsx
+++ b/app/cours/index.tsx
@@ -1,0 +1,320 @@
+// Écran Apprendre — bibliothèque de ressources — E9-04 (#264)
+//
+// UI = "Apprendre" (le label large couvre cours + fiches + exos + annales),
+// même si la tuile Business Hub garde "COURS" (cf brief §15.3).
+//
+// Navigation par niveau → matière → type + recherche live. Liste pleine
+// largeur (contenu texte/document, plus lisible qu'une grille 2 colonnes).
+
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
+import { router, Stack } from 'expo-router';
+import { ArrowLeft, Bookmark, Plus, Search, X } from 'lucide-react-native';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, RefreshControl, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Input, Text, View, XStack, YStack } from 'tamagui';
+
+import { ResourceCard } from '@/features/cours/components/ResourceCard';
+import { TaxonomyChips } from '@/features/cours/components/TaxonomyChips';
+import { useCourseLevels, useCourseSubjects } from '@/features/cours/hooks/useCourseTaxonomy';
+import {
+  RESOURCE_TYPE_LABEL,
+  useResources,
+  useToggleResourceBookmark,
+  type ResourceListItem,
+  type ResourceType,
+  type ResourcesFilters,
+} from '@/features/cours/hooks/useResources';
+
+const TYPE_OPTIONS = (Object.keys(RESOURCE_TYPE_LABEL) as ResourceType[]).map((t) => ({
+  value: t,
+  label: RESOURCE_TYPE_LABEL[t],
+}));
+
+export default function ApprendreScreen() {
+  const insets = useSafeAreaInsets();
+  const listRef = useRef<FlashListRef<ResourceListItem>>(null);
+
+  const [levelCode, setLevelCode] = useState<string | null>(null);
+  const [subjectCode, setSubjectCode] = useState<string | null>(null);
+  const [type, setType] = useState<ResourceType | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+
+  const levelsQuery = useCourseLevels();
+  const subjectsQuery = useCourseSubjects();
+
+  // Maps code → label pour résoudre l'affichage sur les cards.
+  const levelLabelByCode = useMemo(() => {
+    const m = new Map<string, string>();
+    (levelsQuery.data ?? []).forEach((l) => m.set(l.code, l.label));
+    return m;
+  }, [levelsQuery.data]);
+
+  const subjectLabelByCode = useMemo(() => {
+    const m = new Map<string, string>();
+    (subjectsQuery.data ?? []).forEach((s) => m.set(s.code, s.label));
+    return m;
+  }, [subjectsQuery.data]);
+
+  const levelOptions = useMemo(
+    () => (levelsQuery.data ?? []).map((l) => ({ value: l.code, label: l.label })),
+    [levelsQuery.data]
+  );
+  const subjectOptions = useMemo(
+    () => (subjectsQuery.data ?? []).map((s) => ({ value: s.code, label: s.label })),
+    [subjectsQuery.data]
+  );
+
+  const filters = useMemo<ResourcesFilters>(
+    () => ({ levelCode, subjectCode, type, search: searchQuery, sort: 'recent' }),
+    [levelCode, subjectCode, type, searchQuery]
+  );
+
+  const resourcesQuery = useResources(filters);
+  const toggleBookmark = useToggleResourceBookmark();
+
+  const allResources = useMemo<ResourceListItem[]>(
+    () => resourcesQuery.data?.pages.flatMap((p) => p.resources) ?? [],
+    [resourcesQuery.data]
+  );
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/(tabs)/feed');
+  }, []);
+
+  const handleCardPress = useCallback((resourceId: string) => {
+    router.push(`/cours/${resourceId}`);
+  }, []);
+
+  const handleToggleBookmark = useCallback(
+    (resourceId: string) => {
+      toggleBookmark.mutate({ resourceId });
+    },
+    [toggleBookmark]
+  );
+
+  const handleLoadMore = useCallback(() => {
+    if (resourcesQuery.hasNextPage && !resourcesQuery.isFetchingNextPage) {
+      void resourcesQuery.fetchNextPage();
+    }
+  }, [resourcesQuery]);
+
+  const handlePullToRefresh = useCallback(async () => {
+    setIsManualRefreshing(true);
+    await resourcesQuery.refetch();
+    setIsManualRefreshing(false);
+  }, [resourcesQuery]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: ResourceListItem }) => (
+      <View paddingHorizontal={12} paddingBottom={10}>
+        <ResourceCard
+          resource={item}
+          levelLabel={levelLabelByCode.get(item.level_code) ?? item.level_code}
+          subjectLabel={subjectLabelByCode.get(item.subject_code) ?? item.subject_code}
+          onPress={() => handleCardPress(item.id)}
+          onToggleBookmark={() => handleToggleBookmark(item.id)}
+          isBookmarkPending={toggleBookmark.isPending}
+        />
+      </View>
+    ),
+    [
+      levelLabelByCode,
+      subjectLabelByCode,
+      handleCardPress,
+      handleToggleBookmark,
+      toggleBookmark.isPending,
+    ]
+  );
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+        {/* Header */}
+        <XStack
+          height={56}
+          paddingHorizontal={12}
+          alignItems="center"
+          gap={12}
+          borderBottomWidth={StyleSheet.hairlineWidth}
+          borderBottomColor="$borderColor"
+        >
+          <Pressable
+            onPress={handleBack}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Retour"
+          >
+            <ArrowLeft size={24} color="#FFFFFF" />
+          </Pressable>
+          <Text flex={1} color="$color" fontSize={18} fontWeight="700">
+            Apprendre
+          </Text>
+          <Pressable
+            onPress={() => router.push('/cours/bookmarks')}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Mes ressources sauvegardées"
+          >
+            <Bookmark size={22} color="#FFFFFF" strokeWidth={2.2} />
+          </Pressable>
+          <Pressable
+            onPress={() => router.push('/cours/create')}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Publier une ressource"
+            style={styles.createButton}
+          >
+            <Plus size={20} color="#000000" strokeWidth={2.6} />
+          </Pressable>
+        </XStack>
+
+        {/* Recherche */}
+        <YStack paddingHorizontal={12} paddingTop={10} paddingBottom={4}>
+          <XStack
+            alignItems="center"
+            gap={8}
+            height={44}
+            backgroundColor="$surface"
+            borderRadius="$md"
+            paddingHorizontal={12}
+          >
+            <Search size={18} color="#A0A0A0" />
+            <Input
+              flex={1}
+              height={44}
+              borderWidth={0}
+              backgroundColor="transparent"
+              color="$color"
+              placeholder="Rechercher un cours, une fiche…"
+              placeholderTextColor="$placeholderColor"
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              autoCapitalize="none"
+              autoCorrect={false}
+              fontSize={15}
+              paddingHorizontal={0}
+              accessibilityLabel="Rechercher une ressource"
+            />
+            {searchQuery.length > 0 ? (
+              <Pressable
+                onPress={() => setSearchQuery('')}
+                hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                accessibilityRole="button"
+                accessibilityLabel="Effacer la recherche"
+              >
+                <X size={16} color="#A0A0A0" />
+              </Pressable>
+            ) : null}
+          </XStack>
+        </YStack>
+
+        {/* Filtres taxonomie : matière → niveau → type */}
+        <YStack gap={6} paddingVertical={4}>
+          <TaxonomyChips
+            options={subjectOptions}
+            selected={subjectCode}
+            onSelect={setSubjectCode}
+            allLabel="Toutes matières"
+          />
+          <TaxonomyChips
+            options={levelOptions}
+            selected={levelCode}
+            onSelect={setLevelCode}
+            allLabel="Tous niveaux"
+          />
+          <TaxonomyChips
+            options={TYPE_OPTIONS}
+            selected={type}
+            onSelect={(v) => setType(v as ResourceType | null)}
+            allLabel="Tous types"
+          />
+        </YStack>
+
+        {/* Liste */}
+        <View flex={1}>
+          {resourcesQuery.isLoading ? (
+            <YStack flex={1} alignItems="center" justifyContent="center">
+              <ActivityIndicator color="#FFFFFF" />
+            </YStack>
+          ) : resourcesQuery.isError ? (
+            <YStack
+              flex={1}
+              alignItems="center"
+              justifyContent="center"
+              paddingHorizontal={24}
+              gap={8}
+            >
+              <Text fontSize={16} fontWeight="700" color="$color">
+                Impossible de charger les ressources
+              </Text>
+              <Text fontSize={13} color="$textSecondary" textAlign="center">
+                Tire vers le bas pour réessayer.
+              </Text>
+            </YStack>
+          ) : allResources.length === 0 ? (
+            <YStack
+              flex={1}
+              alignItems="center"
+              justifyContent="center"
+              paddingHorizontal={24}
+              gap={8}
+            >
+              <Text fontSize={16} fontWeight="700" color="$color">
+                Aucune ressource trouvée
+              </Text>
+              <Text fontSize={13} color="$textSecondary" textAlign="center">
+                {searchQuery.length > 0
+                  ? `Rien ne correspond à "${searchQuery}".`
+                  : 'Sois le premier à partager un cours ici.'}
+              </Text>
+            </YStack>
+          ) : (
+            <FlashList
+              ref={listRef}
+              data={allResources}
+              renderItem={renderItem}
+              keyExtractor={(item) => item.id}
+              onEndReached={handleLoadMore}
+              onEndReachedThreshold={0.4}
+              contentContainerStyle={styles.listContent}
+              refreshControl={
+                <RefreshControl
+                  refreshing={isManualRefreshing}
+                  onRefresh={() => void handlePullToRefresh()}
+                  tintColor="#10D970"
+                  colors={['#10D970']}
+                />
+              }
+              ListFooterComponent={
+                resourcesQuery.isFetchingNextPage ? (
+                  <YStack paddingVertical={16} alignItems="center">
+                    <ActivityIndicator color="#FFFFFF" />
+                  </YStack>
+                ) : null
+              }
+            />
+          )}
+        </View>
+      </YStack>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  createButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    backgroundColor: '#10D970',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  listContent: {
+    paddingTop: 6,
+    paddingBottom: 24,
+  },
+});

--- a/src/features/cours/components/ResourceCard.tsx
+++ b/src/features/cours/components/ResourceCard.tsx
@@ -1,0 +1,173 @@
+// ResourceCard — E9-04 — Carte d'une ressource dans la liste "Apprendre"
+//
+// Contrairement au ListingCard marketplace (grille 2 col orientée image),
+// une ressource est du contenu texte/document → on privilégie une carte
+// pleine largeur, plus lisible : vignette type à gauche, titre + méta +
+// auteur à droite, bookmark en haut à droite.
+
+import { Image } from 'expo-image';
+import {
+  Bookmark,
+  BookOpen,
+  Eye,
+  FileText,
+  PenLine,
+  ScrollText,
+  type LucideIcon,
+} from 'lucide-react-native';
+import { memo } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+import {
+  RESOURCE_TYPE_LABEL,
+  type ResourceListItem,
+  type ResourceType,
+} from '../hooks/useResources';
+
+const HIT_SLOP = { top: 10, right: 10, bottom: 10, left: 10 };
+
+// Icône + couleur d'accent par type de ressource.
+const TYPE_VISUAL: Record<ResourceType, { Icon: LucideIcon; color: string; bg: string }> = {
+  cours: { Icon: BookOpen, color: '#10D970', bg: '#12291D' },
+  fiche_revision: { Icon: FileText, color: '#3B82F6', bg: '#12203A' },
+  exercices: { Icon: PenLine, color: '#F59E0B', bg: '#2E2410' },
+  annale: { Icon: ScrollText, color: '#EC4899', bg: '#2E1522' },
+};
+
+export interface ResourceCardProps {
+  resource: ResourceListItem;
+  /** Libellé du niveau (résolu depuis la taxonomie par l'écran parent). */
+  levelLabel: string;
+  /** Libellé de la matière. */
+  subjectLabel: string;
+  onPress: () => void;
+  onToggleBookmark: () => void;
+  isBookmarkPending?: boolean;
+}
+
+function ResourceCardComponent({
+  resource,
+  levelLabel,
+  subjectLabel,
+  onPress,
+  onToggleBookmark,
+  isBookmarkPending = false,
+}: ResourceCardProps) {
+  const visual = TYPE_VISUAL[resource.type];
+  const { Icon } = visual;
+  // Si le 1er fichier est une image, on l'affiche en vignette, sinon icône type.
+  const firstImage = resource.files.find((f) => /\.(jpe?g|png|webp)$/i.test(f)) ?? null;
+
+  const a11yLabel = `${RESOURCE_TYPE_LABEL[resource.type]} : ${resource.title}, ${subjectLabel} ${levelLabel}, par ${resource.author_username}`;
+
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={a11yLabel}
+      style={styles.card}
+    >
+      <XStack
+        backgroundColor="$surface"
+        borderRadius={14}
+        padding={12}
+        gap={12}
+        alignItems="center"
+      >
+        {/* Vignette type / image */}
+        <View
+          width={56}
+          height={56}
+          borderRadius={10}
+          overflow="hidden"
+          backgroundColor={visual.bg}
+          alignItems="center"
+          justifyContent="center"
+        >
+          {firstImage ? (
+            <Image source={{ uri: firstImage }} style={styles.thumb} contentFit="cover" />
+          ) : (
+            <Icon size={26} color={visual.color} strokeWidth={1.9} />
+          )}
+        </View>
+
+        {/* Contenu */}
+        <YStack flex={1} minWidth={0} gap={4}>
+          {/* Badge type + niveau·matière */}
+          <XStack alignItems="center" gap={6} flexWrap="wrap">
+            <View
+              backgroundColor={visual.bg}
+              paddingHorizontal={7}
+              paddingVertical={2}
+              borderRadius={4}
+            >
+              <Text fontSize={10} fontWeight="700" color={visual.color}>
+                {RESOURCE_TYPE_LABEL[resource.type]}
+              </Text>
+            </View>
+            <Text fontSize={11} color="$textSecondary" numberOfLines={1}>
+              {subjectLabel} · {levelLabel}
+            </Text>
+          </XStack>
+
+          {/* Titre */}
+          <Text fontSize={15} fontWeight="700" color="$color" numberOfLines={2}>
+            {resource.title}
+          </Text>
+
+          {/* Auteur + vues */}
+          <XStack alignItems="center" gap={8}>
+            <Text fontSize={11} color="$textSecondary" numberOfLines={1}>
+              @{resource.author_username}
+            </Text>
+            <XStack alignItems="center" gap={3}>
+              <Eye size={11} color="#A0A0A0" />
+              <Text fontSize={11} color="$textSecondary">
+                {resource.view_count}
+              </Text>
+            </XStack>
+          </XStack>
+        </YStack>
+
+        {/* Bookmark */}
+        <Pressable
+          onPress={onToggleBookmark}
+          disabled={isBookmarkPending}
+          hitSlop={HIT_SLOP}
+          accessibilityRole="button"
+          accessibilityLabel={
+            resource.bookmarked_by_me ? 'Retirer des favoris' : 'Ajouter aux favoris'
+          }
+          accessibilityState={{ selected: resource.bookmarked_by_me }}
+          style={styles.bookmarkButton}
+        >
+          <Bookmark
+            size={20}
+            color={resource.bookmarked_by_me ? '#10D970' : '#A0A0A0'}
+            fill={resource.bookmarked_by_me ? '#10D970' : 'transparent'}
+            strokeWidth={2.1}
+          />
+        </Pressable>
+      </XStack>
+    </Pressable>
+  );
+}
+
+export const ResourceCard = memo(ResourceCardComponent);
+
+const styles = StyleSheet.create({
+  bookmarkButton: {
+    width: 36,
+    height: 36,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  card: {
+    width: '100%',
+  },
+  thumb: {
+    width: '100%',
+    height: '100%',
+  },
+});

--- a/src/features/cours/components/TaxonomyChips.tsx
+++ b/src/features/cours/components/TaxonomyChips.tsx
@@ -1,0 +1,94 @@
+// TaxonomyChips — E9-04
+//
+// Rangée horizontale scrollable de chips pour filtrer par niveau / matière /
+// type. Composant générique : une chip "Tout" (valeur null) + une chip par
+// option. Réutilisé pour les 3 axes de la bibliothèque.
+//
+// Note layout Android : flexGrow:0 + maxHeight sur le ScrollView pour éviter
+// l'expansion verticale (même correctif que QuickFiltersBar marketplace).
+
+import { Pressable, ScrollView, StyleSheet } from 'react-native';
+import { Text } from 'tamagui';
+
+export interface TaxonomyChipOption {
+  value: string;
+  label: string;
+}
+
+export interface TaxonomyChipsProps {
+  options: TaxonomyChipOption[];
+  /** Valeur sélectionnée, ou null pour "Tout". */
+  selected: string | null;
+  onSelect: (value: string | null) => void;
+  /** Libellé de la chip "tout" (ex. "Tous", "Toutes", "Tous types"). */
+  allLabel?: string;
+}
+
+export function TaxonomyChips({
+  options,
+  selected,
+  onSelect,
+  allLabel = 'Tous',
+}: TaxonomyChipsProps) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      contentContainerStyle={styles.content}
+      keyboardShouldPersistTaps="handled"
+      style={styles.scroll}
+    >
+      <Chip label={allLabel} active={selected === null} onPress={() => onSelect(null)} />
+      {options.map((opt) => (
+        <Chip
+          key={opt.value}
+          label={opt.label}
+          active={selected === opt.value}
+          onPress={() => onSelect(opt.value)}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+function Chip({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) {
+  return (
+    <Pressable
+      onPress={onPress}
+      accessibilityRole="tab"
+      accessibilityLabel={label}
+      accessibilityState={{ selected: active }}
+      style={[styles.chip, active ? styles.chipActive : null]}
+    >
+      <Text
+        fontSize={13}
+        fontWeight={active ? '700' : '500'}
+        color={active ? '#000000' : '#FFFFFF'}
+      >
+        {label}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 9999,
+    backgroundColor: '#1A1A1A',
+    marginRight: 8,
+  },
+  chipActive: {
+    backgroundColor: '#FFFFFF',
+  },
+  content: {
+    paddingHorizontal: 12,
+    alignItems: 'center',
+  },
+  scroll: {
+    flexGrow: 0,
+    flexShrink: 0,
+    maxHeight: 44,
+  },
+});

--- a/src/features/cours/hooks/useCourseTaxonomy.ts
+++ b/src/features/cours/hooks/useCourseTaxonomy.ts
@@ -1,0 +1,75 @@
+// useCourseTaxonomy — E9-04
+//
+// Récupère les référentiels niveaux + matières (tables course_levels /
+// course_subjects, seed E9-01, lecture publique via RLS). La taxonomie ne
+// change quasi jamais → staleTime très long + gcTime long, on évite de la
+// refetch à chaque montée d'écran.
+
+import { useQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export interface CourseLevel {
+  code: string;
+  cycle: string;
+  label: string;
+  sort_order: number;
+}
+
+export interface CourseSubject {
+  code: string;
+  label: string;
+  sort_order: number;
+}
+
+// Ordre d'affichage des cycles (les niveaux sont groupés par cycle à l'UI).
+export const CYCLE_ORDER: { key: string; label: string }[] = [
+  { key: 'primaire', label: 'Primaire' },
+  { key: 'college', label: 'Collège' },
+  { key: 'lycee', label: 'Lycée' },
+  { key: 'superieur', label: 'Supérieur' },
+  { key: 'tout_public', label: 'Tout public' },
+];
+
+const STALE = 60 * 60 * 1000; // 1 h
+
+export function useCourseLevels() {
+  return useQuery({
+    queryKey: ['cours', 'taxonomy', 'levels'],
+    staleTime: STALE,
+    gcTime: STALE,
+    queryFn: async (): Promise<CourseLevel[]> => {
+      const { data, error } = await supabase
+        .from('course_levels')
+        .select('code, cycle, label, sort_order')
+        .eq('is_active', true)
+        .order('sort_order', { ascending: true });
+      if (error) {
+        logger.warn('course_levels fetch failed', { message: error.message });
+        throw error;
+      }
+      return (data ?? []) as CourseLevel[];
+    },
+  });
+}
+
+export function useCourseSubjects() {
+  return useQuery({
+    queryKey: ['cours', 'taxonomy', 'subjects'],
+    staleTime: STALE,
+    gcTime: STALE,
+    queryFn: async (): Promise<CourseSubject[]> => {
+      const { data, error } = await supabase
+        .from('course_subjects')
+        .select('code, label, sort_order')
+        .eq('is_active', true)
+        .order('sort_order', { ascending: true });
+      if (error) {
+        logger.warn('course_subjects fetch failed', { message: error.message });
+        throw error;
+      }
+      return (data ?? []) as CourseSubject[];
+    },
+  });
+}

--- a/src/features/cours/hooks/useResources.ts
+++ b/src/features/cours/hooks/useResources.ts
@@ -1,0 +1,188 @@
+// useResources — E9-04 — Grille des ressources pédagogiques
+//
+// Pattern strictement aligné sur useListings (marketplace) : useInfiniteQuery
+// + cursor created_at + RPC get_resources security definer. La RPC est
+// grantée anon + authenticated → la bibliothèque est consultable sans compte.
+
+import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+const PAGE_SIZE = 20;
+
+export type ResourceType = 'cours' | 'fiche_revision' | 'exercices' | 'annale';
+export type ResourceSort = 'recent' | 'popular';
+
+export const RESOURCE_TYPE_LABEL: Record<ResourceType, string> = {
+  cours: 'Cours',
+  fiche_revision: 'Fiche de révision',
+  exercices: 'Exercices',
+  annale: 'Annale',
+};
+
+export interface ResourceListItem {
+  id: string;
+  author_id: string;
+  author_username: string;
+  author_avatar_url: string | null;
+  author_is_verified: boolean;
+  level_code: string;
+  subject_code: string;
+  type: ResourceType;
+  title: string;
+  description: string | null;
+  files: string[];
+  view_count: number;
+  created_at: string;
+  bookmarked_by_me: boolean;
+}
+
+export interface ResourcesFilters {
+  levelCode?: string | null;
+  subjectCode?: string | null;
+  type?: ResourceType | null;
+  search?: string | null;
+  sort?: ResourceSort;
+}
+
+type RpcRow = Record<string, unknown>;
+
+type ResourcesQueryData = {
+  pages: { resources: ResourceListItem[]; nextCursor: string | null }[];
+  pageParams: unknown[];
+};
+
+export function resourcesQueryKey(filters: ResourcesFilters) {
+  return [
+    'cours',
+    'resources',
+    {
+      levelCode: filters.levelCode ?? null,
+      subjectCode: filters.subjectCode ?? null,
+      type: filters.type ?? null,
+      search: (filters.search ?? '').trim().toLowerCase(),
+      sort: filters.sort ?? 'recent',
+    },
+  ] as const;
+}
+
+function isType(value: unknown): value is ResourceType {
+  return (
+    value === 'cours' || value === 'fiche_revision' || value === 'exercices' || value === 'annale'
+  );
+}
+
+function mapRow(row: RpcRow): ResourceListItem {
+  return {
+    id: String(row.id ?? ''),
+    author_id: String(row.author_id ?? ''),
+    author_username: String(row.author_username ?? ''),
+    author_avatar_url: (row.author_avatar_url as string | null) ?? null,
+    author_is_verified: Boolean(row.author_is_verified ?? false),
+    level_code: String(row.level_code ?? ''),
+    subject_code: String(row.subject_code ?? ''),
+    type: isType(row.type) ? row.type : 'cours',
+    title: String(row.title ?? ''),
+    description: (row.description as string | null) ?? null,
+    files: Array.isArray(row.files) ? (row.files as string[]) : [],
+    view_count: typeof row.view_count === 'number' ? row.view_count : 0,
+    created_at: String(row.created_at ?? ''),
+    bookmarked_by_me: Boolean(row.bookmarked_by_me ?? false),
+  };
+}
+
+async function fetchResourcesPage(cursor: string | null, filters: ResourcesFilters) {
+  const search = (filters.search ?? '').trim();
+  const { data, error } = await supabase.rpc('get_resources', {
+    p_level_code: filters.levelCode ?? null,
+    p_subject_code: filters.subjectCode ?? null,
+    p_type: filters.type ?? null,
+    p_search: search.length > 0 ? search : null,
+    p_sort: filters.sort ?? 'recent',
+    p_cursor: cursor,
+    p_limit: PAGE_SIZE,
+  });
+
+  if (error) {
+    logger.warn('get_resources failed', { message: error.message });
+    throw error;
+  }
+
+  const resources = ((data ?? []) as RpcRow[]).map(mapRow);
+  const nextCursor =
+    resources.length === PAGE_SIZE ? (resources[resources.length - 1]?.created_at ?? null) : null;
+
+  return { resources, nextCursor };
+}
+
+export function useResources(filters: ResourcesFilters = {}) {
+  return useInfiniteQuery({
+    queryKey: resourcesQueryKey(filters),
+    queryFn: ({ pageParam }) => fetchResourcesPage(pageParam, filters),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Toggle bookmark optimiste sur toutes les queries de la verticale Cours.
+ */
+export function useToggleResourceBookmark() {
+  const queryClient = useQueryClient();
+
+  return useMutation<boolean, Error, { resourceId: string }>({
+    mutationFn: async ({ resourceId }) => {
+      const { data, error } = await supabase.rpc('toggle_resource_bookmark', {
+        p_resource_id: resourceId,
+      });
+      if (error) {
+        logger.warn('toggle_resource_bookmark failed', {
+          message: error.message,
+          resourceId,
+        });
+        throw error;
+      }
+      return Boolean(data);
+    },
+    onMutate: async ({ resourceId }) => {
+      await queryClient.cancelQueries({ queryKey: ['cours', 'resources'] });
+      queryClient.setQueriesData<ResourcesQueryData>(
+        { queryKey: ['cours', 'resources'] },
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              resources: page.resources.map((r) =>
+                r.id === resourceId ? { ...r, bookmarked_by_me: !r.bookmarked_by_me } : r
+              ),
+            })),
+          };
+        }
+      );
+    },
+    onError: (_err, vars) => {
+      queryClient.setQueriesData<ResourcesQueryData>(
+        { queryKey: ['cours', 'resources'] },
+        (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              resources: page.resources.map((r) =>
+                r.id === vars.resourceId ? { ...r, bookmarked_by_me: !r.bookmarked_by_me } : r
+              ),
+            })),
+          };
+        }
+      );
+    },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: ['cours', 'bookmarks'] });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

E9-04 (#264) — Écran principal de la verticale Cours : **"Apprendre"** (label large, la tuile Business Hub garde "COURS" cf brief §15.3). Navigation niveau → matière → type + recherche live. **Pur frontend**, aucune migration.

Dépend au runtime de E9-02 (RPC `get_resources`) — codé en amont, marche dès que la migration E9-02 est appliquée.

## Contenu

### Hooks
- **`useCourseTaxonomy`** : `useCourseLevels` + `useCourseSubjects` (tables seed E9-01, lecture publique RLS, staleTime 1h car quasi statique)
- **`useResources`** : `useInfiniteQuery` sur `get_resources` (pattern `useListings`), filtres niveau/matière/type + recherche + tri, cursor created_at
- **`useToggleResourceBookmark`** : optimistic sur toutes les queries `['cours','resources']`

### Composants
- **`ResourceCard`** : carte **pleine largeur** (contenu texte/document plus lisible qu'une grille 2 col), vignette type (icône+couleur par type) ou 1ère image, badge type + matière·niveau, auteur + vues, bookmark. `accessibilityLabel` composite.
- **`TaxonomyChips`** : rangée de chips générique (Tout + options), réutilisée pour les 3 axes. `flexGrow:0` + `maxHeight` (fix layout Android identique à QuickFiltersBar).

### Écran `app/cours/index.tsx`
- Header **Apprendre** + bookmark (→ `/cours/bookmarks`, E9-07) + bouton **+** (→ `/cours/create`, E9-06)
- Recherche live
- 3 rangées de chips : matière / niveau / type
- FlashList pleine largeur + pull to refresh + infinite scroll
- 4 empty states distincts (loading / error / no-results / no-content)
- Tap card → `/cours/[id]` (fiche E9-05)

## Routes branchées en amont (livrées par les tickets suivants)
- `/cours/[id]` → fiche (E9-05)
- `/cours/bookmarks` → favoris (E9-07)
- `/cours/create` → création (E9-06)

## Test plan (après E9-02/E9-03 appliquées)
- [ ] Ouvrir `/cours` → chips matière/niveau/type chargées depuis la taxonomie
- [ ] Sélectionner une matière → liste filtrée
- [ ] Recherche live filtre les ressources
- [ ] Empty state si aucune ressource (DB vide au départ, normal)
- [ ] Bookmark toggle optimiste
- [ ] Pull to refresh + scroll infini

## Suite
E9-09 (tuile Business Hub cliquable → point d'entrée visible), puis E9-05 (fiche) / E9-06 (création).