### PR TITLE
feat(cours): éditeur quiz manuel + import IA — #271, #272 (E9-11/E9-12)

### DIFF
--- a/app/cours/[id].tsx
+++ b/app/cours/[id].tsx
@@ -8,7 +8,7 @@
 
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import * as WebBrowser from 'expo-web-browser';
-import { ArrowLeft, Bookmark, ChevronRight, Eye, Flag } from 'lucide-react-native';
+import { ArrowLeft, Bookmark, ChevronRight, Eye, Flag, GraduationCap } from 'lucide-react-native';
 import { useCallback, useEffect, useState } from 'react';
 import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -17,6 +17,7 @@ import { Button, Image, Text, View, XStack, YStack } from 'tamagui';
 import { ReportReasonSheet } from '@/features/cours/components/ReportReasonSheet';
 import { ResourceFileRow } from '@/features/cours/components/ResourceFileRow';
 import { useCourseLevels, useCourseSubjects } from '@/features/cours/hooks/useCourseTaxonomy';
+import { useQuizByResource } from '@/features/cours/hooks/useQuizByResource';
 import { useReportResource, type ReportReason } from '@/features/cours/hooks/useReportResource';
 import { useResourceDetail } from '@/features/cours/hooks/useResourceDetail';
 import {
@@ -49,6 +50,7 @@ export default function ResourceDetailScreen() {
   const toggleBookmark = useToggleResourceBookmark();
   const getOrCreateDm = useGetOrCreateDm();
   const reportResource = useReportResource();
+  const { data: quiz } = useQuizByResource(resourceId);
   const levelsQuery = useCourseLevels();
   const subjectsQuery = useCourseSubjects();
 
@@ -300,6 +302,62 @@ export default function ResourceDetailScreen() {
               </Text>
             )}
 
+            {/* Quiz — passer (existe) / ajouter (le mien, pas encore) */}
+            {quiz ? (
+              <Pressable
+                onPress={() => router.push(`/cours/quiz/${quiz.id}`)}
+                accessibilityRole="button"
+                accessibilityLabel={`Passer le quiz : ${quiz.title}`}
+                style={styles.quizCard}
+              >
+                <XStack alignItems="center" gap={12}>
+                  <View
+                    width={40}
+                    height={40}
+                    borderRadius={10}
+                    backgroundColor="#12291D"
+                    alignItems="center"
+                    justifyContent="center"
+                  >
+                    <GraduationCap size={20} color="#10D970" />
+                  </View>
+                  <YStack flex={1} minWidth={0}>
+                    <Text fontSize={14} fontWeight="700" color="$color" numberOfLines={1}>
+                      Passer le quiz
+                    </Text>
+                    <Text fontSize={12} color="$textSecondary">
+                      {quiz.question_count} question{quiz.question_count > 1 ? 's' : ''}
+                    </Text>
+                  </YStack>
+                  <ChevronRight size={18} color="#10D970" />
+                </XStack>
+              </Pressable>
+            ) : isMine ? (
+              <Pressable
+                onPress={() =>
+                  router.push({
+                    pathname: '/cours/quiz-create',
+                    params: {
+                      resourceId: resource.id,
+                      levelCode: resource.level_code,
+                      subjectCode: resource.subject_code,
+                      resourceTitle: resource.title,
+                    },
+                  })
+                }
+                accessibilityRole="button"
+                accessibilityLabel="Ajouter un quiz à cette ressource"
+                style={styles.quizAddCard}
+              >
+                <XStack alignItems="center" justifyContent="center" gap={8}>
+                  <GraduationCap size={18} color="#10D970" />
+                  <Text fontSize={14} fontWeight="700" color="$color">
+                    Ajouter un quiz à cette ressource
+                  </Text>
+                </XStack>
+              </Pressable>
+            ) : null}
+
             {/* Carte auteur */}
             <YStack gap={8} paddingTop={4}>
               <Text fontSize={13} color="$textSecondary" fontWeight="700">
@@ -447,5 +505,17 @@ const styles = StyleSheet.create({
   reportLink: {
     marginTop: 16,
     paddingVertical: 8,
+  },
+  quizAddCard: {
+    borderWidth: 1,
+    borderColor: '#2A3F33',
+    borderRadius: 12,
+    paddingVertical: 14,
+    backgroundColor: '#12291D',
+  },
+  quizCard: {
+    backgroundColor: '#12291D',
+    borderRadius: 12,
+    padding: 14,
   },
 });

--- a/app/cours/quiz-create.tsx
+++ b/app/cours/quiz-create.tsx
@@ -1,0 +1,547 @@
+// Écran Éditeur de quiz — E9-11 (#271) + import E9-12 (#272)
+//
+// Crée un quiz question par question (choix unique / multiple / vrai-faux),
+// rattaché à une ressource (resourceId/level/subject passés en params). Deux
+// façons de remplir : manuellement, ou via "Importer depuis ton IA" (E9-12)
+// qui peuple la même liste. Convergence vers le même écran de relecture avant
+// publication (règle d'or brief §7).
+
+import { router, Stack, useLocalSearchParams } from 'expo-router';
+import { ArrowLeft, Check, Plus, Sparkles, Trash2, X } from 'lucide-react-native';
+import { useCallback, useRef, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Input, Text, View, XStack, YStack } from 'tamagui';
+
+import { QuizImportSheet } from '@/features/cours/components/QuizImportSheet';
+import { useCreateQuiz, type QuizQuestionType } from '@/features/cours/hooks/useCreateQuiz';
+import type { ParsedQuizQuestion } from '@/features/cours/lib/quizImport';
+import { SegmentedChoice } from '@/features/marketplace/components/SegmentedChoice';
+import { logger } from '@/lib/logger';
+
+const MAX_TITLE = 120;
+const MAX_QUESTIONS = 30;
+
+interface EditorOption {
+  label: string;
+  isCorrect: boolean;
+}
+interface EditorQuestion {
+  key: string;
+  prompt: string;
+  type: QuizQuestionType;
+  options: EditorOption[];
+}
+
+const TYPE_OPTIONS: { value: QuizQuestionType; label: string }[] = [
+  { value: 'single', label: 'Choix unique' },
+  { value: 'multiple', label: 'Choix multiple' },
+  { value: 'boolean', label: 'Vrai / Faux' },
+];
+
+function makeBooleanOptions(): EditorOption[] {
+  return [
+    { label: 'Vrai', isCorrect: true },
+    { label: 'Faux', isCorrect: false },
+  ];
+}
+
+export default function QuizCreateScreen() {
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{
+    resourceId?: string;
+    levelCode?: string;
+    subjectCode?: string;
+    resourceTitle?: string;
+  }>();
+  const resourceId = typeof params.resourceId === 'string' ? params.resourceId : null;
+  const levelCode = typeof params.levelCode === 'string' ? params.levelCode : '';
+  const subjectCode = typeof params.subjectCode === 'string' ? params.subjectCode : '';
+
+  const createQuiz = useCreateQuiz();
+  const keyCounter = useRef(0);
+  const nextKey = () => `q${keyCounter.current++}`;
+
+  const [title, setTitle] = useState(
+    params.resourceTitle ? `Quiz — ${String(params.resourceTitle)}` : ''
+  );
+  const [questions, setQuestions] = useState<EditorQuestion[]>([]);
+  const [isImportOpen, setIsImportOpen] = useState(false);
+
+  // ---- Mutations de la liste de questions ----
+
+  const addQuestion = useCallback(() => {
+    setQuestions((prev) => {
+      if (prev.length >= MAX_QUESTIONS) return prev;
+      return [
+        ...prev,
+        {
+          key: nextKey(),
+          prompt: '',
+          type: 'single',
+          options: [
+            { label: '', isCorrect: true },
+            { label: '', isCorrect: false },
+          ],
+        },
+      ];
+    });
+  }, []);
+
+  const removeQuestion = useCallback((qi: number) => {
+    setQuestions((prev) => prev.filter((_, i) => i !== qi));
+  }, []);
+
+  const setPrompt = useCallback((qi: number, text: string) => {
+    setQuestions((prev) => prev.map((q, i) => (i === qi ? { ...q, prompt: text } : q)));
+  }, []);
+
+  const setType = useCallback((qi: number, type: QuizQuestionType) => {
+    setQuestions((prev) =>
+      prev.map((q, i) => {
+        if (i !== qi) return q;
+        if (type === 'boolean') return { ...q, type, options: makeBooleanOptions() };
+        // single/multiple : garde les options mais si on repasse de boolean,
+        // repart sur 2 options vides.
+        const options =
+          q.type === 'boolean'
+            ? [
+                { label: '', isCorrect: true },
+                { label: '', isCorrect: false },
+              ]
+            : q.options;
+        return { ...q, type, options };
+      })
+    );
+  }, []);
+
+  const addOption = useCallback((qi: number) => {
+    setQuestions((prev) =>
+      prev.map((q, i) =>
+        i === qi && q.options.length < 6
+          ? { ...q, options: [...q.options, { label: '', isCorrect: false }] }
+          : q
+      )
+    );
+  }, []);
+
+  const removeOption = useCallback((qi: number, oi: number) => {
+    setQuestions((prev) =>
+      prev.map((q, i) =>
+        i === qi && q.options.length > 2
+          ? { ...q, options: q.options.filter((_, j) => j !== oi) }
+          : q
+      )
+    );
+  }, []);
+
+  const setOptionLabel = useCallback((qi: number, oi: number, text: string) => {
+    setQuestions((prev) =>
+      prev.map((q, i) =>
+        i === qi
+          ? { ...q, options: q.options.map((o, j) => (j === oi ? { ...o, label: text } : o)) }
+          : q
+      )
+    );
+  }, []);
+
+  const toggleCorrect = useCallback((qi: number, oi: number) => {
+    setQuestions((prev) =>
+      prev.map((q, i) => {
+        if (i !== qi) return q;
+        // multiple → toggle ; single/boolean → radio (une seule bonne réponse)
+        if (q.type === 'multiple') {
+          return {
+            ...q,
+            options: q.options.map((o, j) => (j === oi ? { ...o, isCorrect: !o.isCorrect } : o)),
+          };
+        }
+        return {
+          ...q,
+          options: q.options.map((o, j) => ({ ...o, isCorrect: j === oi })),
+        };
+      })
+    );
+  }, []);
+
+  // ---- Import E9-12 ----
+
+  const handleImported = useCallback((imported: ParsedQuizQuestion[]) => {
+    setQuestions(
+      imported.map((q) => ({
+        key: nextKey(),
+        prompt: q.prompt,
+        type: q.type,
+        options: q.options.map((o) => ({ label: o.label, isCorrect: o.is_correct })),
+      }))
+    );
+  }, []);
+
+  // ---- Submit ----
+
+  const handleClose = useCallback(() => {
+    if (questions.length === 0 && title.trim().length === 0) {
+      router.back();
+      return;
+    }
+    Alert.alert('Abandonner ce quiz ?', 'Tu perdras les questions saisies.', [
+      { text: 'Continuer', style: 'cancel' },
+      { text: 'Abandonner', style: 'destructive', onPress: () => router.back() },
+    ]);
+  }, [questions.length, title]);
+
+  const validate = useCallback((): string | null => {
+    if (title.trim().length < 3) return 'Donne un titre au quiz (3 caractères min).';
+    if (questions.length === 0) return 'Ajoute au moins 1 question.';
+    for (let i = 0; i < questions.length; i++) {
+      const q = questions[i]!;
+      const label = `Question ${i + 1}`;
+      if (q.prompt.trim().length === 0) return `${label} : énoncé manquant.`;
+      if (q.options.length < 2) return `${label} : au moins 2 options.`;
+      if (q.options.some((o) => o.label.trim().length === 0))
+        return `${label} : toutes les options doivent avoir un libellé.`;
+      if (!q.options.some((o) => o.isCorrect))
+        return `${label} : indique au moins une bonne réponse.`;
+    }
+    return null;
+  }, [questions, title]);
+
+  const handleSubmit = useCallback(async () => {
+    const err = validate();
+    if (err) {
+      Alert.alert('Quiz incomplet', err);
+      return;
+    }
+    if (!levelCode || !subjectCode) {
+      Alert.alert('Erreur', 'Niveau ou matière manquant.');
+      return;
+    }
+    try {
+      await createQuiz.mutateAsync({
+        title: title.trim(),
+        levelCode,
+        subjectCode,
+        resourceId,
+        questions: questions.map((q) => ({
+          prompt: q.prompt.trim(),
+          type: q.type,
+          options: q.options.map((o) => ({ label: o.label.trim(), is_correct: o.isCorrect })),
+        })),
+      });
+      // Retour à la fiche — le quiz apparaîtra (invalidation ['cours','quiz']).
+      router.back();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Réessaie.';
+      logger.warn('create_quiz submit failed', { message });
+      Alert.alert('Publication impossible', message);
+    }
+  }, [validate, levelCode, subjectCode, resourceId, title, questions, createQuiz]);
+
+  const isBusy = createQuiz.isPending;
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        style={styles.flex}
+      >
+        <View flex={1} backgroundColor="$background" paddingTop={insets.top}>
+          {/* Header */}
+          <XStack
+            height={56}
+            paddingHorizontal={12}
+            alignItems="center"
+            gap={12}
+            borderBottomWidth={StyleSheet.hairlineWidth}
+            borderBottomColor="$borderColor"
+          >
+            <Pressable
+              onPress={handleClose}
+              disabled={isBusy}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              accessibilityRole="button"
+              accessibilityLabel="Annuler"
+            >
+              <ArrowLeft size={24} color="#FFFFFF" />
+            </Pressable>
+            <Text flex={1} color="$color" fontSize={18} fontWeight="700">
+              Créer un quiz
+            </Text>
+          </XStack>
+
+          <ScrollView
+            contentContainerStyle={styles.scrollContent}
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+          >
+            {/* Titre */}
+            <YStack gap={8} marginTop={12}>
+              <Input
+                value={title}
+                onChangeText={setTitle}
+                placeholder="Titre du quiz"
+                placeholderTextColor="$placeholderColor"
+                maxLength={MAX_TITLE}
+                editable={!isBusy}
+                color="$color"
+                backgroundColor="$surface"
+                borderWidth={0}
+                borderRadius="$md"
+                height={48}
+                paddingHorizontal={14}
+                accessibilityLabel="Titre du quiz"
+              />
+            </YStack>
+
+            {/* Import IA */}
+            <Pressable
+              onPress={() => setIsImportOpen(true)}
+              disabled={isBusy}
+              accessibilityRole="button"
+              accessibilityLabel="Importer depuis ton IA"
+              style={styles.importRow}
+            >
+              <XStack alignItems="center" justifyContent="center" gap={8}>
+                <Sparkles size={16} color="#10D970" />
+                <Text fontSize={13} fontWeight="700" color="$color">
+                  J&apos;ai déjà mes questions (importer depuis mon IA)
+                </Text>
+              </XStack>
+            </Pressable>
+
+            {/* Questions */}
+            {questions.map((q, qi) => (
+              <YStack
+                key={q.key}
+                marginTop={16}
+                backgroundColor="$surface"
+                borderRadius={14}
+                padding={14}
+                gap={12}
+              >
+                <XStack alignItems="center" justifyContent="space-between">
+                  <Text fontSize={13} fontWeight="800" color="$accentNeon">
+                    Question {qi + 1}
+                  </Text>
+                  <Pressable
+                    onPress={() => removeQuestion(qi)}
+                    disabled={isBusy}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Supprimer la question ${qi + 1}`}
+                  >
+                    <Trash2 size={16} color="#FF6B6B" />
+                  </Pressable>
+                </XStack>
+
+                <Input
+                  value={q.prompt}
+                  onChangeText={(t) => setPrompt(qi, t)}
+                  placeholder="Énoncé de la question"
+                  placeholderTextColor="$placeholderColor"
+                  editable={!isBusy}
+                  color="$color"
+                  backgroundColor="$surfaceElevated"
+                  borderWidth={0}
+                  borderRadius="$md"
+                  height={44}
+                  paddingHorizontal={12}
+                  accessibilityLabel={`Énoncé question ${qi + 1}`}
+                />
+
+                <SegmentedChoice
+                  options={TYPE_OPTIONS}
+                  value={q.type}
+                  onChange={(t) => setType(qi, t)}
+                  disabled={isBusy}
+                />
+
+                {/* Options */}
+                <YStack gap={8}>
+                  {q.options.map((o, oi) => (
+                    <XStack key={oi} alignItems="center" gap={8}>
+                      {/* Toggle correct */}
+                      <Pressable
+                        onPress={() => toggleCorrect(qi, oi)}
+                        disabled={isBusy}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        accessibilityRole={q.type === 'multiple' ? 'checkbox' : 'radio'}
+                        accessibilityLabel={`Bonne réponse : ${o.label || `option ${oi + 1}`}`}
+                        accessibilityState={{ checked: o.isCorrect, selected: o.isCorrect }}
+                        style={[
+                          styles.correctToggle,
+                          o.isCorrect ? styles.correctToggleOn : null,
+                          q.type === 'multiple' ? styles.square : styles.round,
+                        ]}
+                      >
+                        {o.isCorrect ? <Check size={13} color="#000000" strokeWidth={3} /> : null}
+                      </Pressable>
+
+                      <Input
+                        flex={1}
+                        value={o.label}
+                        onChangeText={(t) => setOptionLabel(qi, oi, t)}
+                        placeholder={`Option ${oi + 1}`}
+                        placeholderTextColor="$placeholderColor"
+                        editable={!isBusy && q.type !== 'boolean'}
+                        color="$color"
+                        backgroundColor="$surfaceElevated"
+                        borderWidth={0}
+                        borderRadius="$md"
+                        height={40}
+                        paddingHorizontal={12}
+                        fontSize={14}
+                        accessibilityLabel={`Libellé option ${oi + 1}`}
+                      />
+
+                      {/* Retirer une option (pas en boolean, min 2) */}
+                      {q.type !== 'boolean' && q.options.length > 2 ? (
+                        <Pressable
+                          onPress={() => removeOption(qi, oi)}
+                          disabled={isBusy}
+                          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                          accessibilityRole="button"
+                          accessibilityLabel={`Retirer l'option ${oi + 1}`}
+                        >
+                          <X size={15} color="#A0A0A0" />
+                        </Pressable>
+                      ) : null}
+                    </XStack>
+                  ))}
+
+                  {q.type !== 'boolean' && q.options.length < 6 ? (
+                    <Pressable
+                      onPress={() => addOption(qi)}
+                      disabled={isBusy}
+                      accessibilityRole="button"
+                      accessibilityLabel="Ajouter une option"
+                      style={styles.addOption}
+                    >
+                      <Text fontSize={13} color="$textSecondary" fontWeight="600">
+                        + Ajouter une option
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                </YStack>
+              </YStack>
+            ))}
+
+            {/* Ajouter une question */}
+            {questions.length < MAX_QUESTIONS ? (
+              <Pressable
+                onPress={addQuestion}
+                disabled={isBusy}
+                accessibilityRole="button"
+                accessibilityLabel="Ajouter une question"
+                style={styles.addQuestion}
+              >
+                <XStack alignItems="center" justifyContent="center" gap={8}>
+                  <Plus size={18} color="#FFFFFF" strokeWidth={2} />
+                  <Text fontSize={14} fontWeight="700" color="#FFFFFF">
+                    Ajouter une question
+                  </Text>
+                </XStack>
+              </Pressable>
+            ) : null}
+          </ScrollView>
+
+          {/* CTA Publier */}
+          <YStack
+            paddingHorizontal={16}
+            paddingTop={12}
+            paddingBottom={insets.bottom + 12}
+            backgroundColor="$background"
+            borderTopWidth={StyleSheet.hairlineWidth}
+            borderTopColor="$borderColor"
+          >
+            <Pressable
+              onPress={() => void handleSubmit()}
+              disabled={isBusy}
+              accessibilityRole="button"
+              accessibilityLabel="Publier le quiz"
+              accessibilityState={{ disabled: isBusy }}
+              style={[styles.cta, { backgroundColor: isBusy ? '#1A1A1A' : '#10D970' }]}
+            >
+              {isBusy ? (
+                <ActivityIndicator color="#10D970" />
+              ) : (
+                <Text fontSize={15} fontWeight="800" color="#000000">
+                  Publier le quiz
+                </Text>
+              )}
+            </Pressable>
+          </YStack>
+        </View>
+      </KeyboardAvoidingView>
+
+      <QuizImportSheet
+        open={isImportOpen}
+        onOpenChange={setIsImportOpen}
+        onImport={handleImported}
+      />
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  addOption: {
+    paddingVertical: 8,
+    alignItems: 'center',
+  },
+  addQuestion: {
+    marginTop: 16,
+    borderWidth: 1,
+    borderColor: '#333',
+    borderStyle: 'dashed',
+    borderRadius: 12,
+    paddingVertical: 14,
+  },
+  correctToggle: {
+    width: 24,
+    height: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#555',
+  },
+  correctToggleOn: {
+    backgroundColor: '#10D970',
+    borderColor: '#10D970',
+  },
+  cta: {
+    borderRadius: 9999,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  flex: {
+    flex: 1,
+  },
+  importRow: {
+    marginTop: 12,
+    borderWidth: 1,
+    borderColor: '#2A3F33',
+    borderRadius: 12,
+    paddingVertical: 12,
+    backgroundColor: '#12291D',
+  },
+  round: {
+    borderRadius: 12,
+  },
+  scrollContent: {
+    paddingHorizontal: 16,
+    paddingBottom: 24,
+  },
+  square: {
+    borderRadius: 6,
+  },
+});

--- a/src/features/cours/components/QuizImportSheet.tsx
+++ b/src/features/cours/components/QuizImportSheet.tsx
@@ -1,0 +1,153 @@
+// QuizImportSheet — E9-12 (#272)
+//
+// "Colle tes questions" : bouton Copier le prompt (→ presse-papier), l'user
+// va dans SON IA, revient coller le JSON, on parse + valide. En cas de succès
+// on renvoie les questions à l'éditeur (E9-11) via onImport.
+
+import * as Clipboard from 'expo-clipboard';
+import { Check, Copy } from 'lucide-react-native';
+import { useState } from 'react';
+import { Pressable, StyleSheet } from 'react-native';
+import { Sheet, Text, TextArea, XStack, YStack } from 'tamagui';
+
+import { parseQuizImport, QUIZ_IMPORT_PROMPT, type ParsedQuizQuestion } from '../lib/quizImport';
+
+export interface QuizImportSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onImport: (questions: ParsedQuizQuestion[]) => void;
+}
+
+export function QuizImportSheet({ open, onOpenChange, onImport }: QuizImportSheetProps) {
+  const [pasted, setPasted] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyPrompt = async () => {
+    await Clipboard.setStringAsync(QUIZ_IMPORT_PROMPT);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const handleImport = () => {
+    const result = parseQuizImport(pasted);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+    setError(null);
+    setPasted('');
+    onImport(result.questions);
+    onOpenChange(false);
+  };
+
+  return (
+    <Sheet modal open={open} onOpenChange={onOpenChange} snapPoints={[85]} dismissOnSnapToBottom>
+      <Sheet.Overlay
+        animation="lazy"
+        enterStyle={{ opacity: 0 }}
+        exitStyle={{ opacity: 0 }}
+        backgroundColor="rgba(0,0,0,0.55)"
+      />
+      <Sheet.Handle />
+      <Sheet.Frame
+        backgroundColor="$background"
+        borderTopLeftRadius={20}
+        borderTopRightRadius={20}
+        paddingHorizontal={20}
+        paddingTop={16}
+        paddingBottom={28}
+      >
+        <YStack gap={14} flex={1}>
+          <Text fontSize={18} fontWeight="800" color="$color">
+            Importer depuis ton IA
+          </Text>
+
+          {/* Étape 1 */}
+          <YStack gap={8}>
+            <Text fontSize={13} color="$textSecondary">
+              1. Copie ce prompt, colle-le dans ton IA (ChatGPT, etc.) avec ton cours.
+            </Text>
+            <Pressable
+              onPress={() => void handleCopyPrompt()}
+              accessibilityRole="button"
+              accessibilityLabel="Copier le prompt"
+              style={styles.copyBtn}
+            >
+              <XStack alignItems="center" justifyContent="center" gap={8}>
+                {copied ? (
+                  <Check size={16} color="#000000" strokeWidth={2.4} />
+                ) : (
+                  <Copy size={16} color="#000000" strokeWidth={2.2} />
+                )}
+                <Text fontSize={14} fontWeight="800" color="#000000">
+                  {copied ? 'Prompt copié !' : 'Copier le prompt'}
+                </Text>
+              </XStack>
+            </Pressable>
+          </YStack>
+
+          {/* Étape 2 */}
+          <YStack gap={8} flex={1}>
+            <Text fontSize={13} color="$textSecondary">
+              2. Colle ici la réponse JSON de ton IA.
+            </Text>
+            <TextArea
+              value={pasted}
+              onChangeText={(t) => {
+                setPasted(t);
+                if (error) setError(null);
+              }}
+              placeholder='[ { "prompt": "…", "type": "single", "options": [ … ] } ]'
+              placeholderTextColor="$placeholderColor"
+              color="$color"
+              backgroundColor="$surface"
+              borderWidth={0}
+              borderRadius="$md"
+              flex={1}
+              minHeight={140}
+              paddingHorizontal={14}
+              paddingTop={12}
+              textAlignVertical="top"
+              autoCapitalize="none"
+              autoCorrect={false}
+              accessibilityLabel="Coller le JSON du quiz"
+            />
+            {error ? (
+              <Text fontSize={12} color="#FF6B6B">
+                {error}
+              </Text>
+            ) : null}
+          </YStack>
+
+          {/* CTA */}
+          <Pressable
+            onPress={handleImport}
+            accessibilityRole="button"
+            accessibilityLabel="Importer les questions"
+            style={styles.importBtn}
+          >
+            <Text fontSize={15} fontWeight="800" color="#000000">
+              Importer les questions
+            </Text>
+          </Pressable>
+        </YStack>
+      </Sheet.Frame>
+    </Sheet>
+  );
+}
+
+const styles = StyleSheet.create({
+  copyBtn: {
+    backgroundColor: '#FFFFFF',
+    paddingVertical: 12,
+    borderRadius: 9999,
+    alignItems: 'center',
+  },
+  importBtn: {
+    backgroundColor: '#10D970',
+    paddingVertical: 14,
+    borderRadius: 9999,
+    alignItems: 'center',
+  },
+});

--- a/src/features/cours/hooks/useCreateQuiz.ts
+++ b/src/features/cours/hooks/useCreateQuiz.ts
@@ -1,0 +1,56 @@
+// useCreateQuiz — E9-11 (#271)
+//
+// Wrappe la RPC create_quiz (création imbriquée questions+options en 1 appel).
+// author_id forcé à auth.uid() côté DB. Validation métier (≥1 question, ≥2
+// options, ≥1 bonne réponse) faite côté DB aussi — on valide en amont côté
+// client pour un meilleur feedback.
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type QuizQuestionType = 'single' | 'multiple' | 'boolean';
+
+export interface QuizOptionInput {
+  label: string;
+  is_correct: boolean;
+}
+
+export interface QuizQuestionInput {
+  prompt: string;
+  type: QuizQuestionType;
+  options: QuizOptionInput[];
+}
+
+export interface CreateQuizInput {
+  title: string;
+  levelCode: string;
+  subjectCode: string;
+  questions: QuizQuestionInput[];
+  resourceId?: string | null;
+}
+
+export function useCreateQuiz() {
+  const queryClient = useQueryClient();
+
+  return useMutation<string, Error, CreateQuizInput>({
+    mutationFn: async (input): Promise<string> => {
+      const { data, error } = await supabase.rpc('create_quiz', {
+        p_title: input.title,
+        p_level_code: input.levelCode,
+        p_subject_code: input.subjectCode,
+        p_questions: input.questions,
+        p_resource_id: input.resourceId ?? null,
+      });
+      if (error) {
+        logger.warn('create_quiz failed', { message: error.message });
+        throw error;
+      }
+      return String(data);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['cours', 'quiz'] });
+    },
+  });
+}

--- a/src/features/cours/hooks/useQuizByResource.ts
+++ b/src/features/cours/hooks/useQuizByResource.ts
@@ -1,0 +1,46 @@
+// useQuizByResource — E9-11 (#271)
+//
+// Récupère le quiz rattaché à une ressource (s'il existe). La table quizzes a
+// une RLS "public read" → simple select client, pas besoin de RPC. Sert à
+// afficher sur la fiche soit "Passer le quiz" (existe) soit "Ajouter un quiz"
+// (pas encore, si je suis l'auteur).
+
+import { useQuery } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export interface ResourceQuizSummary {
+  id: string;
+  title: string;
+  question_count: number;
+}
+
+export function quizByResourceQueryKey(resourceId: string) {
+  return ['cours', 'quiz', 'byResource', resourceId] as const;
+}
+
+export function useQuizByResource(resourceId: string | null) {
+  return useQuery({
+    queryKey: resourceId
+      ? quizByResourceQueryKey(resourceId)
+      : ['cours', 'quiz', 'byResource', 'none'],
+    enabled: Boolean(resourceId),
+    queryFn: async (): Promise<ResourceQuizSummary | null> => {
+      if (!resourceId) return null;
+      const { data, error } = await supabase
+        .from('quizzes')
+        .select('id, title, question_count')
+        .eq('resource_id', resourceId)
+        .order('created_at', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+      if (error) {
+        logger.warn('useQuizByResource failed', { message: error.message, resourceId });
+        throw error;
+      }
+      return (data as ResourceQuizSummary | null) ?? null;
+    },
+    staleTime: 30_000,
+  });
+}

--- a/src/features/cours/lib/quizImport.ts
+++ b/src/features/cours/lib/quizImport.ts
@@ -1,0 +1,116 @@
+// quizImport — E9-12 (#272)
+//
+// "Colle tes questions" : l'user génère ses questions avec SON IA (ChatGPT…)
+// via un prompt cadré qu'on lui fournit, puis colle le résultat JSON. On parse
+// + valide ce JSON pour peupler l'éditeur (E9-11). Zéro coût IA pour nous.
+
+import type { QuizQuestionType } from '../hooks/useCreateQuiz';
+
+// Format de sortie imposé à l'IA de l'user. Volontairement strict pour être
+// parsable sans ambiguïté.
+export const QUIZ_IMPORT_PROMPT = `Génère un quiz à partir du cours ci-dessous.
+
+Réponds UNIQUEMENT avec un tableau JSON valide, sans aucun texte avant ou après, au format EXACT suivant :
+
+[
+  {
+    "prompt": "énoncé de la question",
+    "type": "single",
+    "options": [
+      { "label": "une réponse", "is_correct": true },
+      { "label": "une autre réponse", "is_correct": false }
+    ]
+  }
+]
+
+Règles STRICTES :
+- "type" vaut "single" (une seule bonne réponse) ou "multiple" (plusieurs bonnes réponses).
+- Chaque question a entre 2 et 5 options.
+- Au moins une option a "is_correct": true.
+- Réponds en français.
+- 5 à 10 questions.
+
+Cours :
+<<< COLLE TON COURS ICI >>>`;
+
+export interface ParsedQuizQuestion {
+  prompt: string;
+  type: QuizQuestionType;
+  options: { label: string; is_correct: boolean }[];
+}
+
+export type QuizParseResult =
+  | { ok: true; questions: ParsedQuizQuestion[] }
+  | { ok: false; error: string };
+
+// Retire un éventuel fence markdown ```json ... ``` que l'IA aurait ajouté.
+function stripCodeFence(raw: string): string {
+  const trimmed = raw.trim();
+  const fence = trimmed.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return fence ? (fence[1] ?? '').trim() : trimmed;
+}
+
+function isType(value: unknown): value is QuizQuestionType {
+  return value === 'single' || value === 'multiple' || value === 'boolean';
+}
+
+/**
+ * Parse + valide le JSON collé. Messages d'erreur FR clairs pour guider l'user.
+ */
+export function parseQuizImport(raw: string): QuizParseResult {
+  const cleaned = stripCodeFence(raw);
+  if (cleaned.length === 0) {
+    return { ok: false, error: 'Le champ est vide. Colle le JSON généré par ton IA.' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    return {
+      ok: false,
+      error: "Le texte n'est pas un JSON valide. Vérifie que tu as bien copié tout le tableau.",
+    };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return { ok: false, error: 'Le JSON doit être un tableau de questions.' };
+  }
+  if (parsed.length === 0) {
+    return { ok: false, error: 'Aucune question trouvée dans le JSON.' };
+  }
+
+  const questions: ParsedQuizQuestion[] = [];
+  for (let i = 0; i < parsed.length; i++) {
+    const q = parsed[i] as Record<string, unknown>;
+    const label = `Question ${i + 1}`;
+
+    if (typeof q?.prompt !== 'string' || q.prompt.trim().length === 0) {
+      return { ok: false, error: `${label} : énoncé ("prompt") manquant.` };
+    }
+    const type: QuizQuestionType = isType(q.type) ? q.type : 'single';
+
+    if (!Array.isArray(q.options) || q.options.length < 2) {
+      return { ok: false, error: `${label} : il faut au moins 2 options.` };
+    }
+
+    const options: { label: string; is_correct: boolean }[] = [];
+    let hasCorrect = false;
+    for (let j = 0; j < q.options.length; j++) {
+      const o = q.options[j] as Record<string, unknown>;
+      if (typeof o?.label !== 'string' || o.label.trim().length === 0) {
+        return { ok: false, error: `${label}, option ${j + 1} : libellé manquant.` };
+      }
+      const isCorrect = o.is_correct === true;
+      if (isCorrect) hasCorrect = true;
+      options.push({ label: o.label.trim(), is_correct: isCorrect });
+    }
+    if (!hasCorrect) {
+      return { ok: false, error: `${label} : indique au moins une bonne réponse.` };
+    }
+
+    questions.push({ prompt: q.prompt.trim(), type, options });
+  }
+
+  return { ok: true, questions };
+}


### PR DESCRIPTION
## Summary
E9-11 + E9-12 — **Un seul éditeur, deux façons de le remplir** (convergence, brief §7). Pur frontend, aucune migration (utilise les RPCs E9-10).

## E9-11 — Éditeur manuel
- **`useCreateQuiz`** : RPC create_quiz (questions imbriquées)
- **`useQuizByResource`** : sait si une ressource a déjà un quiz (select public sur `quizzes`)
- **Écran `app/cours/quiz-create.tsx`** :
  - Titre + liste dynamique de questions
  - Par question : énoncé + type (Choix unique / multiple / Vrai-Faux) + options
  - Toggle bonne réponse : **radio** (single/boolean) ou **checkbox** (multiple)
  - Vrai-Faux : options Vrai/Faux figées
  - Ajouter/supprimer questions (max 30) et options (2-6)
  - Validation client miroir de la DB + confirmation avant abandon

## E9-12 — Import "colle tes questions" (zéro coût IA pour nous)
- **`lib/quizImport.ts`** : `QUIZ_IMPORT_PROMPT` (prompt cadré imposant le format JSON) + `parseQuizImport` (parser strict, messages FR, tolère un fence markdown)
- **`QuizImportSheet`** : bouton "Copier le prompt" (expo-clipboard) → l'user génère dans SON IA → colle le JSON → parse → **peuple le même éditeur** (relecture obligatoire avant publication)

## Fiche ressource
Section quiz ajoutée :
- **"Passer le quiz"** si un quiz existe → `/cours/quiz/[id]` (E9-13)
- **"Ajouter un quiz"** si c'est ma ressource et pas encore de quiz → éditeur prérempli

## Test plan (après merge E9-10 + rebuild pas nécessaire — expo-clipboard déjà présent)
- [ ] Ma ressource → "Ajouter un quiz" → éditeur prérempli (titre, niveau, matière)
- [ ] Ajouter 2 questions manuellement (single + vrai/faux) → Publier → retour fiche → "Passer le quiz" apparaît
- [ ] Rouvrir l'éditeur, tap "Importer depuis mon IA" → Copier le prompt → coller un JSON valide → questions peuplées
- [ ] JSON invalide → message d'erreur clair
- [ ] Validation : question sans bonne réponse → bloqué

## Suite
E9-13 (passer un quiz + score + corrigé) — le dernier écran du L1.