### PR TITLE
feat(cours): tuile COURS cliquable dans Business Hub — #269 (E9-09)

### DIFF
--- a/src/features/feed/components/BusinessHub.tsx
+++ b/src/features/feed/components/BusinessHub.tsx
@@ -89,7 +89,9 @@ const CATEGORIES: CategoryDef[] = [
     Icon: BookOpen,
     bgColor: '#1F3D2F',
     accentColor: '#10B981',
-    href: null,
+    // E9-09 — verticale Cours ("Apprendre") active. La tuile garde le libellé
+    // "COURS" (fidélité maquette CEO), l'écran s'intitule "Apprendre".
+    href: '/cours',
   },
 ];
 


### PR DESCRIPTION
## Summary

E9-09 (#269) — La tuile **COURS** du Business Hub devient cliquable (comme MARKETPLACE) → ouvre `/cours` (l'écran "Apprendre", E9-04).

Avancée volontairement tôt dans le sprint (cf review) pour avoir un **point d'entrée visible** dans l'app dès maintenant, quitte à ce que la grille se remplisse au fur et à mesure.

## Contenu

1 ligne : `href: null` → `href: '/cours'` sur la catégorie `cours` dans `BusinessHub.tsx`.

Effet : la tuile perd son opacité 0.55 + l'overlay "Bientôt disponible", passe en "Voir plus", et devient tappable.

Libellé de la tuile inchangé ("COURS", fidélité maquette CEO) — l'écran s'intitule "Apprendre".

## Test plan
- [ ] Feed → onglet Business → la tuile COURS est en pleine opacité avec "Voir plus"
- [ ] Tap → ouvre l'écran Apprendre (`/cours`)
- [ ] Les 4 autres tuiles (Films/Immobilier/Jeux/Musique) restent grisées "Bientôt disponible"