### PR TITLE
feat(cours): signalement + modération auto — #268 (E9-08)

### DIFF
--- a/app/cours/[id].tsx
+++ b/app/cours/[id].tsx
@@ -8,14 +8,16 @@
 
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
-import { ArrowLeft, Bookmark, ChevronRight, Eye } from 'lucide-react-native';
+import { ArrowLeft, Bookmark, ChevronRight, Eye, Flag } from 'lucide-react-native';
 import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Button, Image, Text, View, XStack, YStack } from 'tamagui';
 
+import { ReportReasonSheet } from '@/features/cours/components/ReportReasonSheet';
 import { ResourceFileRow } from '@/features/cours/components/ResourceFileRow';
 import { useCourseLevels, useCourseSubjects } from '@/features/cours/hooks/useCourseTaxonomy';
+import { useReportResource, type ReportReason } from '@/features/cours/hooks/useReportResource';
 import { useResourceDetail } from '@/features/cours/hooks/useResourceDetail';
 import {
   RESOURCE_TYPE_LABEL,
@@ -46,8 +48,11 @@ export default function ResourceDetailScreen() {
   const { data: resource, isLoading, isError } = useResourceDetail(resourceId);
   const toggleBookmark = useToggleResourceBookmark();
   const getOrCreateDm = useGetOrCreateDm();
+  const reportResource = useReportResource();
   const levelsQuery = useCourseLevels();
   const subjectsQuery = useCourseSubjects();
+
+  const [isReportOpen, setIsReportOpen] = useState(false);
 
   const [meId, setMeId] = useState<string | null>(null);
   useEffect(() => {
@@ -89,6 +94,25 @@ export default function ResourceDetailScreen() {
     if (!resource) return;
     router.push(`/profile/${resource.author_id}`);
   }, [resource]);
+
+  const handleSelectReportReason = useCallback(
+    (reason: ReportReason) => {
+      if (!resourceId) return;
+      setIsReportOpen(false);
+      reportResource.mutate(
+        { resourceId, reason },
+        {
+          onSuccess: () => {
+            Alert.alert('Merci', 'Ton signalement a bien été envoyé. Nous allons le vérifier.');
+          },
+          onError: (err) => {
+            Alert.alert('Signalement impossible', err.message || 'Réessaie plus tard.');
+          },
+        }
+      );
+    },
+    [reportResource, resourceId]
+  );
 
   const handleContactAuthor = useCallback(() => {
     if (!resource || isMine) return;
@@ -331,8 +355,32 @@ export default function ResourceDetailScreen() {
                 </XStack>
               </Pressable>
             </YStack>
+
+            {/* Signaler (pas sur sa propre ressource) */}
+            {!isMine ? (
+              <Pressable
+                onPress={() => setIsReportOpen(true)}
+                accessibilityRole="button"
+                accessibilityLabel="Signaler cette ressource"
+                style={styles.reportLink}
+              >
+                <XStack alignItems="center" justifyContent="center" gap={6}>
+                  <Flag size={14} color="#A0A0A0" />
+                  <Text fontSize={13} color="$textSecondary" fontWeight="600">
+                    Signaler cette ressource
+                  </Text>
+                </XStack>
+              </Pressable>
+            ) : null}
           </YStack>
         </ScrollView>
+
+        <ReportReasonSheet
+          open={isReportOpen}
+          onOpenChange={setIsReportOpen}
+          onSelect={handleSelectReportReason}
+          disabled={reportResource.isPending}
+        />
 
         {/* CTA sticky bottom — Contacter l'auteur */}
         <YStack
@@ -395,5 +443,9 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     alignItems: 'center',
     justifyContent: 'center',
+  },
+  reportLink: {
+    marginTop: 16,
+    paddingVertical: 8,
   },
 });

--- a/src/features/cours/components/ReportReasonSheet.tsx
+++ b/src/features/cours/components/ReportReasonSheet.tsx
@@ -1,0 +1,83 @@
+// ReportReasonSheet — E9-08 (#268)
+//
+// Bottom-sheet de choix de la raison de signalement. Cross-platform (Tamagui
+// Sheet) — plus propre qu'un Alert à N boutons.
+
+import { Flag } from 'lucide-react-native';
+import { Pressable, StyleSheet } from 'react-native';
+import { Sheet, Text, XStack, YStack } from 'tamagui';
+
+import { REPORT_REASON_LABEL, type ReportReason } from '../hooks/useReportResource';
+
+const REASONS = Object.keys(REPORT_REASON_LABEL) as ReportReason[];
+
+export interface ReportReasonSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSelect: (reason: ReportReason) => void;
+  disabled?: boolean;
+}
+
+export function ReportReasonSheet({
+  open,
+  onOpenChange,
+  onSelect,
+  disabled = false,
+}: ReportReasonSheetProps) {
+  return (
+    <Sheet modal open={open} onOpenChange={onOpenChange} snapPoints={[45]} dismissOnSnapToBottom>
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="rgba(0,0,0,0.55)"
+      />
+      <Sheet.Handle />
+      <Sheet.Frame
+        backgroundColor="$background"
+        borderTopLeftRadius={20}
+        borderTopRightRadius={20}
+        paddingHorizontal={20}
+        paddingTop={16}
+        paddingBottom={28}
+      >
+        <YStack gap={6}>
+          <XStack alignItems="center" gap={8} marginBottom={8}>
+            <Flag size={18} color="#FF6B6B" />
+            <Text fontSize={17} fontWeight="800" color="$color">
+              Signaler cette ressource
+            </Text>
+          </XStack>
+          <Text fontSize={13} color="$textSecondary" marginBottom={8}>
+            Pourquoi signales-tu ce contenu ?
+          </Text>
+
+          {REASONS.map((reason) => (
+            <Pressable
+              key={reason}
+              onPress={() => {
+                if (disabled) return;
+                onSelect(reason);
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={REPORT_REASON_LABEL[reason]}
+              style={styles.row}
+            >
+              <Text fontSize={15} color="$color">
+                {REPORT_REASON_LABEL[reason]}
+              </Text>
+            </Pressable>
+          ))}
+        </YStack>
+      </Sheet.Frame>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    paddingVertical: 14,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#262626',
+  },
+});

--- a/src/features/cours/hooks/useReportResource.ts
+++ b/src/features/cours/hooks/useReportResource.ts
@@ -1,0 +1,34 @@
+// useReportResource — E9-08 (#268)
+//
+// Wrappe la RPC report_resource. Le calcul du seuil + le masquage auto sont
+// entièrement côté DB (security definer). Le client se contente d'envoyer la
+// raison.
+
+import { useMutation } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type ReportReason = 'inapproprie' | 'fausse_info' | 'spam' | 'autre';
+
+export const REPORT_REASON_LABEL: Record<ReportReason, string> = {
+  inapproprie: 'Contenu inapproprié',
+  fausse_info: 'Erreur ou fausse information',
+  spam: 'Spam ou publicité',
+  autre: 'Autre',
+};
+
+export function useReportResource() {
+  return useMutation<void, Error, { resourceId: string; reason: ReportReason }>({
+    mutationFn: async ({ resourceId, reason }) => {
+      const { error } = await supabase.rpc('report_resource', {
+        p_resource_id: resourceId,
+        p_reason: reason,
+      });
+      if (error) {
+        logger.warn('report_resource failed', { message: error.message, resourceId });
+        throw error;
+      }
+    },
+  });
+}

--- a/supabase/migrations/20260702160000_cours_resource_reports.sql
+++ b/supabase/migrations/20260702160000_cours_resource_reports.sql
@@ -1,0 +1,115 @@
+-- E9-08 (#268) — Signalement de ressources + modération auto
+--
+-- Permet de signaler une ressource. Au-delà d'un seuil (configurable en DB,
+-- défaut 3, cf brief §15.4), la ressource passe en status='hidden' et
+-- disparaît du public (get_resources ne renvoie que 'active').
+--
+-- Seuil NON hardcodé côté client : stocké dans app_config → le changer = un
+-- update SQL de 30s, pas un release.
+--
+-- Tout passe par la RPC report_resource (security definer) : le client n'écrit
+-- jamais directement dans resource_reports ni app_config.
+--
+-- Idempotent.
+
+-- ---------------------------------------------------------------------------
+-- app_config — table générique de config (réutilisable)
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.app_config (
+  key        text primary key,
+  int_value  int,
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.app_config is
+  'Config applicative modifiable sans release (ex. seuils de modération). Écriture admin only.';
+
+alter table public.app_config enable row level security;
+-- Aucune policy → deny-by-default. Lu uniquement via RPC security definer.
+
+insert into public.app_config (key, int_value) values
+  ('resource_report_threshold', 3)
+on conflict (key) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- resource_reports — un signalement par (ressource, reporter)
+-- ---------------------------------------------------------------------------
+
+create table if not exists public.resource_reports (
+  id          uuid primary key default gen_random_uuid(),
+  resource_id uuid not null references public.resources(id) on delete cascade,
+  reporter_id uuid not null references public.profiles(id) on delete cascade,
+  reason      text not null check (reason in ('inapproprie', 'fausse_info', 'spam', 'autre')),
+  created_at  timestamptz not null default now(),
+  unique (resource_id, reporter_id) -- 1 signalement max par user par ressource
+);
+
+comment on table public.resource_reports is
+  'E9-08 — Signalements de ressources. Insertion via RPC report_resource uniquement.';
+
+alter table public.resource_reports enable row level security;
+-- Aucune policy client → tout passe par la RPC security definer.
+
+-- ---------------------------------------------------------------------------
+-- RPC report_resource
+-- ---------------------------------------------------------------------------
+
+create or replace function public.report_resource(p_resource_id uuid, p_reason text)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user      uuid := auth.uid();
+  v_author    uuid;
+  v_threshold int;
+  v_count     int;
+begin
+  if v_user is null then raise exception 'Not authenticated'; end if;
+
+  select author_id into v_author from public.resources where id = p_resource_id;
+  if v_author is null then raise exception 'Resource not found'; end if;
+  if v_author = v_user then raise exception 'Cannot report own resource'; end if;
+
+  -- Enregistre le signalement (ignore si l'user a déjà signalé).
+  insert into public.resource_reports (resource_id, reporter_id, reason)
+  values (p_resource_id, v_user, p_reason)
+  on conflict (resource_id, reporter_id) do nothing;
+
+  -- Recompte le nombre de reporters distincts.
+  update public.resources r
+    set report_count = (
+      select count(*) from public.resource_reports rr
+      where rr.resource_id = p_resource_id
+    )
+  where r.id = p_resource_id;
+
+  -- Masquage auto si le seuil configuré est atteint.
+  select int_value into v_threshold
+  from public.app_config where key = 'resource_report_threshold';
+
+  select report_count into v_count
+  from public.resources where id = p_resource_id;
+
+  if v_threshold is not null and v_count >= v_threshold then
+    update public.resources
+      set status = 'hidden'
+    where id = p_resource_id and status <> 'hidden';
+  end if;
+end;
+$$;
+
+grant execute on function public.report_resource(uuid, text) to authenticated;
+revoke execute on function public.report_resource(uuid, text) from anon, public;
+
+-- ---------------------------------------------------------------------------
+-- Post-conditions de vérif :
+--   - report_resource(<autre_id>, 'spam') en authenticated → OK, report_count+1
+--   - report_resource sur SA propre ressource → exception 'Cannot report own'
+--   - 3 users distincts signalent la même ressource → status passe à 'hidden',
+--     la ressource disparaît de get_resources
+--   - changer le seuil : update app_config set int_value = 5
+--     where key = 'resource_report_threshold';
+-- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
E9-08 (#268) — **Dernier ticket du L0 Cours.** Signalement de ressources + masquage auto au seuil. Indispensable pour de l'UGC.

⚠️ 1 migration à appliquer : `20260702160000_cours_resource_reports.sql`.

## Contenu DB

### `app_config` (générique, réutilisable)
Seuil de modération **configurable en DB** (`resource_report_threshold` = 3). Jamais hardcodé côté client → le changer = un `update` SQL de 30s (cf brief §15.4). RLS deny-all, lu via RPC.

### `resource_reports`
1 signalement max par (ressource, reporter) via contrainte unique. RLS deny-all, écriture via RPC uniquement.

### RPC `report_resource(p_resource_id, p_reason)`
- Refuse : sa propre ressource, ressource inexistante
- Insert idempotent (`on conflict do nothing`)
- Recompte `report_count` = reporters distincts
- **Masque auto** (`status='hidden'`) si `report_count >= seuil`
- Les ressources hidden disparaissent de `get_resources` (déjà filtré `active`)

## Client
- **`useReportResource`** : 4 raisons (inapproprié / fausse info / spam / autre)
- **`ReportReasonSheet`** : bottom-sheet Tamagui cross-platform
- **`app/cours/[id].tsx`** : lien "Signaler cette ressource" sous la carte auteur (masqué sur sa propre ressource) → sheet → confirmation "Merci"

## Test plan (après migration)
- [ ] Fiche d'une ressource d'un autre user → "Signaler cette ressource" visible
- [ ] Sur ma propre ressource → pas de lien signaler
- [ ] Tap → sheet avec 4 raisons → choisir → "Merci, signalement envoyé"
- [ ] Signaler 2 fois la même ressource (même compte) → report_count reste à 1 (unique)
- [ ] 3 comptes distincts signalent → la ressource passe hidden + disparaît de la grille
- [ ] `update app_config set int_value=5 where key='resource_report_threshold'` → nouveau seuil pris en compte

## 🎉 Fin du L0 Cours
Après ce merge, la **bibliothèque L0 est complète** (E9-01 → E9-09). Reste le L1 (quiz) et le L2 (communauté).