### PR TITLE
feat(cours): passer un quiz + score + corrigé — #273 (E9-13)

### DIFF
--- a/app/cours/quiz/[id].tsx
+++ b/app/cours/quiz/[id].tsx
@@ -1,0 +1,386 @@
+// Écran Passer un quiz — E9-13 (#273)
+//
+// Deux phases dans le même écran :
+//   1. Jeu : questions une sous l'autre, sélection radio (single/boolean) ou
+//      checkbox (multiple). Bouton Valider actif quand tout est répondu.
+//   2. Résultat : score % + meilleur score + corrigé par question (options
+//      correctes en vert, mauvais choix de l'user en rouge). Recommencer.
+//
+// Scoring 100% serveur (submit_quiz_attempt) — le client ne connaît jamais
+// les bonnes réponses avant d'avoir validé. Tentatives illimitées + meilleur
+// score affiché (brief §15.5).
+
+import { router, Stack, useLocalSearchParams } from 'expo-router';
+import { ArrowLeft, Check, RotateCcw, Trophy, X } from 'lucide-react-native';
+import { useCallback, useMemo, useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, ScrollView, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { Text, View, XStack, YStack } from 'tamagui';
+
+import {
+  useMyBestQuizScore,
+  useQuiz,
+  useSubmitQuizAttempt,
+  type QuizAttemptResult,
+} from '@/features/cours/hooks/useQuizPlay';
+import { logger } from '@/lib/logger';
+
+export default function QuizPlayScreen() {
+  const insets = useSafeAreaInsets();
+  const params = useLocalSearchParams<{ id: string }>();
+  const quizId = typeof params.id === 'string' ? params.id : null;
+
+  const { data: quiz, isLoading, isError } = useQuiz(quizId);
+  const bestScoreQuery = useMyBestQuizScore(quizId);
+  const submitAttempt = useSubmitQuizAttempt();
+
+  // Réponses : questionId → set d'option ids sélectionnés.
+  const [answers, setAnswers] = useState<Record<string, string[]>>({});
+  const [result, setResult] = useState<QuizAttemptResult | null>(null);
+
+  const allAnswered = useMemo(() => {
+    if (!quiz) return false;
+    return quiz.questions.every((q) => (answers[q.id]?.length ?? 0) > 0);
+  }, [quiz, answers]);
+
+  const handleBack = useCallback(() => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/cours');
+  }, []);
+
+  const selectOption = useCallback(
+    (questionId: string, optionId: string, type: 'single' | 'multiple' | 'boolean') => {
+      if (result) return; // verrouillé après validation
+      setAnswers((prev) => {
+        const current = prev[questionId] ?? [];
+        if (type === 'multiple') {
+          const next = current.includes(optionId)
+            ? current.filter((id) => id !== optionId)
+            : [...current, optionId];
+          return { ...prev, [questionId]: next };
+        }
+        // single / boolean → une seule sélection
+        return { ...prev, [questionId]: [optionId] };
+      });
+    },
+    [result]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!quiz || !quizId || !allAnswered) return;
+    try {
+      const payload = quiz.questions.map((q) => ({
+        question_id: q.id,
+        selected_option_ids: answers[q.id] ?? [],
+      }));
+      const res = await submitAttempt.mutateAsync({ quizId, answers: payload });
+      setResult(res);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Réessaie.';
+      logger.warn('submit quiz failed', { message });
+      Alert.alert('Erreur', message);
+    }
+  }, [quiz, quizId, allAnswered, answers, submitAttempt]);
+
+  const handleRetry = useCallback(() => {
+    setAnswers({});
+    setResult(null);
+  }, []);
+
+  // Map questionId → correction pour l'affichage du corrigé.
+  const correctionByQuestion = useMemo(() => {
+    const m = new Map<string, { is_correct: boolean; correct_option_ids: string[] }>();
+    result?.corrections.forEach((c) =>
+      m.set(c.question_id, { is_correct: c.is_correct, correct_option_ids: c.correct_option_ids })
+    );
+    return m;
+  }, [result]);
+
+  const header = (
+    <XStack
+      height={56}
+      paddingHorizontal={12}
+      alignItems="center"
+      gap={12}
+      borderBottomWidth={StyleSheet.hairlineWidth}
+      borderBottomColor="$borderColor"
+    >
+      <Pressable
+        onPress={handleBack}
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        accessibilityRole="button"
+        accessibilityLabel="Retour"
+      >
+        <ArrowLeft size={24} color="#FFFFFF" />
+      </Pressable>
+      <Text flex={1} color="$color" fontSize={17} fontWeight="700" numberOfLines={1}>
+        {quiz?.title ?? 'Quiz'}
+      </Text>
+    </XStack>
+  );
+
+  if (isLoading) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+          {header}
+          <YStack flex={1} alignItems="center" justifyContent="center">
+            <ActivityIndicator color="#FFFFFF" />
+          </YStack>
+        </YStack>
+      </>
+    );
+  }
+
+  if (isError || !quiz) {
+    return (
+      <>
+        <Stack.Screen options={{ headerShown: false }} />
+        <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+          {header}
+          <YStack
+            flex={1}
+            alignItems="center"
+            justifyContent="center"
+            paddingHorizontal={24}
+            gap={8}
+          >
+            <Text fontSize={16} fontWeight="700" color="$color">
+              Quiz introuvable
+            </Text>
+          </YStack>
+        </YStack>
+      </>
+    );
+  }
+
+  const best = bestScoreQuery.data ?? null;
+
+  return (
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <YStack flex={1} backgroundColor="$background" paddingTop={insets.top}>
+        {header}
+
+        <ScrollView
+          contentContainerStyle={{ padding: 16, paddingBottom: 120 + insets.bottom }}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* Résultat (après validation) */}
+          {result ? (
+            <YStack
+              backgroundColor="$surface"
+              borderRadius={16}
+              padding={20}
+              alignItems="center"
+              gap={6}
+              marginBottom={16}
+            >
+              <Trophy size={32} color="#10D970" />
+              <Text fontSize={32} fontWeight="900" color="$accentNeon">
+                {result.score_pct}%
+              </Text>
+              <Text fontSize={14} color="$color" fontWeight="600">
+                {result.correct_count}/{result.total_count} bonnes réponses
+              </Text>
+              {best != null ? (
+                <Text fontSize={12} color="$textSecondary">
+                  Meilleur score : {best}%
+                </Text>
+              ) : null}
+            </YStack>
+          ) : (
+            <XStack alignItems="center" justifyContent="space-between" marginBottom={12}>
+              <Text fontSize={13} color="$textSecondary">
+                {quiz.question_count} question{quiz.question_count > 1 ? 's' : ''}
+              </Text>
+              {best != null ? (
+                <XStack alignItems="center" gap={4}>
+                  <Trophy size={13} color="#10D970" />
+                  <Text fontSize={12} color="$textSecondary">
+                    Meilleur : {best}%
+                  </Text>
+                </XStack>
+              ) : null}
+            </XStack>
+          )}
+
+          {/* Questions */}
+          {quiz.questions.map((q, qi) => {
+            const selected = answers[q.id] ?? [];
+            const correction = correctionByQuestion.get(q.id);
+            const isMulti = q.type === 'multiple';
+            return (
+              <YStack
+                key={q.id}
+                backgroundColor="$surface"
+                borderRadius={14}
+                padding={14}
+                gap={10}
+                marginBottom={12}
+              >
+                <XStack gap={8} alignItems="flex-start">
+                  <Text fontSize={14} fontWeight="800" color="$accentNeon">
+                    {qi + 1}.
+                  </Text>
+                  <Text flex={1} fontSize={15} fontWeight="600" color="$color">
+                    {q.prompt}
+                  </Text>
+                  {correction ? (
+                    correction.is_correct ? (
+                      <Check size={18} color="#10D970" strokeWidth={2.5} />
+                    ) : (
+                      <X size={18} color="#FF6B6B" strokeWidth={2.5} />
+                    )
+                  ) : null}
+                </XStack>
+
+                {isMulti && !result ? (
+                  <Text fontSize={11} color="$textSecondary">
+                    Plusieurs réponses possibles
+                  </Text>
+                ) : null}
+
+                <YStack gap={8}>
+                  {q.options.map((opt) => {
+                    const isSelected = selected.includes(opt.id);
+                    // Couleurs en mode corrigé
+                    let bg = '$surfaceElevated';
+                    let borderColor = 'transparent';
+                    if (correction) {
+                      const isCorrectOpt = correction.correct_option_ids.includes(opt.id);
+                      if (isCorrectOpt) {
+                        bg = '#12291D';
+                        borderColor = '#10D970';
+                      } else if (isSelected) {
+                        bg = '#2E1522';
+                        borderColor = '#FF6B6B';
+                      }
+                    } else if (isSelected) {
+                      bg = '#12291D';
+                      borderColor = '#10D970';
+                    }
+                    return (
+                      <Pressable
+                        key={opt.id}
+                        onPress={() => selectOption(q.id, opt.id, q.type)}
+                        disabled={Boolean(result)}
+                        accessibilityRole={isMulti ? 'checkbox' : 'radio'}
+                        accessibilityLabel={opt.label}
+                        accessibilityState={{ checked: isSelected, selected: isSelected }}
+                        style={[styles.option, { backgroundColor: bg, borderColor }]}
+                      >
+                        <XStack alignItems="center" gap={10}>
+                          <View
+                            style={[
+                              styles.marker,
+                              isMulti ? styles.square : styles.round,
+                              isSelected ? styles.markerOn : null,
+                            ]}
+                          >
+                            {isSelected ? (
+                              <Check size={12} color="#000000" strokeWidth={3} />
+                            ) : null}
+                          </View>
+                          <Text flex={1} fontSize={14} color="$color">
+                            {opt.label}
+                          </Text>
+                        </XStack>
+                      </Pressable>
+                    );
+                  })}
+                </YStack>
+              </YStack>
+            );
+          })}
+        </ScrollView>
+
+        {/* CTA bottom */}
+        <YStack
+          position="absolute"
+          bottom={0}
+          left={0}
+          right={0}
+          paddingHorizontal={16}
+          paddingTop={12}
+          paddingBottom={insets.bottom + 12}
+          backgroundColor="$background"
+          borderTopWidth={StyleSheet.hairlineWidth}
+          borderTopColor="$borderColor"
+        >
+          {result ? (
+            <Pressable
+              onPress={handleRetry}
+              accessibilityRole="button"
+              accessibilityLabel="Recommencer le quiz"
+              style={[styles.cta, { backgroundColor: '#FFFFFF' }]}
+            >
+              <XStack alignItems="center" justifyContent="center" gap={8}>
+                <RotateCcw size={16} color="#000000" strokeWidth={2.4} />
+                <Text fontSize={15} fontWeight="800" color="#000000">
+                  Recommencer
+                </Text>
+              </XStack>
+            </Pressable>
+          ) : (
+            <Pressable
+              onPress={() => void handleSubmit()}
+              disabled={!allAnswered || submitAttempt.isPending}
+              accessibilityRole="button"
+              accessibilityLabel="Valider mes réponses"
+              accessibilityState={{ disabled: !allAnswered || submitAttempt.isPending }}
+              style={[
+                styles.cta,
+                {
+                  backgroundColor: allAnswered && !submitAttempt.isPending ? '#10D970' : '#1A1A1A',
+                },
+              ]}
+            >
+              {submitAttempt.isPending ? (
+                <ActivityIndicator color="#10D970" />
+              ) : (
+                <Text fontSize={15} fontWeight="800" color={allAnswered ? '#000000' : '#666'}>
+                  {allAnswered ? 'Valider' : 'Réponds à toutes les questions'}
+                </Text>
+              )}
+            </Pressable>
+          )}
+        </YStack>
+      </YStack>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  cta: {
+    borderRadius: 9999,
+    paddingVertical: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  marker: {
+    width: 22,
+    height: 22,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 2,
+    borderColor: '#555',
+  },
+  markerOn: {
+    backgroundColor: '#10D970',
+    borderColor: '#10D970',
+  },
+  option: {
+    borderRadius: 10,
+    borderWidth: 1.5,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+  },
+  round: {
+    borderRadius: 11,
+  },
+  square: {
+    borderRadius: 6,
+  },
+});

--- a/src/features/cours/hooks/useQuizPlay.ts
+++ b/src/features/cours/hooks/useQuizPlay.ts
@@ -1,0 +1,163 @@
+// useQuizPlay — E9-13 (#273)
+//
+// Hooks pour jouer un quiz :
+//   - useQuiz : get_quiz (structure SANS les bonnes réponses)
+//   - useSubmitQuizAttempt : submit_quiz_attempt (scoring serveur)
+//   - useMyBestQuizScore : get_my_best_quiz_score (meilleur score)
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { logger } from '@/lib/logger';
+import { supabase } from '@/lib/supabase';
+
+export type QuizQuestionType = 'single' | 'multiple' | 'boolean';
+
+export interface PlayQuizOption {
+  id: string;
+  position: number;
+  label: string;
+}
+export interface PlayQuizQuestion {
+  id: string;
+  position: number;
+  prompt: string;
+  type: QuizQuestionType;
+  options: PlayQuizOption[];
+}
+export interface PlayQuiz {
+  id: string;
+  title: string;
+  resource_id: string | null;
+  level_code: string;
+  subject_code: string;
+  author_id: string;
+  author_username: string;
+  question_count: number;
+  questions: PlayQuizQuestion[];
+}
+
+export interface QuizCorrection {
+  question_id: string;
+  is_correct: boolean;
+  correct_option_ids: string[];
+}
+export interface QuizAttemptResult {
+  score_pct: number;
+  correct_count: number;
+  total_count: number;
+  corrections: QuizCorrection[];
+}
+
+function isType(v: unknown): v is QuizQuestionType {
+  return v === 'single' || v === 'multiple' || v === 'boolean';
+}
+
+function mapQuiz(raw: Record<string, unknown>): PlayQuiz {
+  const rawQuestions = Array.isArray(raw.questions) ? raw.questions : [];
+  return {
+    id: String(raw.id ?? ''),
+    title: String(raw.title ?? ''),
+    resource_id: (raw.resource_id as string | null) ?? null,
+    level_code: String(raw.level_code ?? ''),
+    subject_code: String(raw.subject_code ?? ''),
+    author_id: String(raw.author_id ?? ''),
+    author_username: String(raw.author_username ?? ''),
+    question_count:
+      typeof raw.question_count === 'number' ? raw.question_count : rawQuestions.length,
+    questions: rawQuestions.map((q) => {
+      const qq = q as Record<string, unknown>;
+      const rawOptions = Array.isArray(qq.options) ? qq.options : [];
+      return {
+        id: String(qq.id ?? ''),
+        position: typeof qq.position === 'number' ? qq.position : 0,
+        prompt: String(qq.prompt ?? ''),
+        type: isType(qq.type) ? qq.type : 'single',
+        options: rawOptions.map((o) => {
+          const oo = o as Record<string, unknown>;
+          return {
+            id: String(oo.id ?? ''),
+            position: typeof oo.position === 'number' ? oo.position : 0,
+            label: String(oo.label ?? ''),
+          };
+        }),
+      };
+    }),
+  };
+}
+
+export function quizQueryKey(quizId: string) {
+  return ['cours', 'quiz', 'play', quizId] as const;
+}
+
+export function useQuiz(quizId: string | null) {
+  return useQuery({
+    queryKey: quizId ? quizQueryKey(quizId) : ['cours', 'quiz', 'play', 'none'],
+    enabled: Boolean(quizId),
+    staleTime: 5 * 60_000,
+    queryFn: async (): Promise<PlayQuiz | null> => {
+      if (!quizId) return null;
+      const { data, error } = await supabase.rpc('get_quiz', { p_quiz_id: quizId });
+      if (error) {
+        logger.warn('get_quiz failed', { message: error.message, quizId });
+        throw error;
+      }
+      if (!data || typeof data !== 'object') return null;
+      return mapQuiz(data as Record<string, unknown>);
+    },
+  });
+}
+
+export interface SubmitAttemptInput {
+  quizId: string;
+  answers: { question_id: string; selected_option_ids: string[] }[];
+}
+
+export function useSubmitQuizAttempt() {
+  const queryClient = useQueryClient();
+  return useMutation<QuizAttemptResult, Error, SubmitAttemptInput>({
+    mutationFn: async ({ quizId, answers }): Promise<QuizAttemptResult> => {
+      const { data, error } = await supabase.rpc('submit_quiz_attempt', {
+        p_quiz_id: quizId,
+        p_answers: answers,
+      });
+      if (error) {
+        logger.warn('submit_quiz_attempt failed', { message: error.message, quizId });
+        throw error;
+      }
+      const r = (data ?? {}) as Record<string, unknown>;
+      return {
+        score_pct: typeof r.score_pct === 'number' ? r.score_pct : 0,
+        correct_count: typeof r.correct_count === 'number' ? r.correct_count : 0,
+        total_count: typeof r.total_count === 'number' ? r.total_count : 0,
+        corrections: Array.isArray(r.corrections)
+          ? (r.corrections as Record<string, unknown>[]).map((c) => ({
+              question_id: String(c.question_id ?? ''),
+              is_correct: Boolean(c.is_correct),
+              correct_option_ids: Array.isArray(c.correct_option_ids)
+                ? (c.correct_option_ids as string[])
+                : [],
+            }))
+          : [],
+      };
+    },
+    onSuccess: (_res, { quizId }) => {
+      void queryClient.invalidateQueries({ queryKey: ['cours', 'quiz', 'best', quizId] });
+    },
+  });
+}
+
+export function useMyBestQuizScore(quizId: string | null) {
+  return useQuery({
+    queryKey: quizId ? ['cours', 'quiz', 'best', quizId] : ['cours', 'quiz', 'best', 'none'],
+    enabled: Boolean(quizId),
+    queryFn: async (): Promise<number | null> => {
+      if (!quizId) return null;
+      const { data, error } = await supabase.rpc('get_my_best_quiz_score', { p_quiz_id: quizId });
+      if (error) {
+        logger.warn('get_my_best_quiz_score failed', { message: error.message, quizId });
+        throw error;
+      }
+      return typeof data === 'number' ? data : null;
+    },
+  });
+}


### PR DESCRIPTION
## Summary
E9-13 (#273) — **Dernier écran du L1.** Passer un quiz, score serveur, corrigé. Pur frontend (RPCs E9-10).

## Hooks (`useQuizPlay.ts`)
- **`useQuiz`** : `get_quiz` (structure **sans is_correct** — anti-triche)
- **`useSubmitQuizAttempt`** : `submit_quiz_attempt` (scoring serveur)
- **`useMyBestQuizScore`** : `get_my_best_quiz_score`

## Écran `app/cours/quiz/[id].tsx`
- **Phase jeu** : questions empilées, radio (single/boolean) ou checkbox (multiple). Valider actif quand tout est répondu.
- **Phase résultat** : score % + meilleur score + **corrigé** par question (options correctes en vert, mauvais choix en rouge, ✓/✗ par question). Recommencer (tentatives illimitées).
- Le client ne connaît **jamais** les bonnes réponses avant validation.

## Test plan (après E9-10 + E9-11 mergés)
- [ ] Fiche ressource avec quiz → "Passer le quiz" → écran de jeu
- [ ] Répondre à toutes les questions → Valider → score affiché
- [ ] Corrigé : bonnes réponses en vert, mes erreurs en rouge
- [ ] Score parfait puis re-tenter avec erreurs → meilleur score reste au max
- [ ] Recommencer réinitialise les réponses

## 🎉 Fin du L1 Quiz
E9-10 → E9-13 livrés. Reste le L2 (communauté : #274-276).