### PR TITLE
feat(cours): favoris ressources — #267 (E9-07)

### DIFF
--- a/app/cours/bookmarks.tsx
+++ b/app/cours/bookmarks.tsx
@@ -1,0 +1,215 @@
+// Écran Favoris Cours — E9-07 (#267)
+//
+// Liste des ressources sauvegardées. Réutilise ResourceCard (même UX que la
+// bibliothèque). Pull to refresh + infinite scroll + empty state.
+
+import { FlashList, type FlashListRef } from '@shopify/flash-list';
+import { router, Stack } from 'expo-router';
+import { ArrowLeft, BookmarkX } from 'lucide-react-native';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { ActivityIndicator, Pressable, RefreshControl, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+import { ResourceCard } from '@/features/cours/components/ResourceCard';
+import { useBookmarkedResources } from '@/features/cours/hooks/useBookmarkedResources';
+import { useCourseLevels, useCourseSubjects } from '@/features/cours/hooks/useCourseTaxonomy';
+import {
+  useToggleResourceBookmark,
+  type ResourceListItem,
+} from '@/features/cours/hooks/useResources';
+
+export default function CoursBookmarksScreen() {
+  const insets = useSafeAreaInsets();
+  const listRef = useRef<FlashListRef<ResourceListItem>>(null);
+  const [isManualRefreshing, setIsManualRefreshing] = useState(false);
+
+  const bookmarksQuery = useBookmarkedResources();
+  const toggleBookmark = useToggleResourceBookmark();
+  const levelsQuery = useCourseLevels();
+  const subjectsQuery = useCourseSubjects();
+
+  const levelLabelByCode = useMemo(() => {
+    const m = new Map<string, string>();
+    (levelsQuery.data ?? []).forEach((l) => m.set(l.code, l.label));
+    return m;
+  }, [levelsQuery.data]);
+  const subjectLabelByCode = useMemo(() => {
+    const m = new Map<string, string>();
+    (subjectsQuery.data ?? []).forEach((s) => m.set(s.code, s.label));
+    return m;
+  }, [subjectsQuery.data]);
+
+  const allResources = useMemo<ResourceListItem[]>(
+    () => bookmarksQuery.data?.pages.flatMap((p) => p.resources) ?? [],
+    [bookmarksQuery.data]
+  );
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/cours');
+  }, []);
+
+  const handleCardPress = useCallback((id: string) => {
+    router.push(`/cours/${id}`);
+  }, []);
+
+  const handleToggleBookmark = useCallback(
+    (id: string) => {
+      // Refetch onSettled pour que l'item disparaisse immédiatement de la
+      // liste des favoris après un unbookmark (sinon flicker 1-2s).
+      toggleBookmark.mutate({ resourceId: id }, { onSettled: () => void bookmarksQuery.refetch() });
+    },
+    [bookmarksQuery, toggleBookmark]
+  );
+
+  const handleLoadMore = useCallback(() => {
+    if (bookmarksQuery.hasNextPage && !bookmarksQuery.isFetchingNextPage) {
+      void bookmarksQuery.fetchNextPage();
+    }
+  }, [bookmarksQuery]);
+
+  const handlePullToRefresh = useCallback(async () => {
+    setIsManualRefreshing(true);
+    await bookmarksQuery.refetch();
+    setIsManualRefreshing(false);
+  }, [bookmarksQuery]);
+
+  const renderItem = useCallback(
+    ({ item }: { item: ResourceListItem }) => (
+      <View paddingHorizontal={12} paddingBottom={10}>
+        <ResourceCard
+          resource={item}
+          levelLabel={levelLabelByCode.get(item.level_code) ?? item.level_code}
+          subjectLabel={subjectLabelByCode.get(item.subject_code) ?? item.subject_code}
+          onPress={() => handleCardPress(item.id)}
+          onToggleBookmark={() => handleToggleBookmark(item.id)}
+          isBookmarkPending={toggleBookmark.isPending}
+        />
+      </View>
+    ),
+    [
+      levelLabelByCode,
+      subjectLabelByCode,
+      handleCardPress,
+      handleToggleBookmark,
+      toggleBookmark.isPending,
+    ]
+  );
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+        <XStack
+          height={56}
+          paddingHorizontal={12}
+          alignItems="center"
+          gap={12}
+          borderBottomWidth={StyleSheet.hairlineWidth}
+          borderBottomColor="$borderColor"
+        >
+          <Pressable
+            onPress={handleBack}
+            hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+            accessibilityRole="button"
+            accessibilityLabel="Retour"
+          >
+            <ArrowLeft size={24} color="#FFFFFF" />
+          </Pressable>
+          <Text flex={1} color="$color" fontSize={18} fontWeight="700">
+            Mes ressources
+          </Text>
+        </XStack>
+
+        <View flex={1}>
+          {bookmarksQuery.isLoading ? (
+            <YStack flex={1} alignItems="center" justifyContent="center">
+              <ActivityIndicator color="#FFFFFF" />
+            </YStack>
+          ) : bookmarksQuery.isError ? (
+            <YStack
+              flex={1}
+              alignItems="center"
+              justifyContent="center"
+              paddingHorizontal={24}
+              gap={8}
+            >
+              <Text fontSize={16} fontWeight="700" color="$color">
+                Impossible de charger tes ressources
+              </Text>
+              <Text fontSize={13} color="$textSecondary" textAlign="center">
+                Tire vers le bas pour réessayer.
+              </Text>
+            </YStack>
+          ) : allResources.length === 0 ? (
+            <YStack
+              flex={1}
+              alignItems="center"
+              justifyContent="center"
+              paddingHorizontal={24}
+              gap={12}
+            >
+              <BookmarkX size={48} color="#666" strokeWidth={1.5} />
+              <Text fontSize={16} fontWeight="700" color="$color" textAlign="center">
+                Aucune ressource sauvegardée
+              </Text>
+              <Text fontSize={13} color="$textSecondary" textAlign="center">
+                Touche l&apos;icône signet sur une ressource pour la retrouver ici.
+              </Text>
+              <Pressable
+                onPress={() => router.replace('/cours')}
+                accessibilityRole="button"
+                accessibilityLabel="Explorer les ressources"
+                style={styles.cta}
+              >
+                <Text fontSize={14} fontWeight="800" color="#000000">
+                  Explorer les ressources
+                </Text>
+              </Pressable>
+            </YStack>
+          ) : (
+            <FlashList
+              ref={listRef}
+              data={allResources}
+              renderItem={renderItem}
+              keyExtractor={(item) => item.id}
+              onEndReached={handleLoadMore}
+              onEndReachedThreshold={0.4}
+              contentContainerStyle={styles.listContent}
+              refreshControl={
+                <RefreshControl
+                  refreshing={isManualRefreshing}
+                  onRefresh={() => void handlePullToRefresh()}
+                  tintColor="#10D970"
+                  colors={['#10D970']}
+                />
+              }
+              ListFooterComponent={
+                bookmarksQuery.isFetchingNextPage ? (
+                  <YStack paddingVertical={16} alignItems="center">
+                    <ActivityIndicator color="#FFFFFF" />
+                  </YStack>
+                ) : null
+              }
+            />
+          )}
+        </View>
+      </YStack>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  cta: {
+    marginTop: 8,
+    backgroundColor: '#10D970',
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 9999,
+  },
+  listContent: {
+    paddingTop: 6,
+    paddingBottom: 24,
+  },
+});

--- a/src/features/cours/hooks/useBookmarkedResources.ts
+++ b/src/features/cours/hooks/useBookmarkedResources.ts
@@ -1,0 +1,71 @@
+// useBookmarkedResources — E9-07 (#267)
+//
+// useInfiniteQuery sur get_my_bookmarked_resources. queryKey
+// ['cours','bookmarks'] = celle invalidée par useToggleResourceBookmark →
+// un unbookmark depuis n'importe quel écran rafraîchit celui-ci.
+// Cursor sur bookmarked_at (aligné au ORDER BY rb.created_at desc de la RPC).
+
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+import type { ResourceListItem, ResourceType } from './useResources';
+
+const PAGE_SIZE = 20;
+
+type RpcRow = Record<string, unknown>;
+
+function isType(value: unknown): value is ResourceType {
+  return (
+    value === 'cours' || value === 'fiche_revision' || value === 'exercices' || value === 'annale'
+  );
+}
+
+function mapRow(row: RpcRow): ResourceListItem {
+  return {
+    id: String(row.id ?? ''),
+    author_id: String(row.author_id ?? ''),
+    author_username: String(row.author_username ?? ''),
+    author_avatar_url: (row.author_avatar_url as string | null) ?? null,
+    author_is_verified: Boolean(row.author_is_verified ?? false),
+    level_code: String(row.level_code ?? ''),
+    subject_code: String(row.subject_code ?? ''),
+    type: isType(row.type) ? row.type : 'cours',
+    title: String(row.title ?? ''),
+    description: (row.description as string | null) ?? null,
+    files: Array.isArray(row.files) ? (row.files as string[]) : [],
+    view_count: typeof row.view_count === 'number' ? row.view_count : 0,
+    created_at: String(row.created_at ?? ''),
+    bookmarked_by_me: true,
+  };
+}
+
+async function fetchBookmarksPage(cursor: string | null) {
+  const { data, error } = await supabase.rpc('get_my_bookmarked_resources', {
+    p_cursor: cursor,
+    p_limit: PAGE_SIZE,
+  });
+  if (error) {
+    logger.warn('get_my_bookmarked_resources failed', { message: error.message });
+    throw error;
+  }
+  const rows = (data ?? []) as RpcRow[];
+  const resources = rows.map(mapRow);
+  const lastBookmarkedAt = rows[rows.length - 1]?.bookmarked_at;
+  const nextCursor =
+    resources.length === PAGE_SIZE && typeof lastBookmarkedAt === 'string'
+      ? lastBookmarkedAt
+      : null;
+  return { resources, nextCursor };
+}
+
+export function useBookmarkedResources() {
+  return useInfiniteQuery({
+    queryKey: ['cours', 'bookmarks'],
+    queryFn: ({ pageParam }) => fetchBookmarksPage(pageParam),
+    initialPageParam: null as string | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+    staleTime: 30_000,
+  });
+}

--- a/supabase/migrations/20260702150000_get_my_bookmarked_resources.sql
+++ b/supabase/migrations/20260702150000_get_my_bookmarked_resources.sql
@@ -1,0 +1,71 @@
+-- E9-07 (#267) — RPC liste des ressources favorites de l'user courant
+--
+-- Même patron que get_my_bookmarked_listings (marketplace) : tri par date de
+-- bookmark (plus récent d'abord), cursor sur resource_bookmarks.created_at
+-- exposé en `bookmarked_at` pour une pagination cohérente côté client.
+--
+-- Authentification requise (revoke anon/public). Filtre dur
+-- rb.user_id = auth.uid() → impossible de voir les favoris d'un autre.
+--
+-- On ne renvoie que les ressources encore 'active' (une ressource masquée par
+-- la modération disparaît des favoris).
+--
+-- Idempotent (create or replace).
+
+create or replace function public.get_my_bookmarked_resources(
+  p_cursor timestamptz default null,
+  p_limit  int default 20
+)
+returns table (
+  id                 uuid,
+  author_id          uuid,
+  author_username    text,
+  author_avatar_url  text,
+  author_is_verified boolean,
+  level_code         text,
+  subject_code       text,
+  type               text,
+  title              text,
+  description        text,
+  files              text[],
+  view_count         int,
+  created_at         timestamptz,
+  bookmarked_at      timestamptz,
+  bookmarked_by_me   boolean
+)
+language sql
+security definer
+set search_path = public
+stable
+as $$
+  select
+    r.id,
+    r.author_id,
+    p.username      as author_username,
+    p.avatar_url    as author_avatar_url,
+    coalesce(p.is_verified, false) as author_is_verified,
+    r.level_code,
+    r.subject_code,
+    r.type,
+    r.title,
+    r.description,
+    r.files,
+    r.view_count,
+    r.created_at,
+    rb.created_at   as bookmarked_at,
+    true            as bookmarked_by_me
+  from public.resource_bookmarks rb
+  join public.resources r on r.id = rb.resource_id
+  join public.profiles p on p.id = r.author_id
+  where rb.user_id = auth.uid()
+    and r.status = 'active'
+    and (p_cursor is null or rb.created_at < p_cursor)
+  order by rb.created_at desc
+  limit p_limit;
+$$;
+
+grant execute on function public.get_my_bookmarked_resources(timestamptz, int) to authenticated;
+revoke execute on function public.get_my_bookmarked_resources(timestamptz, int) from anon, public;
+
+comment on function public.get_my_bookmarked_resources(timestamptz, int) is
+  'E9-07 (#267) — Ressources actives en favori de l''user courant, triées par date de bookmark desc.';


### PR DESCRIPTION
## Summary
E9-07 (#267) — Écran des ressources sauvegardées. Basé sur dev à jour (plus d'empilement).

⚠️ 1 migration à appliquer : `20260702150000_get_my_bookmarked_resources.sql`.

## Contenu
- **RPC `get_my_bookmarked_resources`** : ressources actives en favori, tri par date de bookmark desc, `bookmarked_at` exposé pour pagination cohérente. security definer + filtre `rb.user_id = auth.uid()`, revoke anon.
- **`useBookmarkedResources`** : useInfiniteQuery, queryKey `['cours','bookmarks']` (déjà invalidée par le toggle).
- **`app/cours/bookmarks.tsx`** : réutilise ResourceCard, pull to refresh + infinite scroll, empty state, refetch onSettled sur unbookmark (pas de flicker).

## Test plan (après migration appliquée)
- [ ] Header Apprendre → icône bookmark → `/cours/bookmarks`
- [ ] 0 favori → empty state + CTA
- [ ] Bookmark une ressource → apparaît ici en tête
- [ ] Unbookmark depuis cet écran → disparaît immédiatement