### PR TITLE
feat(cours): fiche ressource — #265 (E9-05)

### DIFF
--- a/app/cours/[id].tsx
+++ b/app/cours/[id].tsx
@@ -1,0 +1,399 @@
+// Écran Fiche ressource — E9-05 (#265)
+//
+// Détail d'une ressource : type + titre + matière·niveau + description +
+// fichiers (ouvrables via WebBrowser) + carte auteur + CTA "Contacter
+// l'auteur" (DM pré-rempli, réutilise useGetOrCreateDm de la messagerie).
+//
+// Garde-fou : sur sa propre ressource, le CTA devient "C'est votre ressource".
+
+import { router, Stack, useLocalSearchParams } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
+import { ArrowLeft, Bookmark, ChevronRight, Eye } from 'lucide-react-native';
+import { useCallback, useEffect, useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Button, Image, Text, View, XStack, YStack } from 'tamagui';
+
+import { ResourceFileRow } from '@/features/cours/components/ResourceFileRow';
+import { useCourseLevels, useCourseSubjects } from '@/features/cours/hooks/useCourseTaxonomy';
+import { useResourceDetail } from '@/features/cours/hooks/useResourceDetail';
+import {
+  RESOURCE_TYPE_LABEL,
+  useToggleResourceBookmark,
+} from '@/features/cours/hooks/useResources';
+import { useGetOrCreateDm } from '@/features/messaging/hooks/useGetOrCreateDm';
+import { VerifiedBadge } from '@/features/profile/components/VerifiedBadge';
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+function formatRelativeFr(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '';
+  const elapsed = Math.max(0, Date.now() - date.getTime());
+  const days = Math.floor(elapsed / 86_400_000);
+  if (days < 1) return "aujourd'hui";
+  if (days < 7) return `il y a ${days} j`;
+  if (days < 31) return `il y a ${Math.floor(days / 7)} sem`;
+  if (days < 365) return `il y a ${Math.floor(days / 30)} mois`;
+  return `il y a ${Math.floor(days / 365)} an`;
+}
+
+export default function ResourceDetailScreen() {
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ id: string }>();
+  const resourceId = typeof params.id === 'string' ? params.id : null;
+
+  const { data: resource, isLoading, isError } = useResourceDetail(resourceId);
+  const toggleBookmark = useToggleResourceBookmark();
+  const getOrCreateDm = useGetOrCreateDm();
+  const levelsQuery = useCourseLevels();
+  const subjectsQuery = useCourseSubjects();
+
+  const [meId, setMeId] = useState<string | null>(null);
+  useEffect(() => {
+    void (async () => {
+      const { data } = await supabase.auth.getSession();
+      setMeId(data.session?.user.id ?? null);
+    })();
+  }, []);
+
+  const isMine = meId !== null && resource != null && resource.author_id === meId;
+
+  const levelLabel =
+    levelsQuery.data?.find((l) => l.code === resource?.level_code)?.label ??
+    resource?.level_code ??
+    '';
+  const subjectLabel =
+    subjectsQuery.data?.find((s) => s.code === resource?.subject_code)?.label ??
+    resource?.subject_code ??
+    '';
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/cours');
+  }, []);
+
+  const handleToggleBookmark = useCallback(() => {
+    if (!resourceId) return;
+    toggleBookmark.mutate({ resourceId });
+  }, [resourceId, toggleBookmark]);
+
+  const handleOpenFile = useCallback((url: string) => {
+    void WebBrowser.openBrowserAsync(url).catch((err) => {
+      logger.warn('open resource file failed', { message: String(err) });
+      Alert.alert('Impossible d’ouvrir le fichier', 'Réessaie dans un instant.');
+    });
+  }, []);
+
+  const handleOpenAuthor = useCallback(() => {
+    if (!resource) return;
+    router.push(`/profile/${resource.author_id}`);
+  }, [resource]);
+
+  const handleContactAuthor = useCallback(() => {
+    if (!resource || isMine) return;
+    const prefill = `Bonjour, j'ai une question sur ta ressource '${resource.title}'.`;
+    getOrCreateDm.mutate(resource.author_id, {
+      onSuccess: (conversationId) => {
+        router.push({ pathname: '/messages/[id]', params: { id: conversationId, prefill } });
+      },
+      onError: (err) => {
+        logger.warn('contact author failed', { message: err.message });
+        Alert.alert('Impossible de contacter l’auteur', err.message || 'Réessaie plus tard.');
+      },
+    });
+  }, [getOrCreateDm, isMine, resource]);
+
+  const renderHeader = (
+    <XStack
+      height={56}
+      paddingHorizontal={12}
+      alignItems="center"
+      gap={12}
+      borderBottomWidth={StyleSheet.hairlineWidth}
+      borderBottomColor="$borderColor"
+    >
+      <Pressable
+        onPress={handleBack}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityRole="button"
+        accessibilityLabel="Retour"
+      >
+        <ArrowLeft size={24} color="#FFFFFF" />
+      </Pressable>
+      <Text flex={1} color="$color" fontSize={17} fontWeight="700" numberOfLines={1}>
+        Ressource
+      </Text>
+      {resource ? (
+        <Pressable
+          onPress={handleToggleBookmark}
+          disabled={toggleBookmark.isPending}
+          hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+          accessibilityRole="button"
+          accessibilityLabel={
+            resource.bookmarked_by_me ? 'Retirer des favoris' : 'Ajouter aux favoris'
+          }
+          accessibilityState={{ selected: resource.bookmarked_by_me }}
+        >
+          <Bookmark
+            size={22}
+            color={resource.bookmarked_by_me ? '#10D970' : '#FFFFFF'}
+            fill={resource.bookmarked_by_me ? '#10D970' : 'transparent'}
+            strokeWidth={2.2}
+          />
+        </Pressable>
+      ) : null}
+    </XStack>
+  );
+
+  if (isLoading) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+          {renderHeader}
+          <YStack flex={1} alignItems="center" justifyContent="center">
+            <ActivityIndicator color="#FFFFFF" />
+          </YStack>
+        </YStack>
+      </>
+    );
+  }
+
+  if (isError || !resource) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+          {renderHeader}
+          <YStack
+            flex={1}
+            alignItems="center"
+            justifyContent="center"
+            paddingHorizontal={24}
+            gap={8}
+          >
+            <Text fontSize={16} fontWeight="700" color="$color">
+              Ressource introuvable
+            </Text>
+            <Text fontSize={13} color="$textSecondary" textAlign="center">
+              Elle a peut-être été supprimée ou masquée.
+            </Text>
+            <Button
+              marginTop={12}
+              backgroundColor="$accentNeon"
+              color="#000000"
+              fontWeight="700"
+              borderRadius="$10"
+              onPress={handleBack}
+            >
+              Retour
+            </Button>
+          </YStack>
+        </YStack>
+      </>
+    );
+  }
+
+  const initial = (resource.author_username || '?').charAt(0).toUpperCase();
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+        {renderHeader}
+
+        <ScrollView
+          contentContainerStyle={{ paddingBottom: 110 + insets.bottom }}
+          showsVerticalScrollIndicator={false}
+        >
+          <YStack paddingHorizontal={16} paddingTop={16} gap={14}>
+            {/* Badge type + matière·niveau */}
+            <XStack alignItems="center" gap={8} flexWrap="wrap">
+              <View
+                backgroundColor="$surface"
+                paddingHorizontal={10}
+                paddingVertical={4}
+                borderRadius={9999}
+              >
+                <Text fontSize={12} fontWeight="700" color="$accentNeon">
+                  {RESOURCE_TYPE_LABEL[resource.type]}
+                </Text>
+              </View>
+              <Text fontSize={13} color="$textSecondary">
+                {subjectLabel} · {levelLabel}
+              </Text>
+            </XStack>
+
+            {/* Titre */}
+            <Text fontSize={22} fontWeight="800" color="$color">
+              {resource.title}
+            </Text>
+
+            {/* Méta : vues + date */}
+            <XStack alignItems="center" gap={12}>
+              <XStack alignItems="center" gap={4}>
+                <Eye size={13} color="#A0A0A0" />
+                <Text fontSize={12} color="$textSecondary">
+                  {resource.view_count} vue{resource.view_count > 1 ? 's' : ''}
+                </Text>
+              </XStack>
+              <Text fontSize={12} color="$textSecondary">
+                {formatRelativeFr(resource.created_at)}
+              </Text>
+            </XStack>
+
+            {/* Description */}
+            {resource.description ? (
+              <YStack gap={6}>
+                <Text fontSize={13} color="$textSecondary" fontWeight="700">
+                  Description
+                </Text>
+                <Text fontSize={14} color="$color" lineHeight={20}>
+                  {resource.description}
+                </Text>
+              </YStack>
+            ) : null}
+
+            {/* Fichiers */}
+            {resource.files.length > 0 ? (
+              <YStack gap={8}>
+                <Text fontSize={13} color="$textSecondary" fontWeight="700">
+                  Fichiers ({resource.files.length})
+                </Text>
+                {resource.files.map((url, i) => (
+                  <ResourceFileRow
+                    key={`${url}-${i}`}
+                    url={url}
+                    index={i}
+                    onOpen={handleOpenFile}
+                  />
+                ))}
+              </YStack>
+            ) : (
+              <Text fontSize={13} color="$textSecondary">
+                Aucun fichier joint à cette ressource.
+              </Text>
+            )}
+
+            {/* Carte auteur */}
+            <YStack gap={8} paddingTop={4}>
+              <Text fontSize={13} color="$textSecondary" fontWeight="700">
+                Auteur
+              </Text>
+              <Pressable
+                onPress={handleOpenAuthor}
+                accessibilityRole="button"
+                accessibilityLabel={`Voir le profil de ${resource.author_username}`}
+              >
+                <XStack
+                  backgroundColor="$surface"
+                  borderRadius={12}
+                  padding={12}
+                  alignItems="center"
+                  gap={12}
+                >
+                  <YStack
+                    width={44}
+                    height={44}
+                    borderRadius={9999}
+                    backgroundColor="$surfaceElevated"
+                    overflow="hidden"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    {resource.author_avatar_url ? (
+                      <Image
+                        source={{ uri: resource.author_avatar_url }}
+                        style={styles.avatar}
+                        objectFit="cover"
+                      />
+                    ) : (
+                      <Text fontSize={17} fontWeight="700" color="$color">
+                        {initial}
+                      </Text>
+                    )}
+                  </YStack>
+                  <YStack flex={1} minWidth={0} gap={2}>
+                    <XStack alignItems="center" gap={4}>
+                      <Text fontSize={15} fontWeight="700" color="$color" numberOfLines={1}>
+                        @{resource.author_username}
+                      </Text>
+                      <VerifiedBadge isVerified={resource.author_is_verified} />
+                    </XStack>
+                    {resource.author_full_name ? (
+                      <Text fontSize={12} color="$textSecondary" numberOfLines={1}>
+                        {resource.author_full_name}
+                      </Text>
+                    ) : null}
+                  </YStack>
+                  <ChevronRight size={16} color="#A0A0A0" />
+                </XStack>
+              </Pressable>
+            </YStack>
+          </YStack>
+        </ScrollView>
+
+        {/* CTA sticky bottom — Contacter l'auteur */}
+        <YStack
+          position="absolute"
+          bottom={0}
+          left={0}
+          right={0}
+          paddingHorizontal={16}
+          paddingTop={12}
+          paddingBottom={insets.bottom + 12}
+          backgroundColor="$background"
+          borderTopWidth={StyleSheet.hairlineWidth}
+          borderTopColor="$borderColor"
+        >
+          {isMine ? (
+            <View
+              backgroundColor="$surface"
+              borderRadius={9999}
+              paddingVertical={14}
+              alignItems="center"
+            >
+              <Text fontSize={14} fontWeight="700" color="$textSecondary">
+                {`C'est votre ressource`}
+              </Text>
+            </View>
+          ) : (
+            <Pressable
+              onPress={handleContactAuthor}
+              disabled={getOrCreateDm.isPending}
+              accessibilityRole="button"
+              accessibilityLabel={`Contacter ${resource.author_username}`}
+              accessibilityState={{ disabled: getOrCreateDm.isPending }}
+              style={[
+                styles.cta,
+                { backgroundColor: getOrCreateDm.isPending ? '#1A1A1A' : '#10D970' },
+              ]}
+            >
+              {getOrCreateDm.isPending ? (
+                <ActivityIndicator color="#10D970" />
+              ) : (
+                <Text fontSize={15} fontWeight="800" color="#000000">
+                  Contacter l&apos;auteur
+                </Text>
+              )}
+            </Pressable>
+          )}
+        </YStack>
+      </YStack>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  avatar: {
+    width: '100%',
+    height: '100%',
+  },
+  cta: {
+    borderRadius: 9999,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/src/features/cours/components/ResourceFileRow.tsx
+++ b/src/features/cours/components/ResourceFileRow.tsx
@@ -1,0 +1,86 @@
+// ResourceFileRow — E9-05 — Ligne de fichier téléchargeable/ouvrable
+//
+// Une ressource peut embarquer plusieurs fichiers (PDF, images). On les
+// ouvre via le navigateur in-app (WebBrowser) — suffisant pour lire un PDF
+// ou voir une image. Le téléchargement "dur" (save to disk) sera un +
+// ultérieur si besoin.
+
+import { FileText, ImageIcon, ExternalLink } from 'lucide-react-native';
+import { Pressable, StyleSheet } from 'react-native';
+import { Text, View, XStack } from 'tamagui';
+
+function fileName(url: string): string {
+  try {
+    const path = decodeURIComponent(url.split('?')[0] ?? url);
+    const last = path.split('/').pop() ?? 'fichier';
+    // Les uploads sont nommés <uuid>.<ext> → on affiche juste l'extension en
+    // majuscule + un index lisible côté écran (le nom uuid n'apporte rien).
+    return last;
+  } catch {
+    return 'fichier';
+  }
+}
+
+function isImage(url: string): boolean {
+  return /\.(jpe?g|png|webp|gif)$/i.test(url.split('?')[0] ?? '');
+}
+
+function extLabel(url: string): string {
+  const m = (url.split('?')[0] ?? '').match(/\.([a-z0-9]+)$/i);
+  return m ? m[1]!.toUpperCase() : 'FICHIER';
+}
+
+export interface ResourceFileRowProps {
+  url: string;
+  index: number;
+  onOpen: (url: string) => void;
+}
+
+export function ResourceFileRow({ url, index, onOpen }: ResourceFileRowProps) {
+  const image = isImage(url);
+  const Icon = image ? ImageIcon : FileText;
+  const label = `${image ? 'Image' : 'Document'} ${index + 1}`;
+
+  return (
+    <Pressable
+      onPress={() => onOpen(url)}
+      accessibilityRole="button"
+      accessibilityLabel={`Ouvrir ${label} (${extLabel(url)})`}
+      style={styles.row}
+    >
+      <XStack
+        alignItems="center"
+        gap={12}
+        backgroundColor="$surface"
+        borderRadius={10}
+        padding={12}
+      >
+        <View
+          width={40}
+          height={40}
+          borderRadius={8}
+          backgroundColor="$surfaceElevated"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <Icon size={20} color="#10D970" strokeWidth={2} />
+        </View>
+        <View flex={1} minWidth={0}>
+          <Text fontSize={14} fontWeight="600" color="$color" numberOfLines={1}>
+            {label}
+          </Text>
+          <Text fontSize={11} color="$textSecondary" numberOfLines={1}>
+            {extLabel(url)} · {fileName(url)}
+          </Text>
+        </View>
+        <ExternalLink size={16} color="#A0A0A0" />
+      </XStack>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    width: '100%',
+  },
+});

--- a/src/features/cours/hooks/useResourceDetail.ts
+++ b/src/features/cours/hooks/useResourceDetail.ts
@@ -1,0 +1,87 @@
+// useResourceDetail — E9-05 (Fiche ressource)
+//
+// La RPC get_resource_detail incrémente le view_count à chaque appel côté DB.
+// Comme pour la marketplace, on limite les refetch (staleTime 60s + pas de
+// refetch au focus/mount) pour ne pas spammer le compteur.
+
+import { useQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+import type { ResourceType } from './useResources';
+
+export interface ResourceDetail {
+  id: string;
+  author_id: string;
+  author_username: string;
+  author_full_name: string | null;
+  author_avatar_url: string | null;
+  author_is_verified: boolean;
+  level_code: string;
+  subject_code: string;
+  type: ResourceType;
+  title: string;
+  description: string | null;
+  files: string[];
+  status: string;
+  view_count: number;
+  created_at: string;
+  bookmarked_by_me: boolean;
+}
+
+type RpcRow = Record<string, unknown>;
+
+function isType(value: unknown): value is ResourceType {
+  return (
+    value === 'cours' || value === 'fiche_revision' || value === 'exercices' || value === 'annale'
+  );
+}
+
+function mapDetail(row: RpcRow): ResourceDetail {
+  return {
+    id: String(row.id ?? ''),
+    author_id: String(row.author_id ?? ''),
+    author_username: String(row.author_username ?? ''),
+    author_full_name: (row.author_full_name as string | null) ?? null,
+    author_avatar_url: (row.author_avatar_url as string | null) ?? null,
+    author_is_verified: Boolean(row.author_is_verified ?? false),
+    level_code: String(row.level_code ?? ''),
+    subject_code: String(row.subject_code ?? ''),
+    type: isType(row.type) ? row.type : 'cours',
+    title: String(row.title ?? ''),
+    description: (row.description as string | null) ?? null,
+    files: Array.isArray(row.files) ? (row.files as string[]) : [],
+    status: String(row.status ?? 'active'),
+    view_count: typeof row.view_count === 'number' ? row.view_count : 0,
+    created_at: String(row.created_at ?? ''),
+    bookmarked_by_me: Boolean(row.bookmarked_by_me ?? false),
+  };
+}
+
+export function resourceDetailQueryKey(resourceId: string) {
+  return ['cours', 'detail', resourceId] as const;
+}
+
+export function useResourceDetail(resourceId: string | null) {
+  return useQuery({
+    queryKey: resourceId ? resourceDetailQueryKey(resourceId) : ['cours', 'detail', 'none'],
+    enabled: Boolean(resourceId),
+    queryFn: async (): Promise<ResourceDetail | null> => {
+      if (!resourceId) return null;
+      const { data, error } = await supabase.rpc('get_resource_detail', {
+        p_resource_id: resourceId,
+      });
+      if (error) {
+        logger.warn('get_resource_detail failed', { message: error.message, resourceId });
+        throw error;
+      }
+      const rows = (data ?? []) as RpcRow[];
+      const first = rows[0];
+      return first ? mapDetail(first) : null;
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    refetchOnMount: false,
+  });
+}

--- a/src/features/cours/hooks/useResources.ts
+++ b/src/features/cours/hooks/useResources.ts
@@ -53,6 +53,10 @@ type ResourcesQueryData = {
   pageParams: unknown[];
 };
 
+// Type minimal pour flipper le cache de la fiche détail sans importer
+// ResourceDetail (éviterait un import circulaire avec useResourceDetail).
+type BookmarkableDetail = { id: string; bookmarked_by_me: boolean };
+
 export function resourcesQueryKey(filters: ResourcesFilters) {
   return [
     'cours',
@@ -163,6 +167,12 @@ export function useToggleResourceBookmark() {
           };
         }
       );
+      // Flip aussi le cache de la fiche détail (feedback immédiat sur E9-05).
+      queryClient.setQueriesData<BookmarkableDetail | undefined>(
+        { queryKey: ['cours', 'detail'] },
+        (old) =>
+          old && old.id === resourceId ? { ...old, bookmarked_by_me: !old.bookmarked_by_me } : old
+      );
     },
     onError: (_err, vars) => {
       queryClient.setQueriesData<ResourcesQueryData>(
@@ -179,6 +189,14 @@ export function useToggleResourceBookmark() {
             })),
           };
         }
+      );
+      // Rollback du cache détail aussi.
+      queryClient.setQueriesData<BookmarkableDetail | undefined>(
+        { queryKey: ['cours', 'detail'] },
+        (old) =>
+          old && old.id === vars.resourceId
+            ? { ...old, bookmarked_by_me: !old.bookmarked_by_me }
+            : old
       );
     },
     onSettled: () => {


### PR DESCRIPTION
## Summary

E9-05 (#265) — Fiche détail d'une ressource : consultation + ouverture des fichiers + contacter l'auteur.

> ⚠️ **Branche empilée sur #280 (E9-04)** — merger #280 d'abord. Tant que #280 n'est pas mergée, le diff affiche aussi les fichiers de E9-04 ; il se nettoiera automatiquement après.

## Contenu

### `useResourceDetail`
- `useQuery` sur `get_resource_detail`, staleTime 60s + refetchOnFocus/Mount off (anti-spam view_count, comme la marketplace)

### `useToggleResourceBookmark` (étendu)
- Flippe aussi le cache `['cours','detail']` → feedback immédiat du bookmark sur la fiche (+ rollback onError)

### `ResourceFileRow`
- Une ligne par fichier (PDF/image) → ouverture via `WebBrowser.openBrowserAsync`
- Icône selon type + extension

### Écran `app/cours/[id].tsx`
- Badge type + matière·niveau + titre + vues + date relative FR
- Description + liste de fichiers ouvrables in-app
- Carte auteur → `/profile/[author_id]`
- CTA sticky **Contacter l'auteur** (DM pré-rempli via `useGetOrCreateDm`)
- Garde-fou "C'est votre ressource" sur sa propre ressource
- États loading / introuvable / détail

## Test plan (après #278/#280 mergées + migration E9-02 appliquée)
- [ ] Tap une ressource depuis la grille → fiche s'ouvre, view_count +1
- [ ] Ouvrir un fichier PDF → s'ouvre dans le navigateur in-app
- [ ] Bookmark toggle → immédiat sur la fiche ET la grille
- [ ] Contacter l'auteur → conversation avec message pré-rempli (pas auto-envoyé)
- [ ] Sur ma propre ressource → "C'est votre ressource"

## Suite
E9-06 (création ressource + upload).