### PR TITLE
feat(cours): création ressource + upload PDF/images — #266 (E9-06)

### DIFF
--- a/app/cours/create.tsx
+++ b/app/cours/create.tsx
@@ -1,0 +1,471 @@
+// Écran Création de ressource — E9-06 (#266)
+//
+// Publier un cours / fiche / exo / annale : type + niveau + matière + titre +
+// description + fichiers (PDF/images). RHF + Zod. Pipeline submit identique à
+// la marketplace : valider → upload séquentiel → create_resource → replace
+// vers la fiche fraîche.
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { router, Stack } from 'expo-router';
+import { ArrowLeft } from 'lucide-react-native';
+import { useCallback, useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Input, Text, TextArea, View, XStack, YStack } from 'tamagui';
+import { z } from 'zod';
+
+import {
+  ResourceFilePicker,
+  type PickedFile,
+} from '@/features/cours/components/ResourceFilePicker';
+import { useCourseLevels, useCourseSubjects } from '@/features/cours/hooks/useCourseTaxonomy';
+import { useCreateResource } from '@/features/cours/hooks/useCreateResource';
+import { RESOURCE_TYPE_LABEL, type ResourceType } from '@/features/cours/hooks/useResources';
+import { SegmentedChoice } from '@/features/marketplace/components/SegmentedChoice';
+import { logger } from '@/lib/logger';
+import { uploadResourceFile } from '@/lib/storage';
+
+const MAX_TITLE = 120;
+const MAX_DESCRIPTION = 2000;
+const MAX_FILES = 5;
+
+const TypeEnum = z.enum(['cours', 'fiche_revision', 'exercices', 'annale']);
+
+const ResourceSchema = z.object({
+  type: TypeEnum,
+  levelCode: z.string().min(1, 'Choisis un niveau.'),
+  subjectCode: z.string().min(1, 'Choisis une matière.'),
+  title: z
+    .string()
+    .trim()
+    .min(3, 'Le titre doit faire au moins 3 caractères.')
+    .max(MAX_TITLE, `Maximum ${MAX_TITLE} caractères.`),
+  description: z
+    .string()
+    .trim()
+    .max(MAX_DESCRIPTION, `Maximum ${MAX_DESCRIPTION} caractères.`)
+    .optional(),
+});
+
+type FormValues = z.infer<typeof ResourceSchema>;
+
+const TYPE_OPTIONS = (Object.keys(RESOURCE_TYPE_LABEL) as ResourceType[]).map((t) => ({
+  value: t,
+  label: RESOURCE_TYPE_LABEL[t],
+}));
+
+export default function CreateResourceScreen() {
+  const insets = useSafeAreaInsets();
+  const createResource = useCreateResource();
+  const levelsQuery = useCourseLevels();
+  const subjectsQuery = useCourseSubjects();
+
+  const [files, setFiles] = useState<PickedFile[]>([]);
+  const [filesError, setFilesError] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState<{ done: number; total: number } | null>(
+    null
+  );
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(ResourceSchema),
+    defaultValues: {
+      type: 'cours',
+      levelCode: '',
+      subjectCode: '',
+      title: '',
+      description: '',
+    },
+    mode: 'onSubmit',
+  });
+
+  const levelOptions = useMemo(
+    () => (levelsQuery.data ?? []).map((l) => ({ value: l.code, label: l.label })),
+    [levelsQuery.data]
+  );
+  const subjectOptions = useMemo(
+    () => (subjectsQuery.data ?? []).map((s) => ({ value: s.code, label: s.label })),
+    [subjectsQuery.data]
+  );
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/cours');
+  }, []);
+
+  const handleClose = useCallback(() => {
+    Alert.alert('Abandonner cette ressource ?', 'Tu perdras ce que tu as saisi.', [
+      { text: 'Continuer la saisie', style: 'cancel' },
+      { text: 'Abandonner', style: 'destructive', onPress: handleBack },
+    ]);
+  }, [handleBack]);
+
+  const onSubmit = useCallback(
+    async (values: FormValues) => {
+      if (files.length === 0) {
+        setFilesError('Ajoute au moins 1 fichier (PDF ou image).');
+        return;
+      }
+      setFilesError(null);
+
+      try {
+        setUploadProgress({ done: 0, total: files.length });
+        const publicUrls: string[] = [];
+        for (let i = 0; i < files.length; i++) {
+          const f = files[i];
+          if (!f) continue;
+          const result = await uploadResourceFile(f.uri, {
+            mimeType: f.mimeType,
+            name: f.name,
+          });
+          publicUrls.push(result.publicUrl);
+          setUploadProgress({ done: i + 1, total: files.length });
+        }
+        setUploadProgress(null);
+
+        const newId = await createResource.mutateAsync({
+          type: values.type,
+          levelCode: values.levelCode,
+          subjectCode: values.subjectCode,
+          title: values.title.trim(),
+          description: values.description?.trim() || null,
+          files: publicUrls,
+        });
+
+        router.replace(`/cours/${newId}`);
+      } catch (err) {
+        setUploadProgress(null);
+        const message = err instanceof Error ? err.message : 'Une erreur est survenue, réessaie.';
+        logger.warn('create_resource submit failed', { message });
+        Alert.alert('Publication impossible', message);
+      }
+    },
+    [createResource, files]
+  );
+
+  const isBusy = isSubmitting || createResource.isPending || uploadProgress !== null;
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={styles.flex}
+      >
+        <View flex={1} backgroundColor="$background" paddingTop={insets.top}>
+          {/* Header */}
+          <XStack
+            height={56}
+            paddingHorizontal={12}
+            alignItems="center"
+            gap={12}
+            borderBottomWidth={StyleSheet.hairlineWidth}
+            borderBottomColor="$borderColor"
+          >
+            <Pressable
+              onPress={handleClose}
+              disabled={isBusy}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              accessibilityRole="button"
+              accessibilityLabel="Annuler"
+            >
+              <ArrowLeft size={24} color="#FFFFFF" />
+            </Pressable>
+            <Text flex={1} color="$color" fontSize={18} fontWeight="700">
+              Nouvelle ressource
+            </Text>
+          </XStack>
+
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            {/* Type */}
+            <Section title="Type" required>
+              <Controller
+                control={control}
+                name="type"
+                render={({ field: { value, onChange } }) => (
+                  <SegmentedChoice
+                    options={TYPE_OPTIONS}
+                    value={value}
+                    onChange={onChange}
+                    disabled={isBusy}
+                  />
+                )}
+              />
+            </Section>
+
+            {/* Niveau */}
+            <Section title="Niveau" required>
+              <Controller
+                control={control}
+                name="levelCode"
+                render={({ field: { value, onChange } }) => (
+                  <ChipRow
+                    options={levelOptions}
+                    value={value}
+                    onChange={onChange}
+                    disabled={isBusy}
+                  />
+                )}
+              />
+              {errors.levelCode ? <ErrorText>{errors.levelCode.message}</ErrorText> : null}
+            </Section>
+
+            {/* Matière */}
+            <Section title="Matière" required>
+              <Controller
+                control={control}
+                name="subjectCode"
+                render={({ field: { value, onChange } }) => (
+                  <ChipRow
+                    options={subjectOptions}
+                    value={value}
+                    onChange={onChange}
+                    disabled={isBusy}
+                  />
+                )}
+              />
+              {errors.subjectCode ? <ErrorText>{errors.subjectCode.message}</ErrorText> : null}
+            </Section>
+
+            {/* Titre */}
+            <Section title="Titre" required>
+              <Controller
+                control={control}
+                name="title"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <Input
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Ex : Cours complet sur les fonctions dérivées"
+                    placeholderTextColor="$placeholderColor"
+                    maxLength={MAX_TITLE}
+                    editable={!isBusy}
+                    color="$color"
+                    backgroundColor="$surface"
+                    borderWidth={0}
+                    borderRadius="$md"
+                    height={48}
+                    paddingHorizontal={14}
+                    accessibilityLabel="Titre de la ressource"
+                  />
+                )}
+              />
+              {errors.title ? <ErrorText>{errors.title.message}</ErrorText> : null}
+            </Section>
+
+            {/* Description */}
+            <Section title="Description" subtitle="Optionnel">
+              <Controller
+                control={control}
+                name="description"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextArea
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Résume le contenu, le chapitre couvert, ce que l'élève va apprendre…"
+                    placeholderTextColor="$placeholderColor"
+                    maxLength={MAX_DESCRIPTION}
+                    editable={!isBusy}
+                    color="$color"
+                    backgroundColor="$surface"
+                    borderWidth={0}
+                    borderRadius="$md"
+                    minHeight={110}
+                    paddingHorizontal={14}
+                    paddingTop={12}
+                    textAlignVertical="top"
+                    accessibilityLabel="Description de la ressource"
+                  />
+                )}
+              />
+            </Section>
+
+            {/* Fichiers */}
+            <Section title="Fichiers" required>
+              <ResourceFilePicker
+                files={files}
+                onChange={(next) => {
+                  setFiles(next);
+                  if (next.length > 0) setFilesError(null);
+                }}
+                maxFiles={MAX_FILES}
+                disabled={isBusy}
+              />
+              {filesError ? <ErrorText>{filesError}</ErrorText> : null}
+            </Section>
+
+            {uploadProgress ? (
+              <Text fontSize={12} color="$textSecondary" textAlign="center" marginTop={8}>
+                Upload des fichiers {uploadProgress.done}/{uploadProgress.total}…
+              </Text>
+            ) : null}
+          </ScrollView>
+
+          {/* CTA */}
+          <YStack
+            paddingHorizontal={16}
+            paddingTop={12}
+            paddingBottom={insets.bottom + 12}
+            backgroundColor="$background"
+            borderTopWidth={StyleSheet.hairlineWidth}
+            borderTopColor="$borderColor"
+          >
+            <Pressable
+              onPress={handleSubmit(onSubmit)}
+              disabled={isBusy}
+              accessibilityRole="button"
+              accessibilityLabel="Publier la ressource"
+              accessibilityState={{ disabled: isBusy }}
+              style={[styles.cta, { backgroundColor: isBusy ? '#1A1A1A' : '#10D970' }]}
+            >
+              {isBusy ? (
+                <ActivityIndicator color="#10D970" />
+              ) : (
+                <Text fontSize={15} fontWeight="800" color="#000000">
+                  Publier
+                </Text>
+              )}
+            </Pressable>
+          </YStack>
+        </View>
+      </KeyboardAvoidingView>
+    </>
+  );
+}
+
+// Rangée de chips scrollable pour un choix REQUIS (pas d'option "tout").
+function ChipRow({
+  options,
+  value,
+  onChange,
+  disabled,
+}: {
+  options: { value: string; label: string }[];
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <ScrollView
+      horizontal
+      showsHorizontalScrollIndicator={false}
+      keyboardShouldPersistTaps="handled"
+      contentContainerStyle={styles.chipRowContent}
+      style={styles.chipRow}
+    >
+      {options.map((opt) => {
+        const active = value === opt.value;
+        return (
+          <Pressable
+            key={opt.value}
+            onPress={() => !disabled && onChange(opt.value)}
+            accessibilityRole="radio"
+            accessibilityLabel={opt.label}
+            accessibilityState={{ selected: active, disabled }}
+            style={[styles.chip, active ? styles.chipActive : null]}
+          >
+            <Text
+              fontSize={13}
+              fontWeight={active ? '700' : '500'}
+              color={active ? '#000000' : '#FFFFFF'}
+            >
+              {opt.label}
+            </Text>
+          </Pressable>
+        );
+      })}
+    </ScrollView>
+  );
+}
+
+function Section({
+  title,
+  subtitle,
+  required,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <YStack gap={10} marginTop={20}>
+      <XStack alignItems="baseline" gap={6}>
+        <Text fontSize={14} fontWeight="700" color="$color">
+          {title}
+        </Text>
+        {required ? (
+          <Text fontSize={12} color="#10D970" fontWeight="700">
+            *
+          </Text>
+        ) : null}
+        {subtitle ? (
+          <Text fontSize={11} color="$textSecondary">
+            · {subtitle}
+          </Text>
+        ) : null}
+      </XStack>
+      {children}
+    </YStack>
+  );
+}
+
+function ErrorText({ children }: { children: string | undefined }) {
+  if (!children) return null;
+  return (
+    <Text fontSize={12} color="#FF6B6B" marginTop={4}>
+      {children}
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  chip: {
+    paddingHorizontal: 14,
+    paddingVertical: 9,
+    borderRadius: 9999,
+    backgroundColor: '#1A1A1A',
+    marginRight: 8,
+  },
+  chipActive: {
+    backgroundColor: '#FFFFFF',
+  },
+  chipRow: {
+    flexGrow: 0,
+  },
+  chipRowContent: {
+    paddingRight: 4,
+  },
+  cta: {
+    borderRadius: 9999,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  flex: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 24,
+  },
+});

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "expo-constants": "~55.0.15",
     "expo-dev-client": "~55.0.28",
     "expo-device": "~55.0.15",
+    "expo-document-picker": "~55.0.14",
     "expo-file-system": "~55.0.17",
     "expo-font": "~55.0.6",
     "expo-haptics": "~55.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       expo-device:
         specifier: ~55.0.15
         version: 55.0.15(expo@55.0.17)
+      expo-document-picker:
+        specifier: ~55.0.14
+        version: 55.0.14(expo@55.0.17)
       expo-file-system:
         specifier: ~55.0.17
         version: 55.0.17(expo@55.0.17)(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))
@@ -4276,6 +4279,11 @@ packages:
 
   expo-device@55.0.15:
     resolution: {integrity: sha512-vXy4U/IeYI+zHGG45Ap6J7EuyQmkstyo8I+/5YGr5q2zmqLBo6SWE62wii8i9hLHheHn6AtF9UPrSWAREJrE8A==}
+    peerDependencies:
+      expo: '*'
+
+  expo-document-picker@55.0.14:
+    resolution: {integrity: sha512-Jfw7q5evNc1ebM/gZQ0bmG1t56QdHurbZ6IF8NwSnf/F5B4qjS97OeCfdsq+Q5JLrTmqSIkvYhCZwRYZzuX0Fw==}
     peerDependencies:
       expo: '*'
 
@@ -13280,6 +13288,10 @@ snapshots:
     dependencies:
       expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
       ua-parser-js: 0.7.41
+
+  expo-document-picker@55.0.14(expo@55.0.17):
+    dependencies:
+      expo: 55.0.17(@babel/core@7.29.0)(@expo/dom-webview@55.0.5)(@expo/metro-runtime@55.0.10)(expo-router@55.0.13)(react-dom@19.2.5(react@19.2.0))(react-native-worklets@0.8.1(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0))(react-native@0.83.6(@babel/core@7.29.0)(@react-native/metro-config@0.85.2(@babel/core@7.29.0))(@types/react@19.2.14)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-eas-client@55.0.5: {}
 

--- a/src/features/cours/components/ResourceFilePicker.tsx
+++ b/src/features/cours/components/ResourceFilePicker.tsx
@@ -1,0 +1,132 @@
+// ResourceFilePicker — E9-06 (#266)
+//
+// Sélection des fichiers d'une ressource : PDF (via expo-document-picker) ou
+// images (via le même document-picker, qui gère aussi les images). Limite à
+// MAX_FILES. L'upload réel se fait au submit (cf app/cours/create.tsx).
+//
+// On garde le nom + le mimeType de chaque fichier (nécessaires à
+// uploadResourceFile pour choisir le pipeline PDF vs image).
+
+import * as DocumentPicker from 'expo-document-picker';
+import { FileText, ImageIcon, Plus, X } from 'lucide-react-native';
+import { useCallback } from 'react';
+import { Alert, Pressable, StyleSheet } from 'react-native';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+export interface PickedFile {
+  uri: string;
+  name: string | null;
+  mimeType: string | null;
+}
+
+export interface ResourceFilePickerProps {
+  files: PickedFile[];
+  onChange: (next: PickedFile[]) => void;
+  maxFiles?: number;
+  disabled?: boolean;
+}
+
+const DEFAULT_MAX = 5;
+
+export function ResourceFilePicker({
+  files,
+  onChange,
+  maxFiles = DEFAULT_MAX,
+  disabled = false,
+}: ResourceFilePickerProps) {
+  const canAdd = files.length < maxFiles && !disabled;
+
+  const handleAdd = useCallback(async () => {
+    if (!canAdd) return;
+    try {
+      const result = await DocumentPicker.getDocumentAsync({
+        type: ['application/pdf', 'image/*'],
+        multiple: true,
+        copyToCacheDirectory: true,
+      });
+      if (result.canceled) return;
+      const picked: PickedFile[] = result.assets
+        .slice(0, maxFiles - files.length)
+        .map((a) => ({ uri: a.uri, name: a.name ?? null, mimeType: a.mimeType ?? null }));
+      onChange([...files, ...picked]);
+    } catch {
+      Alert.alert('Sélection impossible', 'Impossible d’ouvrir le sélecteur de fichiers.');
+    }
+  }, [canAdd, files, maxFiles, onChange]);
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      onChange(files.filter((_, i) => i !== index));
+    },
+    [files, onChange]
+  );
+
+  return (
+    <YStack gap={8}>
+      {files.map((f, i) => {
+        const isImage =
+          (f.mimeType ?? '').startsWith('image/') || /\.(jpe?g|png|webp)$/i.test(f.name ?? '');
+        const Icon = isImage ? ImageIcon : FileText;
+        return (
+          <XStack
+            key={`${f.uri}-${i}`}
+            alignItems="center"
+            gap={12}
+            backgroundColor="$surface"
+            borderRadius={10}
+            padding={10}
+          >
+            <View
+              width={36}
+              height={36}
+              borderRadius={8}
+              backgroundColor="$surfaceElevated"
+              alignItems="center"
+              justifyContent="center"
+            >
+              <Icon size={18} color="#10D970" strokeWidth={2} />
+            </View>
+            <Text flex={1} fontSize={13} color="$color" numberOfLines={1}>
+              {f.name ?? `Fichier ${i + 1}`}
+            </Text>
+            <Pressable
+              onPress={() => handleRemove(i)}
+              disabled={disabled}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel={`Retirer ${f.name ?? `le fichier ${i + 1}`}`}
+            >
+              <X size={16} color="#A0A0A0" />
+            </Pressable>
+          </XStack>
+        );
+      })}
+
+      {canAdd ? (
+        <Pressable
+          onPress={() => void handleAdd()}
+          accessibilityRole="button"
+          accessibilityLabel={`Ajouter un fichier (${files.length}/${maxFiles})`}
+          style={styles.addRow}
+        >
+          <XStack alignItems="center" justifyContent="center" gap={8}>
+            <Plus size={18} color="#FFFFFF" strokeWidth={2} />
+            <Text fontSize={13} fontWeight="600" color="#FFFFFF">
+              Ajouter un PDF ou une image ({files.length}/{maxFiles})
+            </Text>
+          </XStack>
+        </Pressable>
+      ) : null}
+    </YStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  addRow: {
+    borderWidth: 1,
+    borderColor: '#333',
+    borderStyle: 'dashed',
+    borderRadius: 10,
+    paddingVertical: 14,
+  },
+});

--- a/src/features/cours/hooks/useCreateResource.ts
+++ b/src/features/cours/hooks/useCreateResource.ts
@@ -1,0 +1,45 @@
+// useCreateResource — E9-06 (#266)
+//
+// Wrappe la RPC create_resource (security definer, author_id forcé à
+// auth.uid() côté DB). Invalide les queries de la grille à success.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+import type { ResourceType } from './useResources';
+
+export interface CreateResourceInput {
+  type: ResourceType;
+  levelCode: string;
+  subjectCode: string;
+  title: string;
+  description?: string | null;
+  files?: string[];
+}
+
+export function useCreateResource() {
+  const queryClient = useQueryClient();
+
+  return useMutation<string, Error, CreateResourceInput>({
+    mutationFn: async (input): Promise<string> => {
+      const { data, error } = await supabase.rpc('create_resource', {
+        p_type: input.type,
+        p_level_code: input.levelCode,
+        p_subject_code: input.subjectCode,
+        p_title: input.title,
+        p_description: input.description ?? null,
+        p_files: input.files ?? [],
+      });
+      if (error) {
+        logger.warn('create_resource failed', { message: error.message, type: input.type });
+        throw error;
+      }
+      return String(data);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['cours'] });
+    },
+  });
+}

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -555,3 +555,72 @@ export async function uploadStoryMedia(
     throw uploadError;
   }
 }
+
+// ---------------------------------------------------------------------------
+// Cours upload (#266 — E9-06 — publication d'une ressource)
+// ---------------------------------------------------------------------------
+
+const RESOURCES_BUCKET = 'resources';
+
+export interface UploadResourceFileResult {
+  publicUrl: string;
+  path: string;
+}
+
+/**
+ * Upload un fichier de ressource (PDF ou image) dans le bucket `resources`.
+ *
+ * - Images (image/*) : compressées via le même pipeline que les posts
+ *   (quality 0.8, resize 1920px) puis uploadées en JPEG.
+ * - PDF (application/pdf) : uploadés tels quels, pas de compression.
+ *
+ * Path : `{user_id}/{uuid}.{ext}` (le 1er segment DOIT être l'auth.uid()
+ * pour satisfaire les policies du bucket).
+ */
+export async function uploadResourceFile(
+  uri: string,
+  file: { mimeType?: string | null; name?: string | null },
+  options?: { signal?: AbortSignal; onProgress?: (p: number) => void }
+): Promise<UploadResourceFileResult> {
+  const signal = options?.signal;
+  const onProgress = options?.onProgress;
+
+  const mime = (file.mimeType ?? '').toLowerCase();
+  const nameExt = (file.name ?? '').split('.').pop()?.toLowerCase() ?? '';
+  const isImage = mime.startsWith('image/') || ['jpg', 'jpeg', 'png', 'webp'].includes(nameExt);
+  const isPdf = mime === 'application/pdf' || nameExt === 'pdf';
+
+  try {
+    if (signal?.aborted) throw abortedError();
+    const session = await getFreshSession();
+
+    if (isImage) {
+      const compressedUri = await compressImage(uri, DEFAULT_QUALITY);
+      const path = `${session.user.id}/${uuidv4()}.jpg`;
+      try {
+        await uploadToStorage(compressedUri, path, RESOURCES_BUCKET, 'image/jpeg', {
+          onProgress,
+          signal,
+        });
+      } finally {
+        await cleanupTempFiles([compressedUri]);
+      }
+      const { data } = supabase.storage.from(RESOURCES_BUCKET).getPublicUrl(path);
+      return { publicUrl: data.publicUrl, path };
+    }
+
+    // PDF (ou tout ce qui n'est pas une image reconnue mais autorisé par le
+    // bucket) : upload direct sans compression.
+    const ext = isPdf ? 'pdf' : nameExt || 'pdf';
+    const contentType = isPdf ? 'application/pdf' : (file.mimeType ?? 'application/octet-stream');
+    const path = `${session.user.id}/${uuidv4()}.${ext}`;
+    await uploadToStorage(uri, path, RESOURCES_BUCKET, contentType, { onProgress, signal });
+    const { data } = supabase.storage.from(RESOURCES_BUCKET).getPublicUrl(path);
+    return { publicUrl: data.publicUrl, path };
+  } catch (error) {
+    const uploadError = error instanceof UploadError ? error : new UploadError('upload', error);
+    if (signal?.aborted) logger.debug('upload_resource_file_cancelled');
+    else logger.error('upload_resource_file_failed', uploadError);
+    throw uploadError;
+  }
+}


### PR DESCRIPTION
## Summary

E9-06 (#266) — Publier une ressource (cours/fiche/exo/annale) : formulaire + upload de fichiers PDF/images.

> ⚠️ **Branche empilée sur #280 (E9-04)** — merger #280 d'abord.
> ⚠️ **Nouvelle dépendance native** `expo-document-picker` → **rebuild EAS requis** avant que l'écran marche sur device.

## Décision de stack

Ajout de **`expo-document-picker@~55.0.14`** (module Expo officiel, validé CTO). Nécessaire au cœur de la feature : un cours est souvent un PDF, et `expo-image-picker` ne gère que les images. Coût : 1 rebuild EAS.

## Contenu

### `src/lib/storage.ts` — `uploadResourceFile`
- Bucket `resources`. Images → compressées + JPEG (pipeline posts). PDF → upload direct sans compression. Path `<user_id>/<uuid>.<ext>`.

### `useCreateResource`
- Mutation sur `create_resource` (author_id forcé auth.uid()), invalide `['cours']`.

### `ResourceFilePicker`
- `expo-document-picker` (pdf + image/*, multiple), garde name+mimeType (nécessaires au choix du pipeline d'upload), max 5, suppression individuelle.

### Écran `app/cours/create.tsx`
- RHF + Zod : type (SegmentedChoice) + niveau + matière (ChipRow scrollable requis) + titre (3-120) + description (optionnelle) + fichiers (≥1)
- Pipeline : valider → upload séquentiel (progress X/Y) → create_resource → `router.replace` vers la fiche
- Confirmation avant abandon, isBusy bloque pendant upload

## Test plan (après rebuild EAS + #278/#280 mergées + migration E9-02)
- [ ] `/cours` → bouton + → écran création
- [ ] Submit sans fichier → erreur "Ajoute au moins 1 fichier"
- [ ] Sélectionner un PDF via le picker → apparaît dans la liste
- [ ] Sélectionner une image → apparaît aussi
- [ ] Choisir type/niveau/matière + titre → Publier → upload → atterrit sur la fiche
- [ ] Ouvrir le PDF depuis la fiche → s'ouvre
- [ ] La ressource apparaît en tête de la grille

## Suite
E9-07 (favoris ressources) + E9-08 (signalement/modération) → fin du L0.